### PR TITLE
Removing pop in sweepIndirectReferences

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -362,7 +362,6 @@ class PdfFileWriter(object):
                     self.stack.append(data.idnum)
                     realdata = self.getObject(data)
                     self._sweepIndirectReferences(externMap, realdata)
-                    self.stack.pop()
                     return data
             else:
                 newobj = externMap.get(data.pdf, {}).get(data.generation, {}).get(data.idnum, None)


### PR DESCRIPTION
When writing pages from a current PDF file into a new one, pyPDF will
attempt to sweep for IndirectObjects in the pages. When sweeping, there
is a check to see if it has already encountered an object by the use of
a stack.  However, once this happens, the object is popped from the
stack.  If an object is encountered again after this, pyPDF sweeps for
the object again, encountering all other previous objects it had
previously encountered, leading to an infinite loop.  Removing the pop
keeps a complete list of IndirectObjects already encountered, preventing
this infinite loop at the cost of slightly increased memory use.
