### PR TITLE
Adding possibility to include metadata (Title, Author, Keywords, Subject, Creator, Producer) to merged PDF

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -214,6 +214,12 @@ class PdfFileMerger(object):
         
         self.inputs = []
         self.output = None
+
+    def add_infos(self, infos):
+        args = {}
+        for key, value in infos.items():
+            args[NameObject(key)] = createStringObject(value)
+        self.output.getObject(self.output._info).update(args)
     
     def _trim_dests(self, pdf, dests, pages):
         """


### PR DESCRIPTION
Example code : 

```python
pdf = open('existing.pdf', 'rb')
pdf2 = open('existing2.pdf', 'rb')
merger = PdfFileMerger()
merger.append(fileobj=pdf)
merger.append(fileobj=pdf2)
# infos must be something like this :
# {
#    u'/Title': u'My title',
#    u'/Author': u'My author',
#    u'/Creator': u'My Creator',
#    u'/Keywords': u'My Keywords',
#    u'/Subject': u'My Subjects',
#    [...]
# }
merger.add_infos(infos)
merger.write_pdf(open("merged_with_infos.pdf", 'wb'))
```
