### PR TITLE
Fixed possible infinite loop when using Python 3 to merge pages

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -2192,7 +2192,7 @@ class ContentStream(DecodedStreamObject):
                     if tok.isspace() or tok in NameObject.delimiterCharacters:
                         stream.seek(-1, 1)
                         break
-                    elif tok == '':
+                    elif tok == b_(''):
                         break
                     operator += tok
                 if operator == "BI":


### PR DESCRIPTION
Merging pages multiple times on the same page objects might end in a infinite loop, because `tok` might be a empty bytes object.
