### PR TITLE
Use utils.readUntilRegex in NumberObject.readFromStream.

### DIFF
--- a/PyPDF2/generic.py
+++ b/PyPDF2/generic.py
@@ -257,18 +257,7 @@ class NumberObject(int, PdfObject):
         stream.write(b_(repr(self)))
 
     def readFromStream(stream):
-        num = b_("")
-        while True:
-            if readNonWhitespace(stream):
-                stream.seek(-1, 1)
-            tok = stream.read(16)
-            m = NumberObject.NumberPattern.search(tok)
-            if m is not None:
-                stream.seek(m.start() - len(tok), 1)
-                num += tok[:m.start()]
-                break
-
-            num += tok
+        num = utils.readUntilRegex(stream, NumberObject.NumberPattern)
         if num.find(NumberObject.ByteDot) != -1:
             return FloatObject(num)
         else:


### PR DESCRIPTION
This probably should have happened when readUntilRegex was first
introduced in d990367334964f8758857eaa266a82ee4bd49cb7, but looks like
it was missed accidentally.

readUntilRegex includes awareness of EOF, which means that for some
cases which would have otherwise gone into an infinite loop, we now
throw an exception.

See mstamy2/PyPDF2#165
