### PR TITLE
ENH: Add support for page labels

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -62,10 +62,6 @@ from typing import Iterator
 from ._protocols import PdfReaderProtocol
 
 
-def number2decimal(number: int) -> str:
-    return str(number)
-
-
 def number2uppercase_roman_numeral(num: int) -> str:
     roman = []
     roman.append((1000, "M"))
@@ -144,7 +140,7 @@ def index2label(reader: PdfReaderProtocol, index: int) -> str:
                 break
             i += 2
         m = {
-            "/D": number2decimal,
+            "/D": str,
             "/R": number2uppercase_roman_numeral,
             "/r": number2lowercase_roman_numeral,
             "/A": number2uppercase_letter,

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -141,7 +141,7 @@ def index2label(reader: PdfReaderProtocol, index: int) -> str:
                 break
             i += 2
         m = {
-            "/D": str,
+            "/D": lambda n: str(n),
             "/R": number2uppercase_roman_numeral,
             "/r": number2lowercase_roman_numeral,
             "/A": number2uppercase_letter,

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -63,20 +63,21 @@ from ._protocols import PdfReaderProtocol
 
 
 def number2uppercase_roman_numeral(num: int) -> str:
-    roman = []
-    roman.append((1000, "M"))
-    roman.append((900, "CM"))
-    roman.append((500, "D"))
-    roman.append((400, "CD"))
-    roman.append((100, "C"))
-    roman.append((90, "XC"))
-    roman.append((50, "L"))
-    roman.append((40, "XL"))
-    roman.append((10, "X"))
-    roman.append((9, "IX"))
-    roman.append((5, "V"))
-    roman.append((4, "IV"))
-    roman.append((1, "I"))
+    roman = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
 
     def roman_num(num: int) -> Iterator[str]:
         for decimal, roman_repr in roman:

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -1,0 +1,160 @@
+"""
+Page labels are shown by PDF viewers as "the page number".
+
+A page has a numeric index, starting with 0. Additionally to that, the page
+has a label. In the most simple case:
+    label = index + 1
+
+However, the title page and the table of contents might have roman numerals as
+page label. This makes things more complicated.
+
+Example 1
+---------
+
+>>> reader.trailer["/Root"]["/PageLabels"]["/Nums"]
+[0, IndirectObject(18, 0, 139929798197504),
+ 8, IndirectObject(19, 0, 139929798197504)]
+>>> reader.get_object(reader.trailer["/Root"]["/PageLabels"]["/Nums"][1])
+{'/S': '/r'}
+>>> reader.get_object(reader.trailer["/Root"]["/PageLabels"]["/Nums"][3])
+{'/S': '/D'}
+
+Example 2
+---------
+The following example shows a document with pages labeled
+i, ii, iii, iv, 1, 2, 3, A-8, A-9, ...
+
+1 0 obj
+    << /Type /Catalog
+    /PageLabels << /Nums [
+            0 << /S /r >>
+            4 << /S /D >>
+            7 << /S /D
+            /P ( A- )
+            /St 8
+            >>
+            % A number tree containing
+            % three page label dictionaries
+        ]
+        >>
+    ...
+    >>
+endobj
+
+
+PDF Specification 1.7
+=====================
+
+Table 159 – Entries in a page label dictionary
+----------------------------------------------
+The S-key:
+D       Decimal arabic numerals
+R       Uppercase roman numerals
+r       Lowercase roman numerals
+A       Uppercase letters (A to Z for the first 26 pages,
+                           AA to ZZ for the next 26, and so on)
+a       Lowercase letters (a to z for the first 26 pages,
+                           aa to zz for the next 26, and so on)
+"""
+
+from typing import Iterator
+
+from ._protocols import PdfReaderProtocol
+
+
+def number2decimal(number: int) -> str:
+    return str(number)
+
+
+def number2uppercase_roman_numeral(num: int) -> str:
+    roman = []
+    roman.append((1000, "M"))
+    roman.append((900, "CM"))
+    roman.append((500, "D"))
+    roman.append((400, "CD"))
+    roman.append((100, "C"))
+    roman.append((90, "XC"))
+    roman.append((50, "L"))
+    roman.append((40, "XL"))
+    roman.append((10, "X"))
+    roman.append((9, "IX"))
+    roman.append((5, "V"))
+    roman.append((4, "IV"))
+    roman.append((1, "I"))
+
+    def roman_num(num: int) -> Iterator[str]:
+        for decimal, roman_repr in roman:
+            x, y = divmod(num, decimal)
+            yield roman_repr * x
+            num -= decimal * x
+            if num <= 0:
+                break
+
+    return "".join([a for a in roman_num(num)])
+
+
+def number2lowercase_roman_numeral(number: int) -> str:
+    return number2uppercase_roman_numeral(number).lower()
+
+
+def number2uppercase_letter(number: int) -> str:
+    if number <= 0:
+        raise ValueError("Expecting a positive number")
+    alphabet = [chr(i) for i in range(ord("A"), ord("Z") + 1)]
+    rep = ""
+    while number > 0:
+        remainder = number % 26
+        if remainder == 0:
+            remainder = 26
+        rep = alphabet[remainder - 1] + rep
+        # update
+        number -= remainder
+        number = number // 26
+    return rep
+
+
+def number2lowercase_letter(number: int) -> str:
+    return number2uppercase_letter(number).lower()
+
+
+def index2label(reader: PdfReaderProtocol, index: int) -> str:
+    """See 7.9.7 "Number Trees"."""
+    root = reader.trailer["/Root"]
+    if "/PageLabels" not in root:
+        return str(index + 1)  # Fallback
+    number_tree = root["/PageLabels"]
+    if "/Nums" in number_tree:
+        # [Nums] shall be an array of the form
+        #   [ key 1 value 1 key 2 value 2 ... key n value n ]
+        # where each key_i is an integer and the corresponding
+        # value_i shall be the object associated with that key.
+        # The keys shall be sorted in numerical order,
+        # analogously to the arrangement of keys in a name tree
+        # as described in 7.9.6, "Name Trees."
+        nums = number_tree["/Nums"]
+        i = 0
+        value = None
+        start_index = 0
+        while i < len(nums):
+            start_index = nums[i]
+            value = nums[i + 1]
+            if i + 2 == len(nums):
+                break
+            if nums[i + 2] > index:
+                break
+            i += 2
+        m = {
+            "/D": number2decimal,
+            "/R": number2uppercase_roman_numeral,
+            "/r": number2lowercase_roman_numeral,
+            "/A": number2uppercase_letter,
+            "/a": number2lowercase_letter,
+        }
+        if not isinstance(value, dict):
+            value = reader.get_object(value)
+        if not isinstance(value, dict):
+            return str(index + 1)  # Fallback
+        return m[value["/S"]](index - start_index + 1)
+    # TODO: Kids
+    # TODO: Limits
+    return str(index + 1)  # Fallback

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -60,6 +60,7 @@ a       Lowercase letters (a to z for the first 26 pages,
 from typing import Iterator
 
 from ._protocols import PdfReaderProtocol
+from ._utils import logger_warning
 
 
 def number2uppercase_roman_numeral(num: int) -> str:
@@ -152,6 +153,14 @@ def index2label(reader: PdfReaderProtocol, index: int) -> str:
         if not isinstance(value, dict):
             return str(index + 1)  # Fallback
         return m[value["/S"]](index - start_index + 1)
-    # TODO: Kids
-    # TODO: Limits
+    if "/Kids" in number_tree or "/Limits" in number_tree:
+        logger_warning(
+            (
+                "/Kids or /Limits found in PageLabels. "
+                "Please share this PDF with pypdf: "
+                "https://github.com/py-pdf/pypdf/pull/1519"
+            ),
+            __name__,
+        )
+    # TODO: Implement /Kids and /Limits for number tree
     return str(index + 1)  # Fallback

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -47,6 +47,10 @@ class PdfReaderProtocol(Protocol):  # pragma: no cover
     def pages(self) -> List[Any]:
         ...
 
+    @property
+    def trailer(self) -> Dict[str, Any]:
+        ...
+
     def get_object(self, indirect_reference: Any) -> Optional[PdfObjectProtocol]:
         ...
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -48,6 +48,7 @@ from typing import (
 
 from ._encryption import Encryption, PasswordType
 from ._page import PageObject, _VirtualList
+from ._page_labels import index2label as page_index2page_label
 from ._utils import (
     StrByteType,
     StreamType,
@@ -984,6 +985,16 @@ class PdfReader:
     def pages(self) -> List[PageObject]:
         """Read-only property that emulates a list of :py:class:`Page<pypdf._page.Page>` objects."""
         return _VirtualList(self._get_num_pages, self._get_page)  # type: ignore
+
+    @property
+    def page_labels(self) -> List[str]:
+        """
+        A list of labels for the pages in this document.
+
+        This property is read-only. The labels are in the order
+        that the pages appear in the document.
+        """
+        return [page_index2page_label(self, i) for i in range(len(self.pages))]
 
     @property
     def page_layout(self) -> Optional[str]:

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -1,0 +1,41 @@
+import pytest
+
+from pypdf._page_labels import (
+    number2lowercase_letter,
+    number2uppercase_roman_numeral,
+)
+
+
+@pytest.mark.parametrize(
+    ("number", "expected"),
+    [
+        (1, "I"),
+        (2, "II"),
+        (3, "III"),
+        (4, "IV"),
+        (5, "V"),
+        (6, "VI"),
+        (7, "VII"),
+        (8, "VIII"),
+        (9, "IX"),
+        (10, "X"),
+    ],
+)
+def test_number2uppercase_roman_numeral(number, expected):
+    assert number2uppercase_roman_numeral(number) == expected
+
+
+@pytest.mark.parametrize(
+    ("number", "expected"),
+    [
+        (1, "a"),
+        (2, "b"),
+        (3, "c"),
+        (25, "y"),
+        (26, "z"),
+        (27, "aa"),
+        (28, "ab"),
+    ],
+)
+def test_number2lowercase_letter(number, expected):
+    assert number2lowercase_letter(number) == expected

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -2,6 +2,7 @@ import pytest
 
 from pypdf._page_labels import (
     number2lowercase_letter,
+    number2lowercase_roman_numeral,
     number2uppercase_roman_numeral,
 )
 
@@ -23,6 +24,10 @@ from pypdf._page_labels import (
 )
 def test_number2uppercase_roman_numeral(number, expected):
     assert number2uppercase_roman_numeral(number) == expected
+
+
+def test_number2lowercase_roman_numeral():
+    assert number2lowercase_roman_numeral(123) == "cxxiii"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1232,3 +1232,26 @@ def test_build_outline_item(caplog):
             )
         )
     assert "Unexpected destination 2" in exc.value.args[0]
+
+
+@pytest.mark.parametrize(
+    ("src", "page_labels"),
+    [
+        (RESOURCE_ROOT / "selenium-pypdf-issue-177.pdf", ["1"]),
+        (RESOURCE_ROOT / "encrypted_doc_no_id.pdf", ["1", "2", "3"]),
+        (RESOURCE_ROOT / "pdflatex-outline.pdf", ["1", "2", "3", "4"]),
+        (
+            SAMPLE_ROOT / "009-pdflatex-geotopo/GeoTopo.pdf",
+            ["i", "ii", "iii", "1", "2", "3"],
+        ),
+    ],
+    ids=[
+        "selenium-pypdf-issue-177.pdf",
+        "encrypted_doc_no_id.pdf",
+        "pdflatex-outline.pdf",
+        "GeoTopo.pdf",
+    ],
+)
+def test_page_labels(src, page_labels):
+    max_indices = 6
+    assert PdfReader(src).page_labels[:max_indices] == page_labels[:max_indices]


### PR DESCRIPTION
Introduce a new PdfReader property `page_labels` that returns a list of strings.

In most cases, the list will just be

```
['1', '2', '3', '4', '5']
```

or similar, but sometimes it will be:

```
['i', 'ii', 'iii', 'iv', '1', '2', '3', '4', '5']
```

## Evidence for User Need

* Stackoverflow: [Retrieve Custom page labels from document with pyPDF](https://stackoverflow.com/questions/12360999/retrieve-custom-page-labels-from-document-with-pypdf)