### PR TITLE
Fix for parsing number tokens with leading spaces.

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -255,6 +255,8 @@ class NumberObject(int, PdfObject):
     def readFromStream(stream):
         num = b_("")
         while True:
+            if readNonWhitespace(stream):
+                stream.seek(-1, 1)
             tok = stream.read(16)
             m = NumberObject.NumberPattern.search(tok)
             if m is not None:


### PR DESCRIPTION
This is  fix for https://github.com/mstamy2/PyPDF2/issues/149
