### PR TITLE
owner_entry should be a ByteStringObject, not str

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -1761,7 +1761,7 @@ class PdfFileReader(object):
     def _authenticateUserPassword(self, password):
         encrypt = self.trailer['/Encrypt'].getObject()
         rev = encrypt['/R'].getObject()
-        owner_entry = encrypt['/O'].getObject().original_bytes
+        owner_entry = encrypt['/O'].getObject()
         p_entry = encrypt['/P'].getObject()
         id_entry = self.trailer['/ID'].getObject()
         id1_entry = id_entry[0].getObject()


### PR DESCRIPTION
`owner_entry` will later be used in `_alg32` which already calls `.original_bytes` and so the code fails if `owner_entry` is an `str`.
