### PR TITLE
Update pdf.py

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -1543,10 +1543,9 @@ class PageObject(DictionaryObject):
             return stream
         stream = ContentStream(stream, pdf)
         for operands,operator in stream.operations:
-            for i in range(len(operands)):
-                op = operands[i]
+            for op in operands:
                 if isinstance(op, NameObject):
-                    operands[i] = rename.get(op, op)
+                    op = rename.get(op, op)
         return stream
     _contentStreamRename = staticmethod(_contentStreamRename)
 


### PR DESCRIPTION
Solved the following bug for me for merging several pdfs together:
  File "pypdf2/pdf.py", line 1547, in _contentStreamRename
    op = operands[i]
KeyError: 0
