### PR TITLE
Fix for non-utf8 characters causing exception

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -470,9 +470,10 @@ class NameObject(str, PdfObject):
         if debug: print(name)
         try:
             return NameObject(name.decode('utf-8'))
-        except Exception, e:
-            print e
+        except UnicodeDecodeError as e:
+            print("error decoding string", e)
             return NameObject(name)
+        
     readFromStream = staticmethod(readFromStream)
 
 


### PR DESCRIPTION
UnicodeDecodeError: 'utf8' codec can't decode byte 0xae in position 13:
invalid start byte
In pdf with that contain non-utf8 characters,  name.decode("utf-8")
throws an exception. 
The character that is causing the problem in the pdf is ®
