### PR TITLE
Added bookmark formatting (colors, bold/italic) to addBookmark

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -514,7 +514,7 @@ class PdfFileWriter(object):
         return bookmarkRef
 
 
-    def addBookmark(self, title, pagenum, parent=None):
+    def addBookmark(self, title, pagenum, parent=None, color=None, bold=False, italic=False, fit='FitH'):
         """
         Add a bookmark to this PDF file.
 
@@ -522,11 +522,17 @@ class PdfFileWriter(object):
         :param int pagenum: Page number this bookmark will point to.
         :param parent: A reference to a parent bookmark to create nested
             bookmarks.
+        :param tuple color: Color of the bookmark as a red, green, blue tuple
+            from 0.0 to 1.0
+        :param bool bold: Bookmark is bold
+        :param bool italic: Bookmark is italic
+        :param str fit: The fit of the page, e.g. 'Fit' (whole page) or FitH
+            (fit horizontal)
         """
         pageRef = self.getObject(self._pages)['/Kids'][pagenum]
         action = DictionaryObject()
         action.update({
-            NameObject('/D') : ArrayObject([pageRef, NameObject('/FitH'), NumberObject(826)]),
+            NameObject('/D') : ArrayObject([pageRef, NameObject('/'+fit), NumberObject(826)]),
             NameObject('/S') : NameObject('/GoTo')
         })
         actionRef = self._addObject(action)
@@ -543,6 +549,17 @@ class PdfFileWriter(object):
             NameObject('/A'): actionRef,
             NameObject('/Title'): createStringObject(title),
         })
+
+        if color is not None:
+            bookmark.update({NameObject('/C'): ArrayObject([FloatObject(c) for c in color])})
+
+        format = 0
+        if italic:
+            format += 1
+        if bold:
+            format += 2
+        if format:
+            bookmark.update({NameObject('/F'): NumberObject(format)})
 
         bookmarkRef = self._addObject(bookmark)
 


### PR DESCRIPTION
This commit adds formatting to bookmarks, allowing the user to set the color (as a red, green, blue tuple) and bold/italic, in PDF readers that support this feature (including Adobe Acrobat).

![bookmark_colors](https://cloud.githubusercontent.com/assets/3883947/3578291/7094862c-0ba7-11e4-9005-d9fac4e49290.png)

The screenshot above was taken from Adobe Acrobat running on Linux, created using the following code:

```
page = 0
outputpdf.addBookmark('Regular', page)
outputpdf.addBookmark('Bold', page, bold=True)
outputpdf.addBookmark('Italic', page, italic=True)
outputpdf.addBookmark('Bold italic', page, bold=True, italic=True)

outputpdf.addBookmark('Red', page, color=(1.0, 0.0, 0.0))
outputpdf.addBookmark('Orange', page, color=(1.0, 0.5, 0.0))
outputpdf.addBookmark('Yellow', page, color=(1.0, 1.0, 0.0))
outputpdf.addBookmark('Green', page, color=(0.0, 1.0, 0.0))
outputpdf.addBookmark('Blue', page, color=(0.0, 0.0, 1.0))
outputpdf.addBookmark('Indigo', page, color=(0.25, 0.0, 0.5))
outputpdf.addBookmark('Violet', page, color=(0.5, 0.0, 1.0))

outputpdf.addBookmark('Fit whole page', page, fit='Fit')
outputpdf.addBookmark('Fit page horizontal', page, fit='FitH')

outputpdf.addBookmark('Bold red', page, color=(1.0, 0.0, 0.0), bold=True)
```

In addition, the page fit setting can be modified using the `fit` argument. This allows the user to specify a whole page fit rather than the previous default of a horizontal page fit.
