### PR TITLE
ENH: Accept hierarchical fields

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -700,9 +700,11 @@ class PdfReader:
             }
         else:
             ff = {}
-            for (k, v) in formfields.items():
+            for (_k, v) in formfields.items():
                 if v.get("/FT") == "/Tx":
-                    ff[indexed_key(cast(str, v["/T"]), ff)] = cast(str, v["/V"])
+                    ff[indexed_key(cast(str, v["/T"]), ff)] = (
+                        cast(str, v["/V"]) if "/V" in v else None
+                    )
         return ff
         """return {
             (field if full_qualified_name else formfields[field]["/T"]): formfields[

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -574,13 +574,19 @@ class PdfReader:
         deprecation_with_replacement("getFields", "get_fields", "3.0.0")
         return self.get_fields(tree, retval, fileobj)
 
-    def _get_qualified_field_name(self, parent):
+    def _get_qualified_field_name(self, parent: DictionaryObject) -> str:
         if "/TM" in parent:
-            return parent["/TM"]
+            return cast(str, parent["/TM"])
         elif "/Parent" in parent:
-            return _get_qualified_field_name(parent["/Parent"]) + "." + parent["/T"]
+            return (
+                self._get_qualified_field_name(
+                    cast(DictionaryObject, parent["/Parent"])
+                )
+                + "."
+                + cast(str, parent["/T"])
+            )
         else:
-            return parent["/T"]
+            return cast(str, parent["/T"])
 
     def _build_field(
         self,
@@ -591,14 +597,19 @@ class PdfReader:
     ) -> None:
         self._check_kids(field, retval, fileobj)
         try:
-            key = field["/TM"]
+            key = cast(str, field["/TM"])
         except KeyError:
             try:
                 if "/Parent" in field:
-                    key = self._get_qualified_field_name(field["/Parent"]) + "."
+                    key = (
+                        self._get_qualified_field_name(
+                            cast(DictionaryObject, field["/Parent"])
+                        )
+                        + "."
+                    )
                 else:
                     key = ""
-                key += field["/T"]
+                key += cast(str, field["/T"])
             except KeyError:
                 # Ignore no-name field for now
                 return

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -701,21 +701,13 @@ class PdfReader:
         formfields = self.get_fields()
         if formfields is None:
             return {}
-        if full_qualified_name:
-            ff = {
-                (field if full_qualified_name else formfields[field]["/T"]): formfields[
-                    field
-                ].get("/V")
-                for field in formfields
-                if formfields[field].get("/FT") == "/Tx"
-            }
-        else:
-            ff = {}
-            for v in formfields.values():
-                if v.get("/FT") == "/Tx":
-                    ff[indexed_key(cast(str, v["/T"]), ff)] = (
-                        cast(str, v["/V"]) if "/V" in v else None
-                    )
+        ff = {}
+        for field, value in formfields.items():
+            if value.get("/FT") == "/Tx":
+                if full_qualified_name:
+                    ff[field] = value.get("/V")
+                else:
+                    ff[indexed_key(cast(str, value["/T"]), ff)] = value.get("/V")
         return ff
         """return {
             (field if full_qualified_name else formfields[field]["/T"]): formfields[

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -700,7 +700,7 @@ class PdfReader:
             }
         else:
             ff = {}
-            for (_k, v) in formfields.items():
+            for v in formfields.values():
                 if v.get("/FT") == "/Tx":
                     ff[indexed_key(cast(str, v["/T"]), ff)] = (
                         cast(str, v["/V"]) if "/V" in v else None

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1090,15 +1090,16 @@ class Field(TreeObject):
     :meth:`get_fields()<pypdf.PdfReader.get_fields>`
     """
 
-    def __init__(self, data: Dict[str, Any]) -> None:
+    def __init__(self, data: DictionaryObject) -> None:
         DictionaryObject.__init__(self)
         field_attributes = (
             FieldDictionaryAttributes.attributes()
             + CheckboxRadioButtonAttributes.attributes()
         )
+        self.indirect_reference = data.indirect_reference
         for attr in field_attributes:
             try:
-                self[NameObject(attr)] = data.raw_get(attr)
+                self[NameObject(attr)] = data[attr]
             except KeyError:
                 pass
 

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1098,7 +1098,7 @@ class Field(TreeObject):
         )
         for attr in field_attributes:
             try:
-                self[NameObject(attr)] = data[attr]
+                self[NameObject(attr)] = data.raw_get(attr)
             except KeyError:
                 pass
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -866,6 +866,25 @@ def test_get_fields():
     assert dict(fields["c1-1"]) == ({"/FT": "/Btn", "/T": "c1-1"})
 
 
+def test_get_full_qualified_fields():
+    url = "https://github.com/py-pdf/PyPDF2/files/10142389/fields_with_dots.pdf"
+    name = "fields_with_dots.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    fields = reader.get_form_text_fields(True)
+    assert fields is not None
+    assert "customer.name" in fields
+
+    fields = reader.get_form_text_fields(False)
+    assert fields is not None
+    assert "customer.name" not in fields
+    assert "name" in fields
+
+    fields = reader.get_fields(True)
+    assert fields is not None
+    assert "customer.name" in fields
+    assert fields["customer.name"]["/T"] == "name"
+
+
 @pytest.mark.external
 @pytest.mark.filterwarnings("ignore::pypdf.errors.PdfReadWarning")
 def test_get_fields_read_else_block():


### PR DESCRIPTION
fixes #1468
Add an optional parameter to `get_form_text_fields`

TBC : behavior with multiple fields with same name create sequence _2, _3, ... does not seem to be applied

Pending : Test to be added