### PR TITLE
Fix for when type isn't present in pages dictionary

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -946,7 +946,11 @@ class PdfFileReader(object):
             self.flattenedPages = []
             catalog = self.trailer["/Root"].getObject()
             pages = catalog["/Pages"].getObject()
-        t = pages["/Type"]
+
+        t = "/Pages"
+        if "/Type" in pages:
+            t = pages["/Type"]
+
         if t == "/Pages":
             for attr in inheritablePageAttributes:
                 if attr in pages:


### PR DESCRIPTION
This is fix for issue mentioned here: https://github.com/mstamy2/PyPDF2/issues/65
