### PR TITLE
Handle nested bookmarks properly (fixes later issue in #40)

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -417,7 +417,7 @@ class PdfFileMerger(object):
     			res = self.findBookmark(bookmark, b)
     			if res:
     				return [i] + res
-    		if b == bookmark or b['/Title'] == bookmark:
+    		elif b == bookmark or b['/Title'] == bookmark:
     			return [i]
     
     	return None


### PR DESCRIPTION
If findBookmark finds an array of bookmark hashes (for a sub-level of bookmarks) that does not contain a match, then it will proceed to see if the array matches the current bookmark. This is nonsensical (it's an array, not a bookmark hash) and fails with:-

```
Traceback (most recent call last):
  File "merge.py", line 27, in <module>
    merged.addBookmark("Two / A", 4, parent)
  File "/usr/local/lib/python2.6/dist-packages/PyPDF2/merger.py", line 426, in addBookmark
    iloc = self.findBookmark(parent)
  File "/usr/local/lib/python2.6/dist-packages/PyPDF2/merger.py", line 409, in findBookmark
    if b == bookmark or b['/Title'] == bookmark:
TypeError: list indices must be integers, not str
```
