### PR TITLE
addLink: Bugfix and Quality-of-Life Improvements

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -698,7 +698,7 @@ class PdfFileWriter(object):
         else:
             borderArr = [NumberObject(0)] * 3
             
-        if isinstance(rect, str if version_info >= (3, 0) else (str, unicode)):
+        if isinstance(rect, Str):
             rect = NameObject(rect)
         elif isinstance(rect, RectangleObject):
             pass


### PR DESCRIPTION
All changes in `pdf.PdfFileWriter.addLink`:
Added documentation to make use of this method a bit clearer.
Fixed an issue where `/P` was mapped to a repr'd `IndirectObject` rather than a proper indirect reference.
Added support for a border-styling argument (as a list).
Allowed `rect` to be a string (as before), or a `RectangleObject`, or a `list`, to make use more intuitive.
Finally, removed the mysterious magic `NumberObject(826)` that was hardcoded into the `/Dest` (does anyone know why this was in there?)
