### PR TITLE
Fix for pdfcat options parse, issue #70

### DIFF
--- a/Sample_Code/pdfcat
+++ b/Sample_Code/pdfcat
@@ -30,17 +30,18 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description=__doc__.format(page_range_help=PAGE_RANGE_HELP),
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("fn_pgrgs", nargs="+",
-                        metavar="filename or page range expression")
     parser.add_argument("-o", "--output",
                         metavar="output_file")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="show page ranges as they are being read")
-    # argparse chokes on page ranges like "-2:".  If that happens, treat
-    # all arguments from that point on as "fn_pgrgs":
-    parsed, unparsed = parser.parse_known_args()
-    parsed.fn_pgrgs += unparsed
-    return parsed
+    parser.add_argument("first_filename", nargs=1,
+                        metavar="filename [page range...]")
+    # argparse chokes on page ranges like "-2:" unless caught like this:
+    parser.add_argument("fn_pgrgs", nargs=argparse.REMAINDER,
+                        metavar="filenames and/or page ranges")
+    args = parser.parse_args()
+    args.fn_pgrgs.insert(0, args.first_filename[0])
+    return args
 
 
 from sys import stderr, stdout, exit


### PR DESCRIPTION
nargs=argparse.REMAINDER means just pass the rest of these arguments unparsed.  "-2:" works in the right place, not in the wrong place.  The --help is still okay (maybe clearer).  Errors in the earlier options are still caught by argparse.  Later problems are caught in parse_filename_page_ranges().  All seems to be well.
