### PR TITLE
STY: Docstring formatting of darglint

### DIFF
--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -290,17 +290,17 @@ class AlgV4:
            value of the encryption dictionary’s Length entry.
 
         Args:
-          password: The encryption secret as a bytes-string
-          rev: The encryption revision (see PDF standard)
-          key_size: The size of the key in bytes
-          o_entry: The owner entry
-          P: A set of flags specifying which operations shall be permitted
-            when the document is opened with user access. If bit 2 is set to 1,
-            all other bits are ignored and all operations are permitted.
-            If bit 2 is set to 0, permission for operations are based on the
-            values of the remaining flags defined in Table 24.
-          id1_entry:
-          metadata_encrypted: A boolean indicating if the metadata is encrypted.
+            password: The encryption secret as a bytes-string
+            rev: The encryption revision (see PDF standard)
+            key_size: The size of the key in bytes
+            o_entry: The owner entry
+            P: A set of flags specifying which operations shall be permitted
+                when the document is opened with user access. If bit 2 is set to 1,
+                all other bits are ignored and all operations are permitted.
+                If bit 2 is set to 0, permission for operations are based on the
+                values of the remaining flags defined in Table 24.
+            id1_entry:
+            metadata_encrypted: A boolean indicating if the metadata is encrypted.
 
         Returns:
             The u_hash digest of length key_size
@@ -353,12 +353,12 @@ class AlgV4:
            the value of the O entry in the encryption dictionary.
 
         Args:
-          owner_password:
-          rev: The encryption revision (see PDF standard)
-          key_size: The size of the key in bytes
+            owner_password:
+            rev: The encryption revision (see PDF standard)
+            key_size: The size of the key in bytes
 
         Returns:
-          The RC4 key
+            The RC4 key
         """
         a = _padding(owner_password)
         o_hash_digest = hashlib.md5(a).digest()
@@ -376,12 +376,12 @@ class AlgV4:
         See :func:`compute_O_value_key`.
 
         Args:
-          rc4_key:
-          user_password:
-          rev: The encryption revision (see PDF standard)
+            rc4_key:
+            user_password:
+            rev: The encryption revision (see PDF standard)
 
         Returns:
-          The RC4 encrypted
+            The RC4 encrypted
         """
         a = _padding(user_password)
         rc4_enc = RC4_encrypt(rc4_key, a)
@@ -407,12 +407,12 @@ class AlgV4:
            encryption dictionary.
 
         Args:
-          key:
-          rev: The encryption revision (see PDF standard)
-          id1_entry:
+            key:
+            rev: The encryption revision (see PDF standard)
+            id1_entry:
 
         Returns:
