### PR TITLE
Allow ConvertFunctionsToVirtualList to be indexed with slices and longs ...

### DIFF
--- a/PyPDF2/utils.py
+++ b/PyPDF2/utils.py
@@ -44,10 +44,13 @@ except ImportError:  # Py3
 if sys.version_info[0] < 3:
     string_type = unicode
     bytes_type = str
+    int_types = (int, long)
 else:
     string_type = str
     bytes_type = bytes
+    int_types = (int,)
 
+Xrange = getattr(builtins, "xrange", range)
 Str = getattr(builtins, "basestring", str)
 
 
@@ -107,8 +110,13 @@ class ConvertFunctionsToVirtualList(object):
     def __len__(self):
         return self.lengthFunction()
 
-    def __getitem__(self, index):
-        if not isinstance(index, int):
+   def __getitem__(self, index):
+        if isinstance(index, slice):
+            indices = Xrange(*index.indices(len(self)))
+            cls = type(self)
+            return cls(indices.__len__, lambda idx: self[indices[idx]])
+
+        if not isinstance(index, int_types):
             raise TypeError("sequence indices must be integers")
         len_self = len(self)
         if index < 0:
@@ -116,7 +124,6 @@ class ConvertFunctionsToVirtualList(object):
             index = len_self + index
         if index < 0 or index >= len_self:
             raise IndexError("sequence index out of range")
-        return self.getFunction(index)
 
 def RC4_encrypt(key, plaintext):
     S = [i for i in range(256)]


### PR DESCRIPTION
...(python2.x)

It may seem silly to allow longs, (after all, a PDF with that many pages has other problems),
but 1L should be valid as small longs should be equivalent to ints and some APIs may return
longs.

Slices are a little more obvious -- It allows the "VirtualList" objects to behave a little
more like regular lists.
