### PR TITLE
fix missing BOM in Producer metadata

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -53,6 +53,7 @@ except ImportError:
 import filters
 import utils
 import warnings
+import codecs
 from generic import *
 from utils import readNonWhitespace, readUntilWhitespace, ConvertFunctionsToVirtualList
 from utils import b_
@@ -90,7 +91,7 @@ class PdfFileWriter(object):
         # info object
         info = DictionaryObject()
         info.update({
-                NameObject("/Producer"): createStringObject(u"PyPDF2".encode('utf-16be'))
+                NameObject("/Producer"): createStringObject(codecs.BOM_UTF16_BE + u"PyPDF2".encode('utf-16be'))
                 })
         self._info = self._addObject(info)
 


### PR DESCRIPTION
Oops. I realized that my previous patch was not working as intended
 because it was missing the big endian BOM. It would get written
 to PDF without the BOM, which is contra the PDF standard.

Please note that almost all UTF-16BE strings actually get successfully
 converted to PDFDocEncoding by TextStringObject.writeToStream()
 So just because we store UTF-16BE doesn't mean the encoding will end
 up in the PDF.

Sorry about the double pull request.

As a side note, I was really surprised to find that PDFDocEncoding covers so many codepoints. I could not find a glyph that did not convert, though they must exist.