-          The value
+            The value
         """
         if rev <= 2:
             value = RC4_encrypt(key, _PADDING)
@@ -482,21 +482,21 @@ class AlgV4:
            to decrypt the document.
 
         Args:
-          user_password: The user passwort as a bytes stream
-          rev: The encryption revision (see PDF standard)
-          key_size: The size of the key in bytes
-          o_entry: The owner entry
-          u_entry: The user entry
-          P: A set of flags specifying which operations shall be permitted
-            when the document is opened with user access. If bit 2 is set to 1,
-            all other bits are ignored and all operations are permitted.
-            If bit 2 is set to 0, permission for operations are based on the
-            values of the remaining flags defined in Table 24.
-          id1_entry:
-          metadata_encrypted: A boolean indicating if the metadata is encrypted.
+            user_password: The user passwort as a bytes stream
+            rev: The encryption revision (see PDF standard)
+            key_size: The size of the key in bytes
+            o_entry: The owner entry
+            u_entry: The user entry
+            P: A set of flags specifying which operations shall be permitted
+                when the document is opened with user access. If bit 2 is set to 1,
+                all other bits are ignored and all operations are permitted.
+                If bit 2 is set to 0, permission for operations are based on the
+                values of the remaining flags defined in Table 24.
+            id1_entry:
+            metadata_encrypted: A boolean indicating if the metadata is encrypted.
 
         Returns:
-          The key
+            The key
         """
         key = AlgV4.compute_key(
             user_password, rev, key_size, o_entry, P, id1_entry, metadata_encrypted
@@ -544,21 +544,21 @@ class AlgV4:
            If it is correct, the password supplied is the correct owner password.
 
         Args:
-          owner_password:
-          rev: The encryption revision (see PDF standard)
-          key_size: The size of the key in bytes
-          o_entry: The owner entry
-          u_entry: The user entry
-          P: A set of flags specifying which operations shall be permitted
-            when the document is opened with user access. If bit 2 is set to 1,
-            all other bits are ignored and all operations are permitted.
-            If bit 2 is set to 0, permission for operations are based on the
-            values of the remaining flags defined in Table 24.
-          id1_entry:
-          metadata_encrypted: A boolean indicating if the metadata is encrypted.
+            owner_password:
+            rev: The encryption revision (see PDF standard)
+            key_size: The size of the key in bytes
+            o_entry: The owner entry
+            u_entry: The user entry
+            P: A set of flags specifying which operations shall be permitted
+                when the document is opened with user access. If bit 2 is set to 1,
+                all other bits are ignored and all operations are permitted.
+                If bit 2 is set to 0, permission for operations are based on the
+                values of the remaining flags defined in Table 24.
+            id1_entry:
+            metadata_encrypted: A boolean indicating if the metadata is encrypted.
 
         Returns:
-          bytes
+            bytes
         """
         rc4_key = AlgV4.compute_O_value_key(owner_password, rev, key_size)
 
@@ -629,19 +629,19 @@ class AlgV5:
            They should match the value in the P key.
 
         Args:
-          R:  A number specifying which revision of the standard security
-            handler shall be used to interpret this dictionary
-          password: The owner password
-          o_value: A 32-byte string, based on both the owner and user passwords,
-            that shall be used in computing the encryption key and in determining
-            whether a valid owner password was entered
-          oe_value:
-          u_value: A 32-byte string, based on the user password, that shall be
-            used in determining whether to prompt the user for a password and, if so,
-            whether a valid user or owner password was entered.
+            R: A number specifying which revision of the standard security
+                handler shall be used to interpret this dictionary
+            password: The owner password
+            o_value: A 32-byte string, based on both the owner and user passwords,
+                that shall be used in computing the encryption key and in
+                determining whether a valid owner password was entered
+            oe_value:
+            u_value: A 32-byte string, based on the user password, that shall be
+                used in determining whether to prompt the user for a password and,
+                if so, whether a valid user or owner password was entered.
 
         Returns:
-          The key
+            The key
         """
         password = password[:127]
         if (
@@ -662,16 +662,16 @@ class AlgV5:
         See :func:`verify_owner_password`.
 
         Args:
-          R:  A number specifying which revision of the standard security
-            handler shall be used to interpret this dictionary
-          password: The user password
-          u_value: A 32-byte string, based on the user password, that shall be
-            used in determining whether to prompt the user for a password and, if so,
-            whether a valid user or owner password was entered.
-          ue_value:
+            R: A number specifying which revision of the standard security
+                handler shall be used to interpret this dictionary
+            password: The user password
+            u_value: A 32-byte string, based on the user password, that shall be
+                used in determining whether to prompt the user for a password
+                and, if so, whether a valid user or owner password was entered.
+            ue_value:
 
         Returns:
-          bytes
+            bytes
         """
         password = password[:127]
         if AlgV5.calculate_hash(R, password, u_value[32:40], b"") != u_value[:32]:
@@ -709,17 +709,18 @@ class AlgV5:
         See :func:`verify_owner_password` and :func:`compute_perms_value`.
 
         Args:
-          key: The owner password
-          perms:
-          p: A set of flags specifying which operations shall be permitted
-            when the document is opened with user access. If bit 2 is set to 1, all other
-            bits are ignored and all operations are permitted. If bit 2 is set to 0,
-            permission for operations are based on the values of the remaining flags
-            defined in Table 24.
-          metadata_encrypted:
+            key: The owner password
+            perms:
+            p: A set of flags specifying which operations shall be permitted
+                when the document is opened with user access.
+                If bit 2 is set to 1, all other bits are ignored and all
+                operations are permitted.
+                If bit 2 is set to 0, permission for operations are based on
+                the values of the remaining flags defined in Table 24.
+            metadata_encrypted:
 
         Returns:
-          A boolean
+            A boolean
         """
         b8 = b"T" if metadata_encrypted else b"F"
         p1 = struct.pack("<I", p) + b"\xff\xff\xff\xff" + b8 + b"adb"
@@ -764,11 +765,11 @@ class AlgV5:
            as the UE key.
 
         Args:
-          password:
-          key:
+            password:
+            key:
 
         Returns:
-          A tuple (u-value, ue value)
+            A tuple (u-value, ue value)
         """
         random_bytes = bytes(random.randrange(0, 256) for _ in range(16))
         val_salt = random_bytes[:8]
@@ -804,14 +805,14 @@ class AlgV5:
            The resulting 32-byte string is stored as the OE key.
 
         Args:
-          password:
-          key:
-          u_value: A 32-byte string, based on the user password, that shall be
-            used in determining whether to prompt the user for a password and,
-            if so, whether a valid user or owner password was entered.
+            password:
+            key:
+            u_value: A 32-byte string, based on the user password, that shall be
+                used in determining whether to prompt the user for a password
+                and, if so, whether a valid user or owner password was entered.
 
         Returns:
-          A tuple (O value, OE value)
+            A tuple (O value, OE value)
         """
         random_bytes = bytes(random.randrange(0, 256) for _ in range(16))
         val_salt = random_bytes[:8]
@@ -845,16 +846,16 @@ class AlgV5:
            for validity when the file is opened.
 
         Args:
-          key:
-          p: A set of flags specifying which operations shall be permitted
-            when the document is opened with user access. If bit 2 is set to 1,
-            all other bits are ignored and all operations are permitted.
-            If bit 2 is set to 0, permission for operations are based on the
-            values of the remaining flags defined in Table 24.
-          metadata_encrypted: A boolean indicating if the metadata is encrypted.
+            key:
+            p: A set of flags specifying which operations shall be permitted
+                when the document is opened with user access. If bit 2 is set to 1,
+                all other bits are ignored and all operations are permitted.
+                If bit 2 is set to 0, permission for operations are based on the
+                values of the remaining flags defined in Table 24.
+            metadata_encrypted: A boolean indicating if the metadata is encrypted.
 
         Returns:
-          The perms value
+            The perms value
         """
         b8 = b"T" if metadata_encrypted else b"F"
         rr = bytes(random.randrange(0, 256) for _ in range(4))
@@ -939,12 +940,12 @@ class Encryption:
            The output is the encrypted data to be stored in the PDF file.
 
         Args:
-          obj:
-          idnum:
-          generation:
+            obj:
+            idnum:
+            generation:
 
         Returns:
-          The PdfObject
+            The PdfObject
         """
         pack1 = struct.pack("<i", idnum)[:3]
         pack2 = struct.pack("<i", generation)[:2]

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -96,11 +96,11 @@ class PdfMerger:
     and :meth:`write()<write>` for usage information.
 
     Args:
-      strict: Determines whether user should be warned of all
-         problems and also causes some correctable problems to be fatal.
-         Defaults to ``False``.
-      fileobj: Output file. Can be a filename or any kind of
-         file-like object.
+        strict: Determines whether user should be warned of all
+            problems and also causes some correctable problems to be fatal.
+            Defaults to ``False``.
+        fileobj: Output file. Can be a filename or any kind of
+            file-like object.
     """
 
     @deprecation_bookmark(bookmarks="outline")
@@ -146,23 +146,23 @@ class PdfMerger:
         specified page number.
 
         Args:
-          page_number: The *page number* to insert this file. File will
-            be inserted after the given number.
-          fileobj: A File Object or an object that supports the standard
-            read and seek methods similar to a File Object. Could also be a
-            string representing a path to a PDF file.
-            None as an argument is deprecated.
-          outline_item: Optionally, you may specify an outline item
-            (previously referred to as a 'bookmark') to be applied at the
-            beginning of the included file by supplying the text of the outline item.
-          pages: can be a :class:`PageRange<pypdf.pagerange.PageRange>`
-            or a ``(start, stop[, step])`` tuple
-            to merge only the specified range of pages from the source
-            document into the output document.
-            Can also be a list of pages to merge.
-         import_outline: You may prevent the source document's
-            outline (collection of outline items, previously referred to as
-            'bookmarks') from being imported by specifying this as ``False``.
+            page_number: The *page number* to insert this file. File will
+                be inserted after the given number.
+            fileobj: A File Object or an object that supports the standard
+                read and seek methods similar to a File Object. Could also be a
+                string representing a path to a PDF file.
+                None as an argument is deprecated.
+            outline_item: Optionally, you may specify an outline item
+                (previously referred to as a 'bookmark') to be applied at the
+                beginning of the included file by supplying the text of the outline item.
+            pages: can be a :class:`PageRange<pypdf.pagerange.PageRange>`
+                or a ``(start, stop[, step])`` tuple
+                to merge only the specified range of pages from the source
+                document into the output document.
+                Can also be a list of pages to merge.
+           import_outline: You may prevent the source document's
+                outline (collection of outline items, previously referred to as
+                'bookmarks') from being imported by specifying this as ``False``.
         """
         if position is not None:  # deprecated
             if page_number is None:
@@ -299,20 +299,20 @@ class PdfMerger:
         position.
 
         Args:
-          fileobj: A File Object or an object that supports the standard
-            read and seek methods similar to a File Object. Could also be a
-            string representing a path to a PDF file.
-          outline_item: Optionally, you may specify an outline item
-            (previously referred to as a 'bookmark') to be applied at the
-            beginning of the included file by supplying the text of the outline item.
-          pages: can be a :class:`PageRange<pypdf.pagerange.PageRange>`
-            or a ``(start, stop[, step])`` tuple
-            to merge only the specified range of pages from the source
-            document into the output document.
-            Can also be a list of pages to append.
-          import_outline: You may prevent the source document's
-            outline (collection of outline items, previously referred to as
-            'bookmarks') from being imported by specifying this as ``False``.
+            fileobj: A File Object or an object that supports the standard
+                read and seek methods similar to a File Object. Could also be a
+                string representing a path to a PDF file.
+            outline_item: Optionally, you may specify an outline item
+                (previously referred to as a 'bookmark') to be applied at the
+                beginning of the included file by supplying the text of the outline item.
+            pages: can be a :class:`PageRange<pypdf.pagerange.PageRange>`
+                or a ``(start, stop[, step])`` tuple
+                to merge only the specified range of pages from the source
+                document into the output document.
+                Can also be a list of pages to append.
+            import_outline: You may prevent the source document's
+                outline (collection of outline items, previously referred to as
+                'bookmarks') from being imported by specifying this as ``False``.
         """
         self.merge(len(self.pages), fileobj, outline_item, pages, import_outline)
 
@@ -321,8 +321,8 @@ class PdfMerger:
         Write all data that has been merged to the given output file.
 
         Args:
-          fileobj: Output file. Can be a filename or any kind of
-            file-like object.
+            fileobj: Output file. Can be a filename or any kind of
+                file-like object.
         """
         if self.output is None:
             raise RuntimeError(ERR_CLOSED_WRITER)
@@ -364,9 +364,9 @@ class PdfMerger:
         Add custom metadata to the output.
 
         Args:
-          infos: a Python dictionary where each key is a field
-            and each value is your new metadata.
-            An example is ``{'/Title': 'My title'}``
+            infos: a Python dictionary where each key is a field
+                and each value is your new metadata.
+                An example is ``{'/Title': 'My title'}``
         """
         if self.output is None:
             raise RuntimeError(ERR_CLOSED_WRITER)
@@ -395,7 +395,7 @@ class PdfMerger:
         Set the page layout.
 
         Args:
-          layout: The page layout to be used
+            layout: The page layout to be used
 
         .. list-table:: Valid ``layout`` arguments
            :widths: 50 200
@@ -433,7 +433,7 @@ class PdfMerger:
         Set the page mode.
 
         Args:
-          mode: The page mode to use.
+            mode: The page mode to use.
 
         .. list-table:: Valid ``mode`` arguments
            :widths: 50 200
@@ -490,12 +490,12 @@ class PdfMerger:
         Remove outline item entries that are not a part of the specified page set.
 
         Args:
-          pdf:
-          outline:
-          pages:
+            pdf:
+            outline:
+            pages:
 
         Returns:
-          An outline type
+            An outline type
         """
         new_outline = []
         prev_header_added = True
@@ -693,15 +693,15 @@ class PdfMerger:
         Add an outline item (commonly referred to as a "Bookmark") to this PDF file.
 
         Args:
-          title: Title to use for this outline item.
-          page_number: Page number this outline item will point to.
-          parent: A reference to a parent outline item to create nested
-            outline items.
-          color: Color of the outline item's font as a red, green, blue tuple
-            from 0.0 to 1.0
-          bold: Outline item font is bold
-          italic: Outline item font is italic
-          fit: The fit of the destination page.
+            title: Title to use for this outline item.
+            page_number: Page number this outline item will point to.
+            parent: A reference to a parent outline item to create nested
+                outline items.
+            color: Color of the outline item's font as a red, green, blue tuple
+                from 0.0 to 1.0
+            bold: Outline item font is bold
+            italic: Outline item font is italic
+            fit: The fit of the destination page.
         """
         if page_number is not None and pagenum is not None:
             raise ValueError(
@@ -807,8 +807,8 @@ class PdfMerger:
         Add a destination to the output.
 
         Args:
-          title: Title to use
-          page_number: Page number this destination points at.
+            title: Title to use
+            page_number: Page number this destination points at.
         """
         if page_number is not None and pagenum is not None:
             raise ValueError(

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -540,6 +540,9 @@ class PageObject(DictionaryObject):
 
         Args:
             angle: Angle to rotate the page.  Must be an increment of 90 deg.
+
+        Returns:
+            The rotated PageObject
         """
         if angle % 90 != 0:
             raise ValueError("Rotation angle must be a multiple of 90")
@@ -580,8 +583,18 @@ class PageObject(DictionaryObject):
         new_res.update(res1.get(resource, DictionaryObject()).get_object())
 
         def compute_unique_key(base_key: str) -> Tuple[str, bool]:
-            """Find a key that either doesn't already exist or has the same
-            value (indicated by the bool)"""
+            """
+            Find a key that either doesn't already exist or has the same
+            value (indicated by the bool)
+
+            Args:
+                base_key: An index is added to this to get the computed key
+
+            Returns:
+                A tuple (computed key, bool) where the boolean indicates
+                if there is a resource of the given computed_key with the same
+                value.
+            """
             value = page2res.raw_get(base_key)
             # try the current key first (e.g. "foo"), but otherwise iterate
             # through "foo-0", "foo-1", etc. new_res can contain only finitely
@@ -1922,7 +1935,12 @@ class PageObject(DictionaryObject):
         Extract text from an XObject.
 
         Args:
+            xform:
+            orientations:
             space_width:  force default space width (if not extracted from font (default 200)
+            visitor_operand_before:
+            visitor_operand_after:
+            visitor_text:
 
         Returns:
             The extracted text
@@ -2138,6 +2156,16 @@ def _get_fonts_walk(
     emb: Optional[Set[str]] = None,
 ) -> Tuple[Set[str], Set[str]]:
     """
+    Get the set of all fonts and all embedded fonts.
+
+    Args:
+        obj: Page resources dictionary
+        fnt: font
+        emb: embedded fonts
+
+    Returns:
+        A tuple (fnt, emb)
+
     If there is a key called 'BaseFont', that is a font that is used in the document.
     If there is a key called 'FontName' and another key in the same dictionary object
     that is called 'FontFilex' (where x is null, 2, or 3), then that fontname is

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -284,15 +284,15 @@ class PdfReader:
     tables are read into memory.
 
     Args:
-      stream: A File object or an object that supports the standard read
-        and seek methods similar to a File object. Could also be a
-        string representing a path to a PDF file.
-      strict: Determines whether user should be warned of all
-        problems and also causes some correctable problems to be fatal.
-        Defaults to ``False``.
-      password: Decrypt PDF file at initialization. If the
-        password is None, the file will not be decrypted.
-        Defaults to ``None``
+        stream: A File object or an object that supports the standard read
+            and seek methods similar to a File object. Could also be a
+            string representing a path to a PDF file.
+        strict: Determines whether user should be warned of all
+            problems and also causes some correctable problems to be fatal.
+            Defaults to ``False``.
+        password: Decrypt PDF file at initialization. If the
+            password is None, the file will not be decrypted.
+            Defaults to ``None``
     """
 
     def __init__(
@@ -436,11 +436,11 @@ class PdfReader:
         Args:
 
         Returns:
-          The number of pages of the parsed PDF file
+            The number of pages of the parsed PDF file
 
         Raises:
-          PdfReadError: if file is encrypted and restrictions prevent
-            this action.
+            PdfReadError: if file is encrypted and restrictions prevent
+                this action.
         """
         # Flattened pages will not work on an Encrypted PDF;
         # the PDF file's page count is used in this case. Otherwise,
@@ -487,11 +487,11 @@ class PdfReader:
         Retrieve a page by number from this PDF file.
 
         Args:
-          page_number: The page number to retrieve
-            (pages begin at zero)
+            page_number: The page number to retrieve
+                (pages begin at zero)
 
         Returns:
-          A :class:`PageObject<pypdf._page.PageObject>` instance.
+            A :class:`PageObject<pypdf._page.PageObject>` instance.
         """
         # ensure that we're not trying to access an encrypted PDF
         # assert not self.trailer.has_key(TK.ENCRYPT)
@@ -533,16 +533,16 @@ class PdfReader:
         The *tree* and *retval* parameters are for recursive use.
 
         Args:
-          tree:
-          retval:
-          fileobj: A file object (usually a text file) to write
-            a report to on all interactive form fields found.
+            tree:
+            retval:
+            fileobj: A file object (usually a text file) to write
+                a report to on all interactive form fields found.
 
         Returns:
-          A dictionary where each key is a field name, and each
-          value is a :class:`Field<pypdf.generic.Field>` object. By
-          default, the mapping name is used for keys.
-          ``None`` if form data could not be located.
+            A dictionary where each key is a field name, and each
+            value is a :class:`Field<pypdf.generic.Field>` object. By
+            default, the mapping name is used for keys.
+            ``None`` if form data could not be located.
 
         """
         field_attributes = FieldDictionaryAttributes.attributes_dict()
@@ -679,13 +679,15 @@ class PdfReader:
         """
         Retrieve form fields from the document with textual data.
 
-        The key is the name of the form field, the value is the content of the
-        field.
+        Args:
+            full_qualified_name: to get full name
 
-        If the document contains multiple form fields with the same name, the
-        second and following will get the suffix .2, .3, ...
+        Returns:
+            A dictionary. The key is the name of the form field,
+            the value is the content of the field.
 
-        full_qualified_name should be used to get full name
+            If the document contains multiple form fields with the same name, the
+            second and following will get the suffix .2, .3, ...
         """
 
         def indexed_key(k: str, fields: dict) -> str:
@@ -738,11 +740,11 @@ class PdfReader:
         Retrieve the named destinations present in the document.
 
         Args:
-          tree:
-          retval:
+            tree:
+            retval:
 
         Returns:
-          A dictionary which maps names to
+            A dictionary which maps names to
             :class:`Destinations<pypdf.generic.Destination>`.
         """
         if retval is None:
@@ -887,10 +889,10 @@ class PdfReader:
         """Generate _page_id2num
 
         Args:
-          indirect_reference:
+            indirect_reference:
 
         Returns:
-          The page number.
+            The page number.
         """
         if self._page_id2num is None:
             self._page_id2num = {
@@ -912,11 +914,11 @@ class PdfReader:
         Retrieve page number of a given PageObject
 
         Args:
-          page: The page to get page number. Should be
-            an instance of :class:`PageObject<pypdf._page.PageObject>`
+            page: The page to get page number. Should be
+                an instance of :class:`PageObject<pypdf._page.PageObject>`
 
         Returns:
-          The page number or -1 if page is not found
+            The page number or -1 if page is not found
         """
         return self._get_page_number_by_indirect(page.indirect_reference)
 
@@ -934,10 +936,10 @@ class PdfReader:
         Retrieve page number of a given Destination object.
 
         Args:
-          destination: The destination to get page number.
+            destination: The destination to get page number.
 
         Returns:
-          The page number or -1 if page is not found
+            The page number or -1 if page is not found
         """
         return self._get_page_number_by_indirect(destination.page)
 
@@ -1265,11 +1267,11 @@ class PdfReader:
         This is equivalent to generic.IndirectObject(num,gen,self).get_object()
 
         Args:
-          num:
-          gen:
+            num:
+            gen:
 
         Returns:
-          A PdfObject
+            A PdfObject
         """
         return IndirectObject(num, gen, self).get_object()
 
@@ -1559,10 +1561,10 @@ class PdfReader:
         Find startxref entry - the location of the xref table.
 
         Args:
-          stream:
+            stream:
 
         Returns:
-          The bytes offset
+            The bytes offset
         """
         line = read_previous_line(stream)
         try:
@@ -1849,11 +1851,11 @@ class PdfReader:
         Return an int which indicates an issue. 0 means there is no issue.
 
         Args:
-          stream:
-          startxref:
+            stream:
+            startxref:
 
         Returns:
-          0 means no issue, other values represent specific issues.
+            0 means no issue, other values represent specific issues.
         """
         stream.seek(startxref - 1, 0)  # -1 to check character before
         line = stream.read(1)
@@ -1994,10 +1996,10 @@ class PdfReader:
         this library.
 
         Args:
-          password: The password to match.
+            password: The password to match.
 
         Returns:
-          A `PasswordType`.
+            A `PasswordType`.
         """
         if not self._encryption:
             raise PdfReadError("Not encrypted file")

--- a/pypdf/_security.py
+++ b/pypdf/_security.py
@@ -66,20 +66,20 @@ def _alg32(
     See section 3.5.2 of the PDF 1.6 reference.
 
     Args:
-      password: The encryption secret as a bytes-string
-      rev: The encryption revision (see PDF standard)
-      keylen:
-      owner_entry:
-      p_entry: A set of flags specifying which operations shall be permitted
+        password: The encryption secret as a bytes-string
+        rev: The encryption revision (see PDF standard)
+        keylen:
+        owner_entry:
+        p_entry: A set of flags specifying which operations shall be permitted
             when the document is opened with user access. If bit 2 is set to 1, all other
             bits are ignored and all operations are permitted. If bit 2 is set to 0,
             permission for operations are based on the values of the remaining flags
             defined in Table 24.
-      id1_entry:
-      metadata_encrypt:  (Default value = True)
+        id1_entry:
+        metadata_encrypt:  (Default value = True)
 
     Returns:
-      An MD5 hash of keylen characters.
+        An MD5 hash of keylen characters.
     """
     # 1. Pad or truncate the password string to exactly 32 bytes.  If the
     # password string is more than 32 bytes long, use only its first 32 bytes;
@@ -129,13 +129,13 @@ def _alg33(
     section 3.5.2 of the PDF 1.6 reference.
 
     Args:
-      owner_password:
-      user_password:
-      rev: The encryption revision (see PDF standard)
-      keylen:
+        owner_password:
+        user_password:
+        rev: The encryption revision (see PDF standard)
+        keylen:
 
     Returns:
-      A transformed version of the owner and the user password
+        A transformed version of the owner and the user password
     """
     # steps 1 - 4
     key = _alg33_1(owner_password, rev, keylen)
@@ -165,12 +165,12 @@ def _alg33_1(password: str, rev: Literal[2, 3, 4], keylen: int) -> bytes:
     Steps 1-4 of algorithm 3.3
 
     Args:
-      password:
-      rev: The encryption revision (see PDF standard)
-      keylen:
+        password:
+        rev: The encryption revision (see PDF standard)
+        keylen:
 
     Returns:
-      A transformed version of the password
+        A transformed version of the password
     """
     # 1. Pad or truncate the owner password string as described in step 1 of
     # algorithm 3.2.  If there is no owner password, use the user password
@@ -205,14 +205,14 @@ def _alg34(
     See section 3.5.2 of the PDF 1.6 reference.
 
     Args:
-      password:
-      owner_entry:
-      p_entry: A set of flags specifying which operations shall be permitted
+        password:
+        owner_entry:
+        p_entry: A set of flags specifying which operations shall be permitted
             when the document is opened with user access. If bit 2 is set to 1, all other
             bits are ignored and all operations are permitted. If bit 2 is set to 0,
             permission for operations are based on the values of the remaining flags
             defined in Table 24.
-      id1_entry:
+        id1_entry:
 
     Returns:
         A Tuple (u-value, key)
@@ -246,20 +246,20 @@ def _alg35(
     See section 3.5.2 of the PDF 1.6 reference.
 
     Args:
-      password:
-      rev: The encryption revision (see PDF standard)
-      keylen:
-      owner_entry:
-      p_entry: A set of flags specifying which operations shall be permitted
+        password:
+        rev: The encryption revision (see PDF standard)
+        keylen:
+        owner_entry:
+        p_entry: A set of flags specifying which operations shall be permitted
             when the document is opened with user access. If bit 2 is set to 1, all other
             bits are ignored and all operations are permitted. If bit 2 is set to 0,
             permission for operations are based on the values of the remaining flags
             defined in Table 24.
-      id1_entry:
-      metadata_encrypt: A boolean
+        id1_entry:
+        metadata_encrypt: A boolean
 
     Returns:
-      A tuple (value, key)
+        A tuple (value, key)
     """
     # 1. Create an encryption key based on the user password string, as
     # described in Algorithm 3.2.

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -102,11 +102,11 @@ def read_until_whitespace(stream: StreamType, maxchars: Optional[int] = None) ->
     Stops upon encountering whitespace or when maxchars is reached.
 
     Args:
-      stream: The data stream from which was read.
-      maxchars: The maximum number of bytes returned; by default unlimited.
+        stream: The data stream from which was read.
+        maxchars: The maximum number of bytes returned; by default unlimited.
 
     Returns:
-      The data which was read.
+        The data which was read.
     """
     txt = b""
     while True:
@@ -124,10 +124,10 @@ def read_non_whitespace(stream: StreamType) -> bytes:
     Find and read the next non-whitespace character (ignores whitespace).
 
     Args:
-      stream: The data stream from which was read.
+        stream: The data stream from which was read.
 
     Returns:
-      The data which was read.
+        The data which was read.
     """
     tok = stream.read(1)
     while tok in WHITESPACES:
@@ -141,11 +141,10 @@ def skip_over_whitespace(stream: StreamType) -> bool:
     one whitespace character was read.
 
     Args:
-      stream: The data stream from which was read.
+        stream: The data stream from which was read.
 
     Returns:
-      True if more than one whitespace was skipped,
-      otherwise return False.
+        True if more than one whitespace was skipped, otherwise return False.
     """
     tok = WHITESPACES[0]
     cnt = 0
@@ -169,10 +168,10 @@ def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:
     Treats EOF on the underlying stream as the end of the token to be matched.
 
     Args:
-      regex: re.Pattern
+        regex: re.Pattern
 
     Returns:
-      The read bytes.
+        The read bytes.
     """
     name = b""
     while True:
@@ -196,11 +195,11 @@ def read_block_backwards(stream: StreamType, to_read: int) -> bytes:
     read.
 
     Args:
-      stream:
-      to_read:
+        stream:
+        to_read:
 
     Returns:
-      The data which was read.
+        The data which was read.
     """
     if stream.tell() < to_read:
         raise PdfStreamError("Could not read malformed PDF file")
@@ -223,10 +222,10 @@ def read_previous_line(stream: StreamType) -> bytes:
     or, if no such byte is found, at the beginning of the stream.
 
     Args:
-      stream: StreamType:
+        stream: StreamType:
 
     Returns:
-      The data which was read.
+        The data which was read.
     """
     line_content = []
     found_crlf = False
@@ -460,6 +459,12 @@ def rename_kwargs(  # type: ignore
 ):
     """
     Helper function to deprecate arguments.
+
+    Args:
+        func_name: Name of the function to be deprecated
+        kwargs:
+        aliases:
+        fail:
     """
 
     for old_term, new_term in aliases.items():

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -320,12 +320,12 @@ class PdfWriter:
         instance.
 
         Args:
-          page: The page to add to the document. Should be
-            an instance of :class:`PageObject<pypdf._page.PageObject>`
-          excluded_keys:
+            page: The page to add to the document. Should be
+                an instance of :class:`PageObject<pypdf._page.PageObject>`
+            excluded_keys:
 
         Returns:
-          The added PageObject.
+            The added PageObject.
         """
         return self._add_page(page, list.append, excluded_keys)
 
@@ -353,12 +353,12 @@ class PdfWriter:
         :class:`PdfReader<pypdf.PdfReader>` instance.
 
         Args:
-          page: The page to add to the document.
-          index: Position at which the page will be inserted.
-          excluded_keys:
+            page: The page to add to the document.
+            index: Position at which the page will be inserted.
+            excluded_keys:
 
         Returns:
-          The added PageObject.
+            The added PageObject.
         """
         return self._add_page(page, lambda kids, p: kids.insert(index, p))
 
@@ -383,11 +383,11 @@ class PdfWriter:
         Retrieve a page by number from this PDF file.
 
         Args:
-          page_number: The page number to retrieve
-            (pages begin at zero)
+            page_number: The page number to retrieve
+                (pages begin at zero)
 
         Returns:
-          The page at the index given by *page_number*
+            The page at the index given by *page_number*
         """
         if pageNumber is not None:  # deprecated
             if page_number is not None:
@@ -437,17 +437,17 @@ class PdfWriter:
         is specified, use the size of the last page.
 
         Args:
-          width: The width of the new page expressed in default user
-            space units.
-          height: The height of the new page expressed in default
-            user space units.
+            width: The width of the new page expressed in default user
+                space units.
+            height: The height of the new page expressed in default
+                user space units.
 
         Returns:
-          The newly appended page
+            The newly appended page
 
         Raises:
-          PageSizeNotDefinedError: if width and height are not defined
-            and previous page does not exist.
+            PageSizeNotDefinedError: if width and height are not defined
+                and previous page does not exist.
         """
         page = PageObject.create_blank_page(self, width, height)
         self.add_page(page)
@@ -475,18 +475,18 @@ class PdfWriter:
         is specified, use the size of the last page.
 
         Args:
-          width: The width of the new page expressed in default user
-            space units.
-          height: The height of the new page expressed in default
-            user space units.
-          index: Position to add the page.
+            width: The width of the new page expressed in default user
+                space units.
+            height: The height of the new page expressed in default
+                user space units.
+            index: Position to add the page.
 
         Returns:
-          The newly appended page
+            The newly appended page
 
         Raises:
-          PageSizeNotDefinedError: if width and height are not defined
-            and previous page does not exist.
+            PageSizeNotDefinedError: if width and height are not defined
+                and previous page does not exist.
         """
         if width is None or height is None and (self._get_num_pages() - 1) >= index:
             oldpage = self.pages[index]
@@ -563,7 +563,7 @@ class PdfWriter:
         Add Javascript which will launch upon opening this PDF.
 
         Args:
-          javascript: Your Javascript.
+            javascript: Your Javascript.
 
         >>> output.add_js("this.print({bUI:true,bSilent:false,bShrinkToFit:true});")
         # Example: This will launch the print window when the PDF is opened.
@@ -612,8 +612,8 @@ class PdfWriter:
         Section 7.11.3
 
         Args:
-          filename: The filename to display.
-          data: The data in the file.
+            filename: The filename to display.
+            data: The data in the file.
         """
         # We need three entries:
         # * The file's data
@@ -708,14 +708,15 @@ class PdfWriter:
         `append` should be prefered.
 
         Args:
-          reader: a PdfReader object from which to copy page
-            annotations to this writer object.  The writer's annots
-            will then be updated
-          after_page_append:
-            Callback function that is invoked after each page is appended to
-            the writer. Signature includes a reference to the appended page
-            (delegates to append_pages_from_reader). The single parameter of the
-            callback is a reference to the page just appended to the document.
+            reader: a PdfReader object from which to copy page
+                annotations to this writer object.  The writer's annots
+                will then be updated
+            after_page_append:
+                Callback function that is invoked after each page is appended to
+                the writer. Signature includes a reference to the appended page
+                (delegates to append_pages_from_reader). The single parameter of
+                the callback is a reference to the page just appended to the
+                document.
         """
         # Get page count from writer and reader
         reader_num_pages = len(reader.pages)
@@ -755,13 +756,13 @@ class PdfWriter:
         If the field links to a parent object, add the information to the parent.
 
         Args:
-          page: Page reference from PDF writer where the
-            annotations and field data will be updated.
-          fields: a Python dictionary of field names (/T) and text
-            values (/V)
-          flags: An integer (0 to 7). The first bit sets ReadOnly, the
-            second bit sets Required, the third bit sets NoExport. See
-            PDF Reference Table 8.70 for details.
+            page: Page reference from PDF writer where the
+                annotations and field data will be updated.
+            fields: a Python dictionary of field names (/T) and text
+                values (/V)
+            flags: An integer (0 to 7). The first bit sets ReadOnly, the
+                second bit sets Required, the third bit sets NoExport. See
+                PDF Reference Table 8.70 for details.
         """
         self.set_need_appearances_writer()
         # Iterate through pages, update field values
@@ -831,7 +832,7 @@ class PdfWriter:
         For partial insertion, `append` should be considered.
 
         Args:
-          reader: PdfReader from the document root should be copied.
+            reader: PdfReader from the document root should be copied.
         """
         self._root_object = cast(DictionaryObject, reader.trailer[TK.ROOT].clone(self))
         self._root = self._root_object.indirect_reference  # type: ignore[assignment]
@@ -905,13 +906,14 @@ class PdfWriter:
         cloning section '/Root' and '/Info' and '/ID' of the pdf
 
         Args:
-          reader: PDF file reader instance from which the clone
-            should be created.
-          after_page_append:
-            Callback function that is invoked after each page is appended to
-            the writer. Signature includes a reference to the appended page
-            (delegates to append_pages_from_reader). The single parameter of the
-            callback is a reference to the page just appended to the document.
+            reader: PDF file reader instance from which the clone
+                should be created.
+            after_page_append:
+                Callback function that is invoked after each page is appended to
+                the writer. Signature includes a reference to the appended page
+                (delegates to append_pages_from_reader). The single parameter of
+                the callback is a reference to the page just appended to the
+                document.
         """
         self.clone_reader_document_root(reader)
         self._info = reader.trailer[TK.INFO].clone(self).indirect_reference  # type: ignore
@@ -953,21 +955,21 @@ class PdfWriter:
         Encrypt this PDF file with the PDF Standard encryption handler.
 
         Args:
-          user_password: The password which allows for opening
-            and reading the PDF file with the restrictions provided.
-          owner_password: The password which allows for
-            opening the PDF files without any restrictions.  By default,
-            the owner password is the same as the user password.
-          use_128bit: flag as to whether to use 128bit
-            encryption.  When false, 40bit encryption will be used.  By default,
-            this flag is on.
-          permissions_flag: permissions as described in
-            TABLE 3.20 of the PDF 1.7 specification. A bit value of 1 means the
-            permission is grantend. Hence an integer value of -1 will set all
-            flags.
-            Bit position 3 is for printing, 4 is for modifying content, 5 and 6
-            control annotations, 9 for form fields, 10 for extraction of
-            text and graphics.
+            user_password: The password which allows for opening
+                and reading the PDF file with the restrictions provided.
+            owner_password: The password which allows for
+                opening the PDF files without any restrictions.  By default,
+                the owner password is the same as the user password.
+            use_128bit: flag as to whether to use 128bit
+                encryption.  When false, 40bit encryption will be used.
+                By default, this flag is on.
+            permissions_flag: permissions as described in
+                TABLE 3.20 of the PDF 1.7 specification. A bit value of 1 means
+                the permission is grantend.
+                Hence an integer value of -1 will set all flags.
+                Bit position 3 is for printing, 4 is for modifying content,
+                5 and 6 control annotations, 9 for form fields,
+                10 for extraction of text and graphics.
         """
         if user_pwd is not None:
             if user_password is not None:
@@ -1067,10 +1069,10 @@ class PdfWriter:
         Write the collection of pages added to this object out as a PDF file.
 
         Args:
-          stream: An object to write the file to.  The object can support
-            the write method and the tell method, similar to a file object, or
-            be a file path, just like the fileobj, just named it stream to keep
-            existing workflow.
+            stream: An object to write the file to.  The object can support
+                the write method and the tell method, similar to a file object, or
+                be a file path, just like the fileobj, just named it stream to keep
+                existing workflow.
 
         Returns:
             A tuple (bool, IO)
@@ -1145,8 +1147,8 @@ class PdfWriter:
         Add custom metadata to the output.
 
         Args:
-          infos: a Python dictionary where each key is a field
-            and each value is your new metadata.
+            infos: a Python dictionary where each key is a field
+                and each value is your new metadata.
         """
         args = {}
         for key, value in list(infos.items()):
@@ -1252,10 +1254,10 @@ class PdfWriter:
         and new idnum is given and generation is always 0.
 
         Args:
-          data:
+            data:
 
         Returns:
-          The resolved indirect object
+            The resolved indirect object
         """
         if hasattr(data.pdf, "stream") and data.pdf.stream.closed:
             raise ValueError(f"I/O operation on closed file: {data.pdf.stream.name}")
@@ -1530,20 +1532,19 @@ class PdfWriter:
         Add an outline item (commonly referred to as a "Bookmark") to the PDF file.
 
         Args:
-          title: Title to use for this outline item.
-          page_number: Page number this outline item will point to.
-          parent: A reference to a parent outline item to create nested
-            outline items.
-          parent: A reference to a parent outline item to create nested
-            outline items.
-          color: Color of the outline item's font as a red, green, blue tuple
-            from 0.0 to 1.0 or as a Hex String (#RRGGBB)
-          bold: Outline item font is bold
-          italic: Outline item font is italic
-          fit: The fit of the destination page.
+            title: Title to use for this outline item.
+            page_number: Page number this outline item will point to.
+            parent: A reference to a parent outline item to create nested
+                outline items.
+            before:
+            color: Color of the outline item's font as a red, green, blue tuple
+                from 0.0 to 1.0 or as a Hex String (#RRGGBB)
+            bold: Outline item font is bold
+            italic: Outline item font is italic
+            fit: The fit of the destination page.
 
         Returns:
-          The added outline item as an indirect object.
+            The added outline item as an indirect object.
         """
         page_ref: Union[None, NullObject, IndirectObject, NumberObject]
         if isinstance(italic, Fit):  # it means that we are on the old params
@@ -1792,8 +1793,8 @@ class PdfWriter:
         Remove images from this output.
 
         Args:
-          ignore_byte_string_object: optional parameter
-            to ignore ByteString Objects.
+            ignore_byte_string_object: optional parameter
+                to ignore ByteString Objects.
         """
         pg_dict = cast(DictionaryObject, self.get_object(self._pages))
         pages = cast(ArrayObject, pg_dict[PA.KIDS])
@@ -1879,7 +1880,7 @@ class PdfWriter:
         Remove text from this output.
 
         Args:
-          ignore_byte_string_object: optional parameter
+            ignore_byte_string_object: optional parameter
         """
         pg_dict = cast(DictionaryObject, self.get_object(self._pages))
         pages = cast(List[IndirectObject], pg_dict[PA.KIDS])
@@ -1940,14 +1941,15 @@ class PdfWriter:
         This uses the basic structure of :meth:`add_link`
 
         Args:
-          page_number: index of the page on which to place the URI action.
-          uri: URI of resource to link to.
-          rect: :class:`RectangleObject<pypdf.generic.RectangleObject>` or
-            array of four integers specifying the clickable rectangular area
-            ``[xLL, yLL, xUR, yUR]``, or string in the form ``"[ xLL yLL xUR yUR ]"``.
-          border: if provided, an array describing border-drawing
-            properties. See the PDF spec for details. No border will be
-            drawn if this argument is omitted.
+            page_number: index of the page on which to place the URI action.
+            uri: URI of resource to link to.
+            rect: :class:`RectangleObject<pypdf.generic.RectangleObject>` or
+                array of four integers specifying the clickable rectangular area
+                ``[xLL, yLL, xUR, yUR]``, or string in the form
+                ``"[ xLL yLL xUR yUR ]"``.
+            border: if provided, an array describing border-drawing
+                properties. See the PDF spec for details. No border will be
+                drawn if this argument is omitted.
         """
         if pagenum is not None:
             warnings.warn(
@@ -2098,7 +2100,7 @@ class PdfWriter:
         Set the page layout.
 
         Args:
-          str: layout: The page layout to be used.
+            layout: The page layout to be used.
 
         .. list-table:: Valid ``layout`` arguments
            :widths: 50 200
@@ -2132,7 +2134,7 @@ class PdfWriter:
         Set the page layout.
 
         Args:
-          layout: The page layout to be used
+            layout: The page layout to be used
 
         .. list-table:: Valid ``layout`` arguments
            :widths: 50 200
@@ -2344,10 +2346,10 @@ class PdfWriter:
         (required for names/dests list)
 
         Args:
-          page:
+            page:
 
         Returns:
-          The cleaned PageObject
+            The cleaned PageObject
         """
         page = cast("PageObject", page.get_object())
         for a in page.get("/Annots", []):
@@ -2417,23 +2419,23 @@ class PdfWriter:
         position.
 
         Args:
-          fileobj: A File Object or an object that supports the standard
-            read and seek methods similar to a File Object. Could also be a
-            string representing a path to a PDF file.
-          outline_item: Optionally, you may specify a string to build an outline
-            (aka 'bookmark') to identify the
-            beginning of the included file.
-          pages: Can be a :class:`PageRange<pypdf.pagerange.PageRange>`
-            or a ``(start, stop[, step])`` tuple
-            or a list of pages to be processed
-            to merge only the specified range of pages from the source
-            document into the output document.
-          import_outline: You may prevent the source document's
-            outline (collection of outline items, previously referred to as
-            'bookmarks') from being imported by specifying this as ``False``.
-          excluded_fields: Provide the list of fields/keys to be ignored
-            if ``/Annots`` is part of the list, the annotation will be ignored
-            if ``/B`` is part of the list, the articles will be ignored
+            fileobj: A File Object or an object that supports the standard
+                read and seek methods similar to a File Object. Could also be a
+                string representing a path to a PDF file.
+            outline_item: Optionally, you may specify a string to build an
+                outline (aka 'bookmark') to identify the beginning of the
+                included file.
+            pages: Can be a :class:`PageRange<pypdf.pagerange.PageRange>`
+                or a ``(start, stop[, step])`` tuple
+                or a list of pages to be processed
+                to merge only the specified range of pages from the source
+                document into the output document.
+            import_outline: You may prevent the source document's
+                outline (collection of outline items, previously referred to as
+                'bookmarks') from being imported by specifying this as ``False``.
+            excluded_fields: Provide the list of fields/keys to be ignored
+                if ``/Annots`` is part of the list, the annotation will be ignored
+                if ``/B`` is part of the list, the articles will be ignored
         """
         if excluded_fields is None:
             excluded_fields = ()
@@ -2464,25 +2466,28 @@ class PdfWriter:
         specified page number.
 
         Args:
-          position: The *page number* to insert this file. File will
-            be inserted after the given number.
-          fileobj: A File Object or an object that supports the standard
-            read and seek methods similar to a File Object. Could also be a
-            string representing a path to a PDF file.
-          outline_item: Optionally, you may specify a string to build an outline
-            (aka 'bookmark') to identify the
-            beginning of the included file.
-          pages: can be a :class:`PageRange<pypdf.pagerange.PageRange>`
-            or a ``(start, stop[, step])`` tuple
-            or a list of pages to be processed
-            to merge only the specified range of pages from the source
-            document into the output document.
-          import_outline: You may prevent the source document's
-            outline (collection of outline items, previously referred to as
-            'bookmarks') from being imported by specifying this as ``False``.
-          excluded_fields: provide the list of fields/keys to be ignored
-            if ``/Annots`` is part of the list, the annotation will be ignored
-            if ``/B`` is part of the list, the articles will be ignored
+            position: The *page number* to insert this file. File will
+                be inserted after the given number.
+            fileobj: A File Object or an object that supports the standard
+                read and seek methods similar to a File Object. Could also be a
+                string representing a path to a PDF file.
+            outline_item: Optionally, you may specify a string to build an outline
+                (aka 'bookmark') to identify the
+                beginning of the included file.
+            pages: can be a :class:`PageRange<pypdf.pagerange.PageRange>`
+                or a ``(start, stop[, step])`` tuple
+                or a list of pages to be processed
+                to merge only the specified range of pages from the source
+                document into the output document.
+            import_outline: You may prevent the source document's
+                outline (collection of outline items, previously referred to as
+                'bookmarks') from being imported by specifying this as ``False``.
+            excluded_fields: provide the list of fields/keys to be ignored
+                if ``/Annots`` is part of the list, the annotation will be ignored
+                if ``/B`` is part of the list, the articles will be ignored
+
+        Raises:
+            TypeError: The pages attribute is not configured properly
         """
         if isinstance(fileobj, PdfReader):
             reader = fileobj
@@ -2585,12 +2590,12 @@ class PdfWriter:
         Clone the thread with only the applicable articles
 
         Args:
-          thread:
-          pages:
-          reader:
+            thread:
+            pages:
+            reader:
 
         Returns:
-          The added thread as an indirect reference
+            The added thread as an indirect reference
         """
         nthread = thread.clone(
             self, force_duplicate=True, ignore_fields=("/F",)
@@ -2649,9 +2654,9 @@ class PdfWriter:
         Add articles matching the defined criteria
 
         Args:
-          fltr:
-          pages:
-          reader:
+            fltr:
+            pages:
+            reader:
         """
         if isinstance(fltr, str):
             fltr = re.compile(fltr)
@@ -2748,12 +2753,12 @@ class PdfWriter:
         Extract outline item entries that are part of the specified page set.
 
         Args:
-          node:
-          pages:
-          reader:
+            node:
+            pages:
+            reader:
 
         Returns:
-          A list of destination objects.
+            A list of destination objects.
         """
         new_outline = []
         node = node.get_object()
@@ -2874,8 +2879,8 @@ class PdfWriter:
         late cloning will create new independent objects
 
         Args:
-          reader: PdfReader or IndirectObject refering a PdfReader object.
-            if set to None or omitted, all tables will be reset.
+            reader: PdfReader or IndirectObject refering a PdfReader object.
+                if set to None or omitted, all tables will be reset.
         """
         if reader is None:
             self._id_translated = {}

--- a/pypdf/generic/_annotations.py
+++ b/pypdf/generic/_annotations.py
@@ -37,14 +37,14 @@ class AnnotationBuilder:
         Add text annotation.
 
         Args:
-          rect: array of four integers ``[xLL, yLL, xUR, yUR]``
-            specifying the clickable rectangular area
-          text: The text that is added to the document
-          open:
-          flags:
+            rect: array of four integers ``[xLL, yLL, xUR, yUR]``
+                specifying the clickable rectangular area
+            text: The text that is added to the document
+            open:
+            flags:
 
         Returns:
-          A dictionary object representing the annotation.
+            A dictionary object representing the annotation.
         """
         # TABLE 8.23 Additional entries specific to a text annotation
         text_obj = DictionaryObject(
@@ -75,19 +75,20 @@ class AnnotationBuilder:
         Add text in a rectangle to a page.
 
         Args:
-          text: Text to be added
-          rect: array of four integers ``[xLL, yLL, xUR, yUR]``
-            specifying the clickable rectangular area
-          font: Name of the Font, e.g. 'Helvetica'
-          bold: Print the text in bold
-          italic: Print the text in italic
-          font_size: How big the text will be, e.g. '14pt'
-          font_color: Hex-string for the color, e.g. cdcdcd
-          border_color: Hex-string for the border color, e.g. cdcdcd
-          background_color: Hex-string for the background of the annotation, e.g. cdcdcd
+            text: Text to be added
+            rect: array of four integers ``[xLL, yLL, xUR, yUR]``
+                specifying the clickable rectangular area
+            font: Name of the Font, e.g. 'Helvetica'
+            bold: Print the text in bold
+            italic: Print the text in italic
+            font_size: How big the text will be, e.g. '14pt'
+            font_color: Hex-string for the color, e.g. cdcdcd
+            border_color: Hex-string for the border color, e.g. cdcdcd
+            background_color: Hex-string for the background of the annotation,
+                e.g. cdcdcd
 
         Returns:
-          A dictionary object representing the annotation.
+            A dictionary object representing the annotation.
         """
         font_str = "font: "
         if bold is True:
@@ -133,16 +134,16 @@ class AnnotationBuilder:
         Draw a line on the PDF.
 
         Args:
-          p1: First point
-          p2: Second point
-          rect: array of four integers ``[xLL, yLL, xUR, yUR]``
-            specifying the clickable rectangular area
-          text: Text to be displayed as the line annotation
-          title_bar: Text to be displayed in the title bar of the
-            annotation; by convention this is the name of the author
+            p1: First point
+            p2: Second point
+            rect: array of four integers ``[xLL, yLL, xUR, yUR]``
+                specifying the clickable rectangular area
+            text: Text to be displayed as the line annotation
+            title_bar: Text to be displayed in the title bar of the
+                annotation; by convention this is the name of the author
 
         Returns:
-          A dictionary object representing the annotation.
+            A dictionary object representing the annotation.
         """
         line_obj = DictionaryObject(
             {
@@ -187,13 +188,13 @@ class AnnotationBuilder:
         This method uses the /Square annotation type of the PDF format.
 
         Args:
-          rect: array of four integers ``[xLL, yLL, xUR, yUR]``
-            specifying the clickable rectangular area
-          interiour_color: None or hex-string for the color, e.g. cdcdcd
-            If None is used, the interiour is transparent.
+            rect: array of four integers ``[xLL, yLL, xUR, yUR]``
+                specifying the clickable rectangular area
+            interiour_color: None or hex-string for the color, e.g. cdcdcd
+                If None is used, the interiour is transparent.
 
         Returns:
-          A dictionary object representing the annotation.
+            A dictionary object representing the annotation.
         """
         square_obj = DictionaryObject(
             {
@@ -221,13 +222,13 @@ class AnnotationBuilder:
         This method uses the /Circle annotation type of the PDF format.
 
         Args:
-          rect: array of four integers ``[xLL, yLL, xUR, yUR]`` specifying
-            the bounding box of the ellipse
-          interiour_color: None or hex-string for the color, e.g. cdcdcd
-            If None is used, the interiour is transparent.
+            rect: array of four integers ``[xLL, yLL, xUR, yUR]`` specifying
+                the bounding box of the ellipse
+            interiour_color: None or hex-string for the color, e.g. cdcdcd
+                If None is used, the interiour is transparent.
 
         Returns:
-          A dictionary object representing the annotation.
+            A dictionary object representing the annotation.
         """
         ellipse_obj = DictionaryObject(
             {
@@ -288,22 +289,22 @@ class AnnotationBuilder:
         An internal link requires the target_page_index, fit, and fit args.
 
         Args:
-          rect: array of four integers ``[xLL, yLL, xUR, yUR]``
-            specifying the clickable rectangular area
-          border: if provided, an array describing border-drawing
-            properties. See the PDF spec for details. No border will be
-            drawn if this argument is omitted.
-            - horizontal corner radius,
-            - vertical corner radius, and
-            - border width
-            - Optionally: Dash
-          url: Link to a website (if you want to make an external link)
-          target_page_index: index of the page to which the link should go
-            (if you want to make an internal link)
-          fit: Page fit or 'zoom' option.
+            rect: array of four integers ``[xLL, yLL, xUR, yUR]``
+                specifying the clickable rectangular area
+            border: if provided, an array describing border-drawing
+                properties. See the PDF spec for details. No border will be
+                drawn if this argument is omitted.
+                - horizontal corner radius,
+                - vertical corner radius, and
+                - border width
+                - Optionally: Dash
+            url: Link to a website (if you want to make an external link)
+            target_page_index: index of the page to which the link should go
+                (if you want to make an internal link)
+            fit: Page fit or 'zoom' option.
 
         Returns:
-          A dictionary object representing the annotation.
+            A dictionary object representing the annotation.
         """
         from ..types import BorderArrayType
 

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -192,10 +192,10 @@ class DictionaryObject(dict, PdfObject):
         Update the object from src
 
         Args:
-          src: "DictionaryObject":
-          pdf_dest:
-          force_duplicate:
-          ignore_fields:
+            src: "DictionaryObject":
+            pdf_dest:
+            force_duplicate:
+            ignore_fields:
         """
         #  First check if this is a chain list, we need to loop to prevent recur
         if (
@@ -583,10 +583,10 @@ class TreeObject(DictionaryObject):
         Adjust the pointers of the linked list and tree node count.
 
         Args:
-          prev:
-          prev_ref:
-          cur:
-          last:
+            prev:
+            prev_ref:
+            cur:
+            last:
         """
         next_ref = cur.get(NameObject("/Next"), None)
         if prev is None:
@@ -689,7 +689,7 @@ def _reset_node_tree_relationship(child_obj: Any) -> None:
     This resets the nodes attributes in respect to that tree.
 
     Args:
-      child_obj:
+        child_obj:
     """
     del child_obj[NameObject("/Parent")]
     if NameObject("/Next") in child_obj:
@@ -714,10 +714,10 @@ class StreamObject(DictionaryObject):
         Update the object from src.
 
         Args:
-          src:
-          pdf_dest:
-          force_duplicate:
-          ignore_fields:
+            src:
+            pdf_dest:
+            force_duplicate:
+            ignore_fields:
         """
         self._data = cast("StreamObject", src)._data
         try:
@@ -916,12 +916,12 @@ class ContentStream(DecodedStreamObject):
         Clone object into pdf_dest.
 
         Args:
-          pdf_dest:
-          force_duplicate:
-          ignore_fields:
+            pdf_dest:
+            force_duplicate:
+            ignore_fields:
 
         Returns:
-          The cloned ContentStream
+            The cloned ContentStream
         """
         try:
             if self.indirect_reference.pdf == pdf_dest and not force_duplicate:  # type: ignore
@@ -948,10 +948,10 @@ class ContentStream(DecodedStreamObject):
         Update the object from src.
 
         Args:
-          src:
-          pdf_dest:
-          force_duplicate:
-          ignore_fields:
+            src:
+            pdf_dest:
+            force_duplicate:
+            ignore_fields:
         """
         self.pdf = pdf_dest
         self.operations = list(cast("ContentStream", src).operations)
@@ -1291,13 +1291,13 @@ class Destination(TreeObject):
     See section 8.2.1 of the PDF 1.6 reference.
 
     Args:
-      title: Title of this destination.
-      page: Reference to the page of this destination. Should
-        be an instance of :class:`IndirectObject<pypdf.generic.IndirectObject>`.
-      fit: How the destination is displayed.
+        title: Title of this destination.
+        page: Reference to the page of this destination. Should
+            be an instance of :class:`IndirectObject<pypdf.generic.IndirectObject>`.
+        fit: How the destination is displayed.
 
     Raises:
-      PdfReadError: If destination type is invalid.
+        PdfReadError: If destination type is invalid.
 
     """
 

--- a/pypdf/generic/_fit.py
+++ b/pypdf/generic/_fit.py
@@ -31,12 +31,12 @@ class Fit:
         A zoom value of 0 has the same meaning as a null value.
 
         Args:
-          left:
-          top:
-          zoom:
+            left:
+            top:
+            zoom:
 
         Returns:
-          The created fit object.
+            The created fit object.
         """
         return Fit(fit_type="/XYZ", fit_args=(left, top, zoom))
 
@@ -63,10 +63,10 @@ class Fit:
         parameter is to be retained unchanged.
 
         Args:
-          top:
+            top:
 
         Returns:
-          The created fit object.
+            The created fit object.
         """
         return Fit(fit_type="/FitH", fit_args=(top,))
 
@@ -96,13 +96,13 @@ class Fit:
         behavior.
 
         Args:
-          left:
-          bottom:
-          right:
-          top:
+            left:
+            bottom:
+            right:
+            top:
 
         Returns:
-          The created fit object.
+            The created fit object.
         """
         return Fit(fit_type="/FitR", fit_args=(left, bottom, right, top))
 
@@ -129,10 +129,10 @@ class Fit:
         is to be retained unchanged.
 
         Args:
-          top:
+            top:
 
         Returns:
-          The created fit object.
+            The created fit object.
         """
         return Fit(fit_type="/FitBH", fit_args=(top,))
 
@@ -148,10 +148,10 @@ class Fit:
         parameter is to be retained unchanged.
 
         Args:
-          left:
+            left:
 
         Returns:
-          The created fit object.
+            The created fit object.
         """
         return Fit(fit_type="/FitBV", fit_args=(left,))
 

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -118,14 +118,14 @@ def create_string_object(
     Create a ByteStringObject or a TextStringObject from a string to represent the string.
 
     Args:
-      string: The data being used
-      forced_encoding: Typically None, or an encoding string
+        string: The data being used
+        forced_encoding: Typically None, or an encoding string
 
     Returns:
-      A ByteStringObject
+        A ByteStringObject
 
     Raises:
-      TypeError: If string is not of type str or bytes.
+        TypeError: If string is not of type str or bytes.
 
     """
     if isinstance(string, str):

--- a/pypdf/pagerange.py
+++ b/pypdf/pagerange.py
@@ -82,10 +82,10 @@ class PageRange:
         True if input is a valid initializer for a PageRange.
 
         Args:
-          input: A possible PageRange string or a PageRange object.
+            input: A possible PageRange string or a PageRange object.
 
         Returns:
-          True, if the ``input`` is a valid PageRange.
+            True, if the ``input`` is a valid PageRange.
         """
         return isinstance(input, (slice, PageRange)) or (
             isinstance(input, str) and bool(re.match(PAGE_RANGE_RE, input))
@@ -120,10 +120,10 @@ class PageRange:
         See help(slice.indices).
 
         Args:
-          n:  the length of the list of pages to choose from.
+            n:  the length of the list of pages to choose from.
 
         Returns:
-          Arguments for range()
+            Arguments for range()
         """
         return self._slice.indices(n)
 
@@ -160,12 +160,12 @@ def parse_filename_page_ranges(
     Given a list of filenames and page ranges, return a list of (filename, page_range) pairs.
 
     Args:
-      args: A list where the first element is a filename. The other elements are
-        filenames, page-range expressions, slice objects, or PageRange objects.
-        A filename not followed by a page range indicates all pages of the file.
+        args: A list where the first element is a filename. The other elements are
+            filenames, page-range expressions, slice objects, or PageRange objects.
+            A filename not followed by a page range indicates all pages of the file.
 
     Returns:
-      A list of (filename, page_range) pairs.
+        A list of (filename, page_range) pairs.
     """
     pairs: List[Tuple[str, PageRange]] = []
     pdf_filename = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,7 @@ tests_dir = tests/
 
 [tool:check-wheel-contents]
 package = ./pypdf
+
+[darglint]
+enable=DAR201
+ignore=DAR002


### PR DESCRIPTION
Found a couple of issues with darglint: https://pypi.org/project/darglint/

However, there are many false-positives:

1. Properties: I don't want `Returns` for any property
2. Deprecations: Deprecated arguments should not be documented; the docstrings of deprecated code should not be changed.