### PR TITLE
DOC: Fix linked markdown documents

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ history and [GitHubs 'Contributors' feature](https://github.com/py-pdf/pypdf/gra
 
 ## Contributors to the pypdf (formerly pyPdf / PyPDF2) project
 
+* [abyesilyurt](https://github.com/abyesilyurt)
 * [DL6ER](https://github.com/DL6ER)
 * [ediamondscience](https://github.com/ediamondscience)
 * [Górny, Michał](https://github.com/mgorny)

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -1,4 +1,4 @@
 sphinx
 sphinx_rtd_theme
-myst_parser
+myst_parser==0.16.1
 -e .

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -39,7 +39,7 @@ mdit-py-plugins==0.3.3
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-myst-parser==0.18.1
+myst-parser==0.16.1
     # via -r requirements/docs.in
 packaging==22.0
     # via sphinx


### PR DESCRIPTION
Internal markdown links in docs did not work due to a bug in myst-parser. We can use an older version of myst-parser until the bug is fixed.

Example: On page: https://pypdf.readthedocs.io/en/stable/dev/intro.html, link to "See testing pypdf with pytest"

Related issue: https://github.com/executablebooks/MyST-Parser/issues/658