### PR TITLE
Adding Documentation to / clone_reader_document_root

### DIFF
--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -683,7 +683,7 @@ class PdfWriter:
 
     def clone_reader_document_root(self, reader: PdfReader) -> None:
         """
-        Copy the reader document root to the writer.
+       This method copys the root document like copying the text or any other information or data. 
 
         :param reader:  PdfReader from the document root should be copied.
         """

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -683,7 +683,9 @@ class PdfWriter:
 
     def clone_reader_document_root(self, reader: PdfReader) -> None:
         """
-       This method copys the root document like copying the text or any other information or data. 
+       This method copys the root document like copying the text or any other information or data.
+        Another example could be copying the style of the pdf document so it can be analyzed. 
+        Once the data from the root has been copied the pdf document can be processed. 
 
         :param reader:  PdfReader from the document root should be copied.
         """

--- a/PyPDF2/_writer.py
+++ b/PyPDF2/_writer.py
@@ -686,6 +686,7 @@ class PdfWriter:
        This method copys the root document like copying the text or any other information or data.
         Another example could be copying the style of the pdf document so it can be analyzed. 
         Once the data from the root has been copied the pdf document can be processed. 
+        This way the document can be processed. 
 
         :param reader:  PdfReader from the document root should be copied.
         """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "myst_parser",
+    "myst_parser"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "myst-parser",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "myst_parser",
+    "myst-parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "myst_parser"
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ You can contribute to `PyPDF2 on GitHub <https://github.com/py-pdf/PyPDF2>`_.
    modules/Field
    modules/PageRange
    modules/AnnotationBuilder
+   modules/PaperSize
 
 .. toctree::
    :caption: Developer Guide

--- a/docs/modules/PaperSize.rst
+++ b/docs/modules/PaperSize.rst
@@ -1,0 +1,7 @@
+The PaperSize Class
+------------------------
+
+.. autoclass:: PyPDF2.PaperSize
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
I added the documentation to the / clone_reader_document_root method.  This change is necessary as it provides a better description on what the method does. This helps the developers understand the code and they will be able to update it later. Adding the documentation for the / clone_reader_document_root method will allow developers to better understand the method functionalities and will allow them to update it later. 