### PR TITLE
MISC: Add more precise license field to setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ description = PDF toolkit
 long_description = file: README.md
 long_description_content_type = text/markdown
 
+license = BSD-3-Clause
+
 url = https://pypdf2.readthedocs.io/en/latest/
 project_urls =
     Source = https://github.com/py-pdf/PyPDF2


### PR DESCRIPTION
This PR makes the license metadata for the package more precise by utilizing the optional [`License`](https://packaging.python.org/en/latest/specifications/core-metadata/#license-optional) field, so that people will see that it's the `BSD-3-Clause` license, and not just any old BSD license. Ideally we'd be able to use a classifier, but blocked on that front by https://github.com/pypa/trove-classifiers/issues/17.