### PR TITLE
DOC: Removed the redundant `fields` variable

### DIFF
--- a/docs/user/forms.md
+++ b/docs/user/forms.md
@@ -19,7 +19,6 @@ reader = PdfReader("form.pdf")
 writer = PdfWriter()
 
 page = reader.pages[0]
-fields = reader.get_fields()
 
 writer.add_page(page)
 


### PR DESCRIPTION
The following code example does not use the fields variable. It is defined but not used.