### PR TITLE
Python 3.3 decimal.Decimal fix

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -206,6 +206,8 @@ class IndirectObject(PdfObject):
 
 class FloatObject(decimal.Decimal, PdfObject):
     def __new__(cls, value="0", context=None):
+        if not context:
+            return decimal.Decimal.__new__(cls, utils.str_(value))
         return decimal.Decimal.__new__(cls, utils.str_(value), context)
     def __repr__(self):
         if self == self.to_integral():


### PR DESCRIPTION
Hi. In Python3.3, there is a bug with the decimal.Decimal class that appears in PyPDF2 with certain PDF files (the ons created by inkscape for instance) This is a fix

Try

```
import decimal 
decimal.Decimal('1', context=None) 
```

in Python3.3
