### PR TITLE
fix to work on pypy2.2

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -450,7 +450,7 @@ class NameObject(str, PdfObject):
     delimiterCharacters = b_("("), b_(")"), b_("<"), b_(">"), b_("["), b_("]"), b_("{"), b_("}"), b_("/"), b_("%")
 
     def __init__(self, data):
-        super(NameObject, self).__init__(data)
+        str.__init__(super(NameObject, self).__new__(str, data))
 
     def writeToStream(self, stream, encryption_key):
         stream.write(b_(self))


### PR DESCRIPTION
Fixes the following error when running with PyPy 2.2

```
  File "/Users/shaz/Documents/PyPDF2/PyPDF2/generic.py", line 453, in __init__
    str.__init__(data)
TypeError: unbound method __init__() must be called with str instance as first argument (got unicode instance instead)
```
