### PR TITLE
Explicitly set metadata encoding as utf-16be

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -90,7 +90,7 @@ class PdfFileWriter(object):
         # info object
         info = DictionaryObject()
         info.update({
-                NameObject("/Producer"): createStringObject(u"PyPDF2")
+                NameObject("/Producer"): createStringObject(u"PyPDF2".encode('utf-16be'))
                 })
         self._info = self._addObject(info)
 


### PR DESCRIPTION
all metadata should be utf-16be encoded

See discussion:
https://github.com/mstamy2/PyPDF2/pull/43

Again, I think ideally we should transparently try to convert any string to utf-16be when the user sets the metadata. This is a patch which demonstrates the way to set the encoding that is supported by the ISO PDF standard.
