### PR TITLE
Prevent infinite loops in malformed PDFs

### DIFF
--- a/PyPDF2/pdf.py
+++ b/PyPDF2/pdf.py
@@ -1700,6 +1700,11 @@ class PdfFileReader(object):
         if debug: print(">>readNextEndLine")
         line = b_("")
         while True:
+
+            # Prevent infinite loops in malformed PDFs
+            if stream.tell() == 0:
+                raise ValueError
+
             x = stream.read(1)
             if debug: print(("  x:", x, "%x"%ord(x)))
             stream.seek(-2, 1)


### PR DESCRIPTION
The error is if you have a PDF file that has no newlines, carriage returns, or "%%EOF" markers. If someone inputs a file with content "%PDF" , there will be an infinite loop instead of an error.
