### PR TITLE
Dictionary object values should be utf-16

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -90,7 +90,7 @@ class PdfFileWriter(object):
         # info object
         info = DictionaryObject()
         info.update({
-                NameObject("/Producer"): createStringObject(u"PyPDF2")
+                NameObject("/Producer"): createStringObject(u"PyPDF2".encode('utf-16'))
                 })
         self._info = self._addObject(info)
 


### PR DESCRIPTION
Set "PyPDF2" as an example for how I believe metadata should be encoded

It's in the PDF standard that all unicode metadata must be utf-16 (utf-8 is not okay, though most applications seem to tolerate it alright). All metadata must either be ASCII or utf-16, period. Unless I've missed the PDF revision that says otherwise, which is always possible.

Ideally, I think PyPDF2's metadata methods should accept unicode string and encode them as utf-16 before writing. Though I'd like feedback from the project management on this idea.
