### PR TITLE
Fix typos in OutlinesObject().add()

### DIFF
--- a/PyPDF2/merger.py
+++ b/PyPDF2/merger.py
@@ -477,7 +477,7 @@ class OutlinesObject(list):
         del self[index]
         self.tree.removeChild(obj)
         
-    def add(self, title, page):
+    def add(self, title, pagenum):
         pageRef = self.pdf.getObject(self.pdf._pages)['/Kids'][pagenum]
         action = DictionaryObject()
         action.update({
@@ -492,7 +492,7 @@ class OutlinesObject(list):
             NameObject('/Title'): createStringObject(title),
         })
 
-        pdf._addObject(bookmark)
+        self.pdf._addObject(bookmark)
 
         self.tree.addChild(bookmark)
         


### PR DESCRIPTION
By using pylint, I found some undefined variables, I corrected those which I understand.

There is still the `debugging` in `generic.py` which is not defined.
