### PR TITLE
Annotate tests appropriately

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -176,7 +176,6 @@ def test_get_outline(src, outline_elements):
     assert len(outline) == outline_elements
 
 
-
 @pytest.mark.samples
 @pytest.mark.parametrize(
     ("src", "expected_images"),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -175,6 +175,8 @@ def test_get_outline(src, outline_elements):
     outline = reader.outline
     assert len(outline) == outline_elements
 
+
+
 @pytest.mark.samples
 @pytest.mark.parametrize(
     ("src", "expected_images"),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -175,7 +175,7 @@ def test_get_outline(src, outline_elements):
     outline = reader.outline
     assert len(outline) == outline_elements
 
-
+@pytest.mark.samples
 @pytest.mark.parametrize(
     ("src", "expected_images"),
     [
@@ -866,6 +866,7 @@ def test_get_fields():
     assert dict(fields["c1-1"]) == ({"/FT": "/Btn", "/T": "c1-1"})
 
 
+@pytest.mark.external
 def test_get_full_qualified_fields():
     url = "https://github.com/py-pdf/PyPDF2/files/10142389/fields_with_dots.pdf"
     name = "fields_with_dots.pdf"
@@ -1214,6 +1215,7 @@ def test_zeroing_xref():
     len(reader.pages)
 
 
+@pytest.mark.external
 def test_thread():
     url = "https://github.com/py-pdf/pypdf/files/9066120/UTA_OSHA_3115_Fall_Protection_Training_09162021_.pdf"
     name = "UTA_OSHA.pdf"
@@ -1226,6 +1228,7 @@ def test_thread():
     assert len(reader.threads) >= 1
 
 
+@pytest.mark.external
 def test_build_outline_item(caplog):
     url = "https://github.com/py-pdf/pypdf/files/9464742/shiv_resume.pdf"
     name = "shiv_resume.pdf"
@@ -1253,6 +1256,7 @@ def test_build_outline_item(caplog):
     assert "Unexpected destination 2" in exc.value.args[0]
 
 
+@pytest.mark.samples
 @pytest.mark.parametrize(
     ("src", "page_labels"),
     [

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -930,6 +930,7 @@ def test_startup_dest():
     pdf_file_writer.open_destination = None
 
 
+@pytest.mark.external
 def test_iss471():
     url = "https://github.com/py-pdf/pypdf/files/9139245/book.pdf"
     name = "book_471.pdf"
@@ -942,6 +943,7 @@ def test_iss471():
     )
 
 
+@pytest.mark.external
 def test_reset_translation():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"
@@ -977,6 +979,7 @@ def test_threads_empty():
     assert thr == thr2
 
 
+@pytest.mark.external
 def test_append_without_annots_and_articles():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"
@@ -993,6 +996,7 @@ def test_append_without_annots_and_articles():
     assert len(writer.threads) >= 1
 
 
+@pytest.mark.external
 def test_append_multiple():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"


### PR DESCRIPTION
By annotating these tests, we can use pytest markers to skip external tests and tests that depend on sample-files.