### PR TITLE
STY: Apply docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,11 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: end-of-file-fixer
-        exclude: "resources/.*"
+        exclude: "resources/.*|docs/make.bat"
     -   id: trailing-whitespace
     -   id: mixed-line-ending
         args: ['--fix=lf']
+        exclude: "docs/make.bat"
     -   id: check-added-large-files
         args: ['--maxkb=1000']
 -   repo: https://github.com/pycqa/flake8
@@ -26,7 +27,7 @@ repos:
 #     hooks:
 #     -   id: mypy
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         name: isort (python)
@@ -37,10 +38,11 @@ repos:
     -   id: black
         args: [--target-version, py36]
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.13.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==22.1.0]
+        exclude: "docs/user/robustness.md"
 -   repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,8 @@
 """
 Configuration file for the Sphinx documentation builder.
 
-This file only contains a selection of the most common options. For a full
-list see the documentation:
+This file only contains a selection of the most common options.
+For a full list see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 # -- Path setup --------------------------------------------------------------

--- a/docs/user/adding-pdf-annotations.md
+++ b/docs/user/adding-pdf-annotations.md
@@ -136,6 +136,7 @@ writer.add_page(page)
 # Add the rectangle
 annotation = AnnotationBuilder.ellipse(
     rect=(50, 550, 200, 650),
+)
 writer.add_annotation(page_number=0, annotation=annotation)
 
 # Write the annotated file to disk

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -750,7 +750,7 @@ class AlgV5:
     def compute_U_value(password: bytes, key: bytes) -> Tuple[bytes, bytes]:
         """
         Algorithm 3.8 Computing the encryption dictionary’s U (user password)
-        and UE (user encryption key) values
+        and UE (user encryption key) values.
 
         1. Generate 16 random bytes of data using a strong random number generator.
            The first 8 bytes are the User Validation Salt. The second 8 bytes
@@ -829,7 +829,8 @@ class AlgV5:
     @staticmethod
     def compute_Perms_value(key: bytes, p: int, metadata_encrypted: bool) -> bytes:
         """
-        Algorithm 3.10 Computing the encryption dictionary’s Perms (permissions) value
+        Algorithm 3.10 Computing the encryption dictionary’s Perms
+        (permissions) value.
 
         1. Extend the permissions (contents of the P integer) to 64 bits by
            setting the upper 32 bits to all 1’s.

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -374,18 +374,18 @@ class PdfMerger:
 
     def addMetadata(self, infos: Dict[str, Any]) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_metadata` instead.
 
-            Use :meth:`add_metadata` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addMetadata", "add_metadata")
         self.add_metadata(infos)
 
     def setPageLayout(self, layout: LayoutType) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`set_page_layout` instead.
 
-            Use :meth:`set_page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("setPageLayout", "set_page_layout")
         self.set_page_layout(layout)
@@ -421,9 +421,9 @@ class PdfMerger:
 
     def setPageMode(self, mode: PagemodeType) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`set_page_mode` instead.
 
-            Use :meth:`set_page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("setPageMode", "set_page_mode", "3.0.0")
         self.set_page_mode(mode)

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -221,7 +221,8 @@ class Transformation:
     def matrix(self) -> TransformationMatrixType:
         """
         Return the transformation matrix as a tuple of tuples in the form:
-            ((a, b, 0), (c, d, 0), (e, f, 1))
+
+        ((a, b, 0), (c, d, 0), (e, f, 1))
         """
         return (
             (self.ctm[0], self.ctm[1], 0),
@@ -397,9 +398,9 @@ class PageObject(DictionaryObject):
         """
         A read-only positive number giving the size of user space units.
 
-        It is in multiples of 1/72 inch. Hence a value of 1 means a user space
-        unit is 1/72 inch, and a value of 3 means that a user space unit is
-        3/72 inch.
+        It is in multiples of 1/72 inch. Hence a value of 1 means a user
+        space unit is 1/72 inch, and a value of 3 means that a user
+        space unit is 3/72 inch.
         """
         return self.get(PG.USER_UNIT, 1)
 
@@ -455,9 +456,9 @@ class PageObject(DictionaryObject):
         height: Union[float, Decimal, None] = None,
     ) -> "PageObject":  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`create_blank_page` instead.
 
-            Use :meth:`create_blank_page` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("createBlankPage", "create_blank_page", "3.0.0")
         return PageObject.create_blank_page(pdf, width, height)
@@ -491,8 +492,7 @@ class PageObject(DictionaryObject):
         The VISUAL rotation of the page.
 
         This number has to be a multiple of 90 degrees: 0, 90, 180, or 270 are
-        valid values.
-        This property does not affect ``/Contents``.
+        valid values. This property does not affect ``/Contents``.
         """
         return int(self.get(PG.ROTATE, 0))
 
@@ -502,7 +502,8 @@ class PageObject(DictionaryObject):
 
     def transfer_rotation_to_content(self) -> None:
         """
-        Apply the rotation of the page to the content and the media/crop/... boxes.
+        Apply the rotation of the page to the content and the media/crop/...
+        boxes.
 
         It's recommended to apply this function before page merging.
         """
@@ -559,18 +560,18 @@ class PageObject(DictionaryObject):
 
     def rotateClockwise(self, angle: int) -> "PageObject":  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`rotate_clockwise` instead.
 
-            Use :meth:`rotate_clockwise` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("rotateClockwise", "rotate", "3.0.0")
         return self.rotate(angle)
 
     def rotateCounterClockwise(self, angle: int) -> "PageObject":  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`rotate_clockwise` with a negative argument instead.
 
-            Use :meth:`rotate_clockwise` with a negative argument instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("rotateCounterClockwise", "rotate", "3.0.0")
         return self.rotate(-angle)
@@ -584,8 +585,8 @@ class PageObject(DictionaryObject):
 
         def compute_unique_key(base_key: str) -> Tuple[str, bool]:
             """
-            Find a key that either doesn't already exist or has the same
-            value (indicated by the bool)
+            Find a key that either doesn't already exist or has the same value
+            (indicated by the bool)
 
             Args:
                 base_key: An index is added to this to get the computed key
@@ -699,9 +700,9 @@ class PageObject(DictionaryObject):
 
     def getContents(self) -> Optional[ContentStream]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_contents` instead.
 
-            Use :meth:`get_contents` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getContents", "get_contents", "3.0.0")
         return self.get_contents()
@@ -726,9 +727,9 @@ class PageObject(DictionaryObject):
 
     def mergePage(self, page2: "PageObject") -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`merge_page` instead.
 
-            Use :meth:`merge_page` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("mergePage", "merge_page", "3.0.0")
         return self.merge_page(page2)
@@ -1005,7 +1006,8 @@ class PageObject(DictionaryObject):
     ) -> None:  # deprecated
         """
         mergeRotatedTranslatedPage is similar to merge_page, but the stream to
-        be merged is rotated and translated by applying a transformation matrix.
+        be merged is rotated and translated by applying a transformation
+        matrix.
 
         :param PageObject page2: the page to be merged into this one. Should be
             an instance of :class:`PageObject<PageObject>`.
@@ -1064,8 +1066,8 @@ class PageObject(DictionaryObject):
         expand: bool = False,
     ) -> None:  # deprecated
         """
-        mergeScaledTranslatedPage is similar to merge_page, but the stream to be
-        merged is translated and scaled by applying a transformation matrix.
+        mergeScaledTranslatedPage is similar to merge_page, but the stream to
+        be merged is translated and scaled by applying a transformation matrix.
 
         :param PageObject page2: the page to be merged into this one. Should be
             an instance of :class:`PageObject<PageObject>`.
@@ -1185,17 +1187,17 @@ class PageObject(DictionaryObject):
         self, ctm: CompressedTransformationMatrix
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_transformation` instead.
 
-            Use :meth:`add_transformation` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addTransformation", "add_transformation", "3.0.0")
         self.add_transformation(ctm)
 
     def scale(self, sx: float, sy: float) -> None:
         """
-        Scale a page by the given factors by applying a transformation
-        matrix to its content and updating the page size.
+        Scale a page by the given factors by applying a transformation matrix
+        to its content and updating the page size.
 
         This updates the mediabox, the cropbox, and the contents
         of the page.
@@ -1247,8 +1249,8 @@ class PageObject(DictionaryObject):
 
     def scale_by(self, factor: float) -> None:
         """
-        Scale a page by the given factor by applying a transformation
-        matrix to its content and updating the page size.
+        Scale a page by the given factor by applying a transformation matrix to
+        its content and updating the page size.
 
         Args:
             factor: The scaling factor (for both X and Y axis).
@@ -1257,17 +1259,17 @@ class PageObject(DictionaryObject):
 
     def scaleBy(self, factor: float) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`scale_by` instead.
 
-            Use :meth:`scale_by` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("scaleBy", "scale_by", "3.0.0")
         self.scale(factor, factor)
 
     def scale_to(self, width: float, height: float) -> None:
         """
-        Scale a page to the specified dimensions by applying a
-        transformation matrix to its content and updating the page size.
+        Scale a page to the specified dimensions by applying a transformation
+        matrix to its content and updating the page size.
 
         Args:
             width: The new width.
@@ -1279,9 +1281,9 @@ class PageObject(DictionaryObject):
 
     def scaleTo(self, width: float, height: float) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`scale_to` instead.
 
-            Use :meth:`scale_to` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("scaleTo", "scale_to", "3.0.0")
         self.scale_to(width, height)
@@ -1302,9 +1304,9 @@ class PageObject(DictionaryObject):
 
     def compressContentStreams(self) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`compress_content_streams` instead.
 
-            Use :meth:`compress_content_streams` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "compressContentStreams", "compress_content_streams", "3.0.0"
@@ -1958,9 +1960,9 @@ class PageObject(DictionaryObject):
 
     def extractText(self, Tj_sep: str = "", TJ_sep: str = "") -> str:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`extract_text` instead.
 
-            Use :meth:`extract_text` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("extractText", "extract_text", "3.0.0")
         return self.extract_text()
@@ -1979,18 +1981,16 @@ class PageObject(DictionaryObject):
         return embedded, unembedded
 
     mediabox = _create_rectangle_accessor(PG.MEDIABOX, ())
-    """
-    A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
+    """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the boundaries of the physical medium on
-    which the page is intended to be displayed or printed.
-    """
+    which the page is intended to be displayed or printed."""
 
     @property
     def mediaBox(self) -> RectangleObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`mediabox` instead.
 
-            Use :py:attr:`mediabox` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("mediaBox", "mediabox", "3.0.0")
         return self.mediabox
@@ -1998,9 +1998,9 @@ class PageObject(DictionaryObject):
     @mediaBox.setter
     def mediaBox(self, value: RectangleObject) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`mediabox` instead.
 
-            Use :py:attr:`mediabox` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("mediaBox", "mediabox", "3.0.0")
         self.mediabox = value
@@ -2008,18 +2008,21 @@ class PageObject(DictionaryObject):
     cropbox = _create_rectangle_accessor("/CropBox", (PG.MEDIABOX,))
     """
     A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
-    default user space units, defining the visible region of default user space.
+    default user space units, defining the visible region of default user
+    space.
+
     When the page is displayed or printed, its contents are to be clipped
     (cropped) to this rectangle and then imposed on the output medium in some
-    implementation-defined manner.  Default value: same as :attr:`mediabox<mediabox>`.
+    implementation-defined manner.  Default value: same as
+    :attr:`mediabox<mediabox>`.
     """
 
     @property
     def cropBox(self) -> RectangleObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`cropbox` instead.
 
-            Use :py:attr:`cropbox` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("cropBox", "cropbox", "3.0.0")
         return self.cropbox
@@ -2030,18 +2033,16 @@ class PageObject(DictionaryObject):
         self.cropbox = value
 
     bleedbox = _create_rectangle_accessor("/BleedBox", ("/CropBox", PG.MEDIABOX))
-    """
-    A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
+    """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the region to which the contents of the
-    page should be clipped when output in a production environment.
-    """
+    page should be clipped when output in a production environment."""
 
     @property
     def bleedBox(self) -> RectangleObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`bleedbox` instead.
 
-            Use :py:attr:`bleedbox` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("bleedBox", "bleedbox", "3.0.0")
         return self.bleedbox
@@ -2052,18 +2053,16 @@ class PageObject(DictionaryObject):
         self.bleedbox = value
 
     trimbox = _create_rectangle_accessor("/TrimBox", ("/CropBox", PG.MEDIABOX))
-    """
-    A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
+    """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the intended dimensions of the finished
-    page after trimming.
-    """
+    page after trimming."""
 
     @property
     def trimBox(self) -> RectangleObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`trimbox` instead.
 
-            Use :py:attr:`trimbox` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("trimBox", "trimbox", "3.0.0")
         return self.trimbox
@@ -2074,18 +2073,16 @@ class PageObject(DictionaryObject):
         self.trimbox = value
 
     artbox = _create_rectangle_accessor("/ArtBox", ("/CropBox", PG.MEDIABOX))
-    """
-    A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
+    """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the extent of the page's meaningful
-    content as intended by the page's creator.
-    """
+    content as intended by the page's creator."""
 
     @property
     def artBox(self) -> RectangleObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`artbox` instead.
 
-            Use :py:attr:`artbox` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("artBox", "artbox", "3.0.0")
         return self.artbox

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -57,20 +57,11 @@ a       Lowercase letters (a to z for the first 26 pages,
                            aa to zz for the next 26, and so on)
 """
 
-from typing import (
-    Iterator,
-    Optional,
-    Tuple,
-)
+from typing import Iterator, Optional, Tuple
 
 from ._protocols import PdfReaderProtocol
 from ._utils import logger_warning
-
-from .generic import (
-    ArrayObject,
-    DictionaryObject,
-    NumberObject,
-)
+from .generic import ArrayObject, DictionaryObject, NumberObject
 
 
 def number2uppercase_roman_numeral(num: int) -> str:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -141,11 +141,9 @@ class DocumentInformation(DictionaryObject):
 
     def getText(self, key: str) -> Optional[str]:  # deprecated
         """
-        The text value of the specified key or None.
+        Use the attributes (e.g. :py:attr:`title` / :py:attr:`author`).
 
         .. deprecated:: 1.28.0
-
-            Use the attributes (e.g. :py:attr:`title` / :py:attr:`author`).
         """
         deprecation_no_replacement("getText", "3.0.0")
         return self._get_text(key)
@@ -204,11 +202,10 @@ class DocumentInformation(DictionaryObject):
         """
         Read-only property accessing the document's creator.
 
-        If the document was converted to PDF from another format, this
-        is the name of the application (e.g. OpenOffice) that created
-        the original document from which it was converted. Returns a
-        ``TextStringObject`` or ``None`` if the creator is not
-        specified.
+        If the document was converted to PDF from another format, this is the
+        name of the application (e.g. OpenOffice) that created the original
+        document from which it was converted. Returns a ``TextStringObject`` or
+        ``None`` if the creator is not specified.
         """
         return self._get_text(DI.CREATOR)
 
@@ -222,10 +219,10 @@ class DocumentInformation(DictionaryObject):
         """
         Read-only property accessing the document's producer.
 
-        If the document was converted to PDF from another format, this
-        is the name of the application (for example, OSX Quartz) that
-        converted it to PDF. Returns a ``TextStringObject`` or ``None``
-        if the producer is not specified.
+        If the document was converted to PDF from another format, this is the
+        name of the application (for example, OSX Quartz) that converted it to
+        PDF. Returns a ``TextStringObject`` or ``None`` if the producer is not
+        specified.
         """
         return self._get_text(DI.PRODUCER)
 
@@ -247,8 +244,8 @@ class DocumentInformation(DictionaryObject):
         """
         The "raw" version of creation date; can return a ``ByteStringObject``.
 
-        Typically in the format ``D:YYYYMMDDhhmmss[+-]hh'mm`` where the
-        suffix is the offset from UTC.
+        Typically in the format ``D:YYYYMMDDhhmmss[+-]hh'mm`` where the suffix
+        is the offset from UTC.
         """
         return self.get(DI.CREATION_DATE)
 
@@ -270,8 +267,8 @@ class DocumentInformation(DictionaryObject):
         The "raw" version of modification date; can return a
         ``ByteStringObject``.
 
-        Typically in the format ``D:YYYYMMDDhhmmss[+-]hh'mm`` where the
-        suffix is the offset from UTC.
+        Typically in the format ``D:YYYYMMDDhhmmss[+-]hh'mm`` where the suffix
+        is the offset from UTC.
         """
         return self.get(DI.MOD_DATE)
 
@@ -352,9 +349,8 @@ class PdfReader:
         """
         The first 8 bytes of the file.
 
-        This is typically something like ``'%PDF-1.6'`` and can be used
-        to detect if the file is actually a PDF file and which version
-        it is.
+        This is typically something like ``'%PDF-1.6'`` and can be used to
+        detect if the file is actually a PDF file and which version it is.
         """
         # TODO: Make this return a bytes object for consistency
         #       but that needs a deprecation
@@ -370,8 +366,8 @@ class PdfReader:
         Retrieve the PDF file's document information dictionary, if it exists.
 
         Note that some PDF files use metadata streams instead of docinfo
-        dictionaries, and these metadata streams will not be accessed by
-        this function.
+        dictionaries, and these metadata streams will not be accessed by this
+        function.
         """
         if TK.INFO not in self.trailer:
             return None
@@ -713,13 +709,6 @@ class PdfReader:
                 else:
                     ff[indexed_key(cast(str, value["/T"]), ff)] = value.get("/V")
         return ff
-        """return {
-            (field if full_qualified_name else formfields[field]["/T"]): formfields[
-                field
-            ].get("/V")
-            for field in formfields
-            if formfields[field].get("/FT") == "/Tx"
-        }"""
 
     def getFormTextFields(self) -> Dict[str, Any]:  # deprecated
         """
@@ -1071,8 +1060,8 @@ class PdfReader:
         """
         A list of labels for the pages in this document.
 
-        This property is read-only. The labels are in the order that the
-        pages appear in the document.
+        This property is read-only. The labels are in the order that the pages
+        appear in the document.
         """
         return [page_index2page_label(self, i) for i in range(len(self.pages))]
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -153,10 +153,10 @@ class DocumentInformation(DictionaryObject):
     @property
     def title(self) -> Optional[str]:
         """
-        Read-only property accessing the document's **title**.
+        Read-only property accessing the document's title.
 
-        Returns a unicode string (``TextStringObject``) or ``None``
-        if the title is not specified.
+        Returns a ``TextStringObject`` or ``None`` if the title is not
+        specified.
         """
         return (
             self._get_text(DI.TITLE) or self.get(DI.TITLE).get_object()  # type: ignore
@@ -172,10 +172,10 @@ class DocumentInformation(DictionaryObject):
     @property
     def author(self) -> Optional[str]:
         """
-        Read-only property accessing the document's **author**.
+        Read-only property accessing the document's author.
 
-        Returns a unicode string (``TextStringObject``) or ``None``
-        if the author is not specified.
+        Returns a ``TextStringObject`` or ``None`` if the author is not
+        specified.
         """
         return self._get_text(DI.AUTHOR)
 
@@ -187,10 +187,10 @@ class DocumentInformation(DictionaryObject):
     @property
     def subject(self) -> Optional[str]:
         """
-        Read-only property accessing the document's **subject**.
+        Read-only property accessing the document's subject.
 
-        Returns a unicode string (``TextStringObject``) or ``None``
-        if the subject is not specified.
+        Returns a ``TextStringObject`` or ``None`` if the subject is not
+        specified.
         """
         return self._get_text(DI.SUBJECT)
 
@@ -202,12 +202,13 @@ class DocumentInformation(DictionaryObject):
     @property
     def creator(self) -> Optional[str]:
         """
-        Read-only property accessing the document's **creator**.
+        Read-only property accessing the document's creator.
 
-        If the document was converted to PDF from another format, this is the
-        name of the application (e.g. OpenOffice) that created the original
-        document from which it was converted. Returns a unicode string
-        (``TextStringObject``) or ``None`` if the creator is not specified.
+        If the document was converted to PDF from another format, this
+        is the name of the application (e.g. OpenOffice) that created
+        the original document from which it was converted. Returns a
+        ``TextStringObject`` or ``None`` if the creator is not
+        specified.
         """
         return self._get_text(DI.CREATOR)
 
@@ -219,12 +220,12 @@ class DocumentInformation(DictionaryObject):
     @property
     def producer(self) -> Optional[str]:
         """
-        Read-only property accessing the document's **producer**.
+        Read-only property accessing the document's producer.
 
-        If the document was converted to PDF from another format, this is
-        the name of the application (for example, OSX Quartz) that converted
-        it to PDF. Returns a unicode string (``TextStringObject``)
-        or ``None`` if the producer is not specified.
+        If the document was converted to PDF from another format, this
+        is the name of the application (for example, OSX Quartz) that
+        converted it to PDF. Returns a ``TextStringObject`` or ``None``
+        if the producer is not specified.
         """
         return self._get_text(DI.PRODUCER)
 
@@ -235,9 +236,7 @@ class DocumentInformation(DictionaryObject):
 
     @property
     def creation_date(self) -> Optional[datetime]:
-        """
-        Read-only property accessing the document's **creation date**.
-        """
+        """Read-only property accessing the document's creation date."""
         text = self._get_text(DI.CREATION_DATE)
         if text is None:
             return None
@@ -248,15 +247,15 @@ class DocumentInformation(DictionaryObject):
         """
         The "raw" version of creation date; can return a ``ByteStringObject``.
 
-        Typically in the format D:YYYYMMDDhhmmss[+-]hh'mm where the suffix is the
-        offset from UTC.
+        Typically in the format ``D:YYYYMMDDhhmmss[+-]hh'mm`` where the
+        suffix is the offset from UTC.
         """
         return self.get(DI.CREATION_DATE)
 
     @property
     def modification_date(self) -> Optional[datetime]:
         """
-        Read-only property accessing the document's **modification date**.
+        Read-only property accessing the document's modification date.
 
         The date and time the document was most recently modified.
         """
@@ -268,10 +267,11 @@ class DocumentInformation(DictionaryObject):
     @property
     def modification_date_raw(self) -> Optional[str]:
         """
-        The "raw" version of modification date; can return a ``ByteStringObject``.
+        The "raw" version of modification date; can return a
+        ``ByteStringObject``.
 
-        Typically in the format D:YYYYMMDDhhmmss[+-]hh'mm where the suffix is the
-        offset from UTC.
+        Typically in the format ``D:YYYYMMDDhhmmss[+-]hh'mm`` where the
+        suffix is the offset from UTC.
         """
         return self.get(DI.MOD_DATE)
 
@@ -352,8 +352,9 @@ class PdfReader:
         """
         The first 8 bytes of the file.
 
-        This is typically something like ``'%PDF-1.6'`` and can be used to
-        detect if the file is actually a PDF file and which version it is.
+        This is typically something like ``'%PDF-1.6'`` and can be used
+        to detect if the file is actually a PDF file and which version
+        it is.
         """
         # TODO: Make this return a bytes object for consistency
         #       but that needs a deprecation
@@ -367,9 +368,10 @@ class PdfReader:
     def metadata(self) -> Optional[DocumentInformation]:
         """
         Retrieve the PDF file's document information dictionary, if it exists.
+
         Note that some PDF files use metadata streams instead of docinfo
-        dictionaries, and these metadata streams will not be accessed by this
-        function.
+        dictionaries, and these metadata streams will not be accessed by
+        this function.
         """
         if TK.INFO not in self.trailer:
             return None
@@ -384,9 +386,9 @@ class PdfReader:
 
     def getDocumentInfo(self) -> Optional[DocumentInformation]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use the attribute :py:attr:`metadata` instead.
 
-            Use the attribute :py:attr:`metadata` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getDocumentInfo", "metadata", "3.0.0")
         return self.metadata
@@ -394,9 +396,9 @@ class PdfReader:
     @property
     def documentInfo(self) -> Optional[DocumentInformation]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use the attribute :py:attr:`metadata` instead.
 
-            Use the attribute :py:attr:`metadata` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("documentInfo", "metadata", "3.0.0")
         return self.metadata
@@ -412,9 +414,9 @@ class PdfReader:
 
     def getXmpMetadata(self) -> Optional[XmpInformation]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use the attribute :py:attr:`metadata` instead.
 
-            Use the attribute :py:attr:`xmp_metadata` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getXmpMetadata", "xmp_metadata", "3.0.0")
         return self.xmp_metadata
@@ -422,9 +424,9 @@ class PdfReader:
     @property
     def xmpMetadata(self) -> Optional[XmpInformation]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use the attribute :py:attr:`xmp_metadata` instead.
 
-            Use the attribute :py:attr:`xmp_metadata` instead.
+        .. deprecated:: 1.28.0.
         """
         deprecation_with_replacement("xmpMetadata", "xmp_metadata", "3.0.0")
         return self.xmp_metadata
@@ -454,9 +456,9 @@ class PdfReader:
 
     def getNumPages(self) -> int:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :code:`len(reader.pages)` instead.
 
-            Use :code:`len(reader.pages)` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("reader.getNumPages", "len(reader.pages)", "3.0.0")
         return self._get_num_pages()
@@ -464,18 +466,18 @@ class PdfReader:
     @property
     def numPages(self) -> int:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :code:`len(reader.pages)` instead.
 
-            Use :code:`len(reader.pages)` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("reader.numPages", "len(reader.pages)", "3.0.0")
         return self._get_num_pages()
 
     def getPage(self, pageNumber: int) -> PageObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :code:`reader.pages[page_number]` instead.
 
-            Use :code:`reader.pages[page_number]` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "reader.getPage(pageNumber)", "reader.pages[page_number]", "3.0.0"
@@ -503,9 +505,9 @@ class PdfReader:
     @property
     def namedDestinations(self) -> Dict[str, Any]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`named_destinations` instead.
 
-            Use :py:attr:`named_destinations` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("namedDestinations", "named_destinations", "3.0.0")
         return self.named_destinations
@@ -543,7 +545,6 @@ class PdfReader:
             value is a :class:`Field<pypdf.generic.Field>` object. By
             default, the mapping name is used for keys.
             ``None`` if form data could not be located.
-
         """
         field_attributes = FieldDictionaryAttributes.attributes_dict()
         field_attributes.update(CheckboxRadioButtonAttributes.attributes_dict())
@@ -579,9 +580,9 @@ class PdfReader:
         fileobj: Optional[Any] = None,
     ) -> Optional[Dict[str, Any]]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_fields` instead.
 
-            Use :meth:`get_fields` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getFields", "get_fields", "3.0.0")
         return self.get_fields(tree, retval, fileobj)
@@ -722,9 +723,9 @@ class PdfReader:
 
     def getFormTextFields(self) -> Dict[str, Any]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_form_text_fields` instead.
 
-            Use :meth:`get_form_text_fields` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "getFormTextFields", "get_form_text_fields", "3.0.0"
@@ -791,9 +792,9 @@ class PdfReader:
         retval: Optional[Any] = None,
     ) -> Dict[str, Any]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`named_destinations` instead.
 
-            Use :py:attr:`named_destinations` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "getNamedDestinations", "named_destinations", "3.0.0"
@@ -803,17 +804,19 @@ class PdfReader:
     @property
     def outline(self) -> OutlineType:
         """
-        Read-only property for the outline (i.e., a collection of 'outline items'
-        which are also known as 'bookmarks') present in the document.
+        Read-only property for the outline present in the document.
+
+        (i.e., a collection of 'outline items' which are also known as
+        'bookmarks')
         """
         return self._get_outline()
 
     @property
     def outlines(self) -> OutlineType:  # deprecated
         """
-        .. deprecated:: 2.9.0
+        Use :py:attr:`outline` instead.
 
-            Use :py:attr:`outline` instead.
+        .. deprecated:: 2.9.0
         """
         deprecation_with_replacement("outlines", "outline", "3.0.0")
         return self.outline
@@ -863,9 +866,9 @@ class PdfReader:
         self, node: Optional[DictionaryObject] = None, outline: Optional[Any] = None
     ) -> OutlineType:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`outline` instead.
 
-            Use :py:attr:`outline` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getOutlines", "outline", "3.0.0")
         return self._get_outline(node, outline)
@@ -873,9 +876,12 @@ class PdfReader:
     @property
     def threads(self) -> Optional[ArrayObject]:
         """
-        Read-only property for the list of threads see §8.3.2 from PDF 1.7 spec.
-        It's an array of dictionaries with "/F" and "/I" properties
-        or None if there are no articles.
+        Read-only property for the list of threads.
+
+        See §8.3.2 from PDF 1.7 spec.
+
+        It's an array of dictionaries with "/F" and "/I" properties or
+        None if there are no articles.
         """
         catalog = cast(DictionaryObject, self.trailer[TK.ROOT])
         if CO.THREADS in catalog:
@@ -886,7 +892,8 @@ class PdfReader:
     def _get_page_number_by_indirect(
         self, indirect_reference: Union[None, int, NullObject, IndirectObject]
     ) -> int:
-        """Generate _page_id2num
+        """
+        Generate _page_id2num.
 
         Args:
             indirect_reference:
@@ -911,7 +918,7 @@ class PdfReader:
 
     def get_page_number(self, page: PageObject) -> int:
         """
-        Retrieve page number of a given PageObject
+        Retrieve page number of a given PageObject.
 
         Args:
             page: The page to get page number. Should be
@@ -924,9 +931,9 @@ class PdfReader:
 
     def getPageNumber(self, page: PageObject) -> int:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_page_number` instead.
 
-            Use :meth:`get_page_number` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getPageNumber", "get_page_number", "3.0.0")
         return self.get_page_number(page)
@@ -945,9 +952,9 @@ class PdfReader:
 
     def getDestinationPageNumber(self, destination: Destination) -> int:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_destination_page_number` instead.
 
-            Use :meth:`get_destination_page_number` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "getDestinationPageNumber", "get_destination_page_number", "3.0.0"
@@ -1064,8 +1071,8 @@ class PdfReader:
         """
         A list of labels for the pages in this document.
 
-        This property is read-only. The labels are in the order
-        that the pages appear in the document.
+        This property is read-only. The labels are in the order that the
+        pages appear in the document.
         """
         return [page_index2page_label(self, i) for i in range(len(self.pages))]
 
@@ -1099,9 +1106,9 @@ class PdfReader:
 
     def getPageLayout(self) -> Optional[str]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_layout` instead.
 
-            Use :py:attr:`page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getPageLayout", "page_layout", "3.0.0")
         return self.page_layout
@@ -1109,9 +1116,9 @@ class PdfReader:
     @property
     def pageLayout(self) -> Optional[str]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_layout` instead.
 
-            Use :py:attr:`page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("pageLayout", "page_layout", "3.0.0")
         return self.page_layout
@@ -1144,9 +1151,9 @@ class PdfReader:
 
     def getPageMode(self) -> Optional[PagemodeType]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getPageMode", "page_mode", "3.0.0")
         return self.page_mode
@@ -1154,9 +1161,9 @@ class PdfReader:
     @property
     def pageMode(self) -> Optional[PagemodeType]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("pageMode", "page_mode", "3.0.0")
         return self.page_mode
@@ -1264,6 +1271,7 @@ class PdfReader:
     def _get_indirect_object(self, num: int, gen: int) -> Optional[PdfObject]:
         """
         Used to ease development.
+
         This is equivalent to generic.IndirectObject(num,gen,self).get_object()
 
         Args:
@@ -1409,9 +1417,9 @@ class PdfReader:
         self, indirectReference: IndirectObject
     ) -> Optional[PdfObject]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_object` instead.
 
-            Use :meth:`get_object` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getObject", "get_object", "3.0.0")
         return self.get_object(indirectReference)
@@ -1446,9 +1454,9 @@ class PdfReader:
 
     def readObjectHeader(self, stream: StreamType) -> Tuple[int, int]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`read_object_header` instead.
 
-            Use :meth:`read_object_header` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("readObjectHeader", "read_object_header", "3.0.0")
         return self.read_object_header(stream)
@@ -1462,9 +1470,9 @@ class PdfReader:
         self, generation: int, idnum: int
     ) -> Optional[PdfObject]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`cache_get_indirect_object` instead.
 
-            Use :meth:`cache_get_indirect_object` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "cacheGetIndirectObject", "cache_get_indirect_object", "3.0.0"
@@ -1488,9 +1496,9 @@ class PdfReader:
         self, generation: int, idnum: int, obj: Optional[PdfObject]
     ) -> Optional[PdfObject]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`cache_indirect_object` instead.
 
-            Use :meth:`cache_indirect_object` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("cacheIndirectObject", "cache_indirect_object")
         return self.cache_indirect_object(generation, idnum, obj)
@@ -2025,6 +2033,7 @@ class PdfReader:
     def is_encrypted(self) -> bool:
         """
         Read-only boolean property showing whether this PDF file is encrypted.
+
         Note that this property, if true, will remain true even after the
         :meth:`decrypt()<pypdf.PdfReader.decrypt>` method is called.
         """
@@ -2032,9 +2041,9 @@ class PdfReader:
 
     def getIsEncrypted(self) -> bool:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`is_encrypted` instead.
 
-            Use :py:attr:`is_encrypted` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getIsEncrypted", "is_encrypted", "3.0.0")
         return self.is_encrypted
@@ -2042,9 +2051,9 @@ class PdfReader:
     @property
     def isEncrypted(self) -> bool:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`is_encrypted` instead.
 
-            Use :py:attr:`is_encrypted` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("isEncrypted", "is_encrypted", "3.0.0")
         return self.is_encrypted

--- a/pypdf/_security.py
+++ b/pypdf/_security.py
@@ -162,7 +162,7 @@ def _alg33(
 
 def _alg33_1(password: str, rev: Literal[2, 3, 4], keylen: int) -> bytes:
     """
-    Steps 1-4 of algorithm 3.3
+    Steps 1-4 of algorithm 3.3.
 
     Args:
         password:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -137,8 +137,8 @@ def read_non_whitespace(stream: StreamType) -> bytes:
 
 def skip_over_whitespace(stream: StreamType) -> bool:
     """
-    Similar to read_non_whitespace, but return a boolean if more than
-    one whitespace character was read.
+    Similar to read_non_whitespace, but return a boolean if more than one
+    whitespace character was read.
 
     Args:
         stream: The data stream from which was read.
@@ -349,7 +349,6 @@ def ord_(b: Union[int, str, bytes]) -> Union[int, bytes]:
 
 
 def hexencode(b: bytes) -> bytes:
-
     coder = getencoder("hex_codec")
     coded = coder(b)  # type: ignore
     return coded[0]
@@ -387,32 +386,24 @@ def deprecation(msg: str) -> None:
 def deprecate_with_replacement(
     old_name: str, new_name: str, removed_in: str = "3.0.0"
 ) -> None:
-    """
-    Raise an exception that a feature will be removed, but has a replacement.
-    """
+    """Raise an exception that a feature will be removed, but has a replacement."""
     deprecate(DEPR_MSG.format(old_name, new_name, removed_in), 4)
 
 
 def deprecation_with_replacement(
     old_name: str, new_name: str, removed_in: str = "3.0.0"
 ) -> None:
-    """
-    Raise an exception that a feature was already removed, but has a replacement.
-    """
+    """Raise an exception that a feature was already removed, but has a replacement."""
     deprecation(DEPR_MSG_HAPPENED.format(old_name, removed_in, new_name))
 
 
 def deprecate_no_replacement(name: str, removed_in: str = "3.0.0") -> None:
-    """
-    Raise an exception that a feature will be removed without replacement.
-    """
+    """Raise an exception that a feature will be removed without replacement."""
     deprecate(DEPR_MSG_NO_REPLACEMENT.format(name, removed_in), 4)
 
 
 def deprecation_no_replacement(name: str, removed_in: str = "3.0.0") -> None:
-    """
-    Raise an exception that a feature was already removed without replacement.
-    """
+    """Raise an exception that a feature was already removed without replacement."""
     deprecation(DEPR_MSG_NO_REPLACEMENT_HAPPENED.format(name, removed_in))
 
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -245,9 +245,9 @@ class PdfWriter:
 
     def getObject(self, ido: Union[int, IndirectObject]) -> PdfObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_object` instead.
 
-            Use :meth:`get_object` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getObject", "get_object", "3.0.0")
         return self.get_object(ido)
@@ -314,7 +314,8 @@ class PdfWriter:
     ) -> PageObject:
         """
         Add a page to this PDF file.
-        Recommended for advanced usage including the adequate excluded_keys
+
+        Recommended for advanced usage including the adequate excluded_keys.
 
         The page is usually acquired from a :class:`PdfReader<pypdf.PdfReader>`
         instance.
@@ -335,9 +336,9 @@ class PdfWriter:
         excluded_keys: Iterable[str] = (),
     ) -> PageObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_page` instead.
 
-            Use :meth:`add_page` instead.
+        .. deprecated:: 1.28.0.
         """
         deprecation_with_replacement("addPage", "add_page", "3.0.0")
         return self.add_page(page, excluded_keys)
@@ -369,9 +370,9 @@ class PdfWriter:
         excluded_keys: Iterable[str] = (),
     ) -> PageObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`insert_page` instead.
 
-            Use :meth:`insert_page` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("insertPage", "insert_page", "3.0.0")
         return self.insert_page(page, index, excluded_keys)
@@ -404,9 +405,9 @@ class PdfWriter:
 
     def getPage(self, pageNumber: int) -> PageObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :code:`writer.pages[page_number]` instead.
 
-            Use :code:`writer.pages[page_number]` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getPage", "writer.pages[page_number]", "3.0.0")
         return self.get_page(pageNumber)
@@ -417,9 +418,9 @@ class PdfWriter:
 
     def getNumPages(self) -> int:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :code:`len(writer.pages)` instead.
 
-            Use :code:`len(writer.pages)` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getNumPages", "len(writer.pages)", "3.0.0")
         return self._get_num_pages()
@@ -433,8 +434,9 @@ class PdfWriter:
         self, width: Optional[float] = None, height: Optional[float] = None
     ) -> PageObject:
         """
-        Append a blank page to this PDF file and returns it. If no page size
-        is specified, use the size of the last page.
+        Append a blank page to this PDF file and returns it.
+
+        If no page size is specified, use the size of the last page.
 
         Args:
             width: The width of the new page expressed in default user
@@ -457,9 +459,9 @@ class PdfWriter:
         self, width: Optional[float] = None, height: Optional[float] = None
     ) -> PageObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_blank_page` instead.
 
-            Use :meth:`add_blank_page` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addBlankPage", "add_blank_page", "3.0.0")
         return self.add_blank_page(width, height)
@@ -471,8 +473,9 @@ class PdfWriter:
         index: int = 0,
     ) -> PageObject:
         """
-        Insert a blank page to this PDF file and returns it. If no page size
-        is specified, use the size of the last page.
+        Insert a blank page to this PDF file and returns it.
+
+        If no page size is specified, use the size of the last page.
 
         Args:
             width: The width of the new page expressed in default user
@@ -503,9 +506,9 @@ class PdfWriter:
         index: int = 0,
     ) -> PageObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`insertBlankPage` instead.
 
-            Use :meth:`insertBlankPage` instead.
+        .. deprecated:: 1.28.0.
         """
         deprecation_with_replacement("insertBlankPage", "insert_blank_page", "3.0.0")
         return self.insert_blank_page(width, height, index)
@@ -515,9 +518,9 @@ class PdfWriter:
         self,
     ) -> Union[None, Destination, TextStringObject, ByteStringObject]:
         """
-        Property to access the opening destination (``/OpenAction`` entry in the
-        PDF catalog).
-        it returns `None` if the entry does not exist is not set.
+        Property to access the opening destination (``/OpenAction`` entry in
+        the PDF catalog). it returns `None` if the entry does not exist is not
+        set.
 
         Raises:
             Exception: If a destination is invalid
@@ -596,9 +599,9 @@ class PdfWriter:
 
     def addJS(self, javascript: str) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_js` instead.
 
-            Use :meth:`add_js` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addJS", "add_js", "3.0.0")
         return self.add_js(javascript)
@@ -689,9 +692,9 @@ class PdfWriter:
 
     def addAttachment(self, fname: str, fdata: Union[str, bytes]) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_attachment` instead.
 
-            Use :meth:`add_attachment` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addAttachment", "add_attachment", "3.0.0")
         return self.add_attachment(fname, fdata)
@@ -734,9 +737,9 @@ class PdfWriter:
         after_page_append: Optional[Callable[[PageObject], None]] = None,
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`append_pages_from_reader` instead.
 
-            Use :meth:`append_pages_from_reader` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "appendPagesFromReader", "append_pages_from_reader", "3.0.0"
@@ -816,9 +819,9 @@ class PdfWriter:
         flags: FieldFlag = OPTIONAL_READ_WRITE_FIELD,
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`update_page_form_field_values` instead.
 
-            Use :meth:`update_page_form_field_values` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "updatePageFormFieldValues", "update_page_form_field_values", "3.0.0"
@@ -828,8 +831,8 @@ class PdfWriter:
     def clone_reader_document_root(self, reader: PdfReader) -> None:
         """
         Copy the reader document root to the writer and all sub elements,
-        including pages, threads, outlines,...
-        For partial insertion, `append` should be considered.
+        including pages, threads, outlines,... For partial insertion, `append`
+        should be considered.
 
         Args:
             reader: PdfReader from the document root should be copied.
@@ -845,9 +848,9 @@ class PdfWriter:
 
     def cloneReaderDocumentRoot(self, reader: PdfReader) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`clone_reader_document_root` instead.
 
-            Use :meth:`clone_reader_document_root` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "cloneReaderDocumentRoot", "clone_reader_document_root", "3.0.0"
@@ -902,8 +905,8 @@ class PdfWriter:
         after_page_append: Optional[Callable[[PageObject], None]] = None,
     ) -> None:
         """
-        Create a copy (clone) of a document from a PDF file reader
-        cloning section '/Root' and '/Info' and '/ID' of the pdf
+        Create a copy (clone) of a document from a PDF file reader cloning
+        section '/Root' and '/Info' and '/ID' of the pdf.
 
         Args:
             reader: PDF file reader instance from which the clone
@@ -933,9 +936,9 @@ class PdfWriter:
         after_page_append: Optional[Callable[[PageObject], None]] = None,
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`clone_document_from_reader` instead.
 
-            Use :meth:`clone_document_from_reader` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "cloneDocumentFromReader", "clone_document_from_reader", "3.0.0"
@@ -1157,9 +1160,9 @@ class PdfWriter:
 
     def addMetadata(self, infos: Dict[str, Any]) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_metadata` instead.
 
-            Use :meth:`add_metadata` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addMetadata", "add_metadata", "3.0.0")
         self.add_metadata(infos)
@@ -1298,9 +1301,9 @@ class PdfWriter:
 
     def getReference(self, obj: PdfObject) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_reference` instead.
 
-            Use :meth:`get_reference` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getReference", "get_reference", "3.0.0")
         return self.get_reference(obj)
@@ -1341,7 +1344,9 @@ class PdfWriter:
     @property
     def threads(self) -> ArrayObject:
         """
-        Read-only property for the list of threads see §8.3.2 from PDF 1.7 spec
+        Read-only property for the list of threads.
+
+        See §8.3.2 from PDF 1.7 spec.
 
         Each element is a dictionaries with ``/F`` and ``/I`` keys.
         """
@@ -1349,9 +1354,9 @@ class PdfWriter:
 
     def getOutlineRoot(self) -> TreeObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_outline_root` instead.
 
-            Use :meth:`get_outline_root` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getOutlineRoot", "get_outline_root", "3.0.0")
         return self.get_outline_root()
@@ -1393,9 +1398,9 @@ class PdfWriter:
 
     def getNamedDestRoot(self) -> ArrayObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_named_dest_root` instead.
 
-            Use :meth:`get_named_dest_root` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getNamedDestRoot", "get_named_dest_root", "3.0.0")
         return self.get_named_dest_root()
@@ -1444,9 +1449,9 @@ class PdfWriter:
         parent: Union[None, TreeObject, IndirectObject] = None,
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 2.9.0
+        Use :meth:`add_outline_item_destination` instead.
 
-            Use :meth:`add_outline_item_destination` instead.
+        .. deprecated:: 2.9.0
         """
         deprecation_with_replacement(
             "add_bookmark_destination", "add_outline_item_destination", "3.0.0"
@@ -1457,9 +1462,9 @@ class PdfWriter:
         self, dest: PageObject, parent: Optional[TreeObject] = None
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_outline_item_destination` instead.
 
-            Use :meth:`add_outline_item_destination` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "addBookmarkDestination", "add_outline_item_destination", "3.0.0"
@@ -1493,9 +1498,9 @@ class PdfWriter:
         self, outline_item: OutlineItemType, parent: Optional[TreeObject] = None
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 2.9.0
+        Use :meth:`add_outline_item_dict` instead.
 
-            Use :meth:`add_outline_item_dict` instead.
+        .. deprecated:: 2.9.0
         """
         deprecation_with_replacement(
             "add_bookmark_dict", "add_outline_item_dict", "3.0.0"
@@ -1507,9 +1512,9 @@ class PdfWriter:
         self, outline_item: OutlineItemType, parent: Optional[TreeObject] = None
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_outline_item_dict` instead.
 
-            Use :meth:`add_outline_item_dict` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "addBookmarkDict", "add_outline_item_dict", "3.0.0"
@@ -1608,9 +1613,9 @@ class PdfWriter:
         *args: ZoomArgType,
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 2.9.0
+        Use :meth:`add_outline_item` instead.
 
-            Use :meth:`add_outline_item` instead.
+        .. deprecated:: 2.9.0
         """
         deprecation_with_replacement("add_bookmark", "add_outline_item", "3.0.0")
         return self.add_outline_item(
@@ -1635,9 +1640,9 @@ class PdfWriter:
         *args: ZoomArgType,
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_outline_item` instead.
 
-            Use :meth:`add_outline_item` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addBookmark", "add_outline_item", "3.0.0")
         return self.add_outline_item(
@@ -1706,9 +1711,9 @@ class PdfWriter:
         self, dest: Destination
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_named_destination_object` instead.
 
-            Use :meth:`add_named_destination_object` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "addNamedDestinationObject", "add_named_destination_object", "3.0.0"
@@ -1761,9 +1766,9 @@ class PdfWriter:
         self, title: str, pagenum: int
     ) -> IndirectObject:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_named_destination` instead.
 
-            Use :meth:`add_named_destination` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "addNamedDestination", "add_named_destination", "3.0.0"
@@ -1781,9 +1786,9 @@ class PdfWriter:
 
     def removeLinks(self) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`remove_links` instead.
 
-            Use :meth:`remove_links` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("removeLinks", "remove_links", "3.0.0")
         return self.remove_links()
@@ -1868,9 +1873,9 @@ class PdfWriter:
 
     def removeImages(self, ignoreByteStringObject: bool = False) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`remove_images` instead.
 
-            Use :meth:`remove_images` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("removeImages", "remove_images", "3.0.0")
         return self.remove_images(ignoreByteStringObject)
@@ -1921,9 +1926,9 @@ class PdfWriter:
 
     def removeText(self, ignoreByteStringObject: bool = False) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`remove_text` instead.
 
-            Use :meth:`remove_text` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("removeText", "remove_text", "3.0.0")
         return self.remove_text(ignoreByteStringObject)
@@ -1938,6 +1943,7 @@ class PdfWriter:
     ) -> None:
         """
         Add an URI from a rectangular area to the specified page.
+
         This uses the basic structure of :meth:`add_link`
 
         Args:
@@ -2013,9 +2019,9 @@ class PdfWriter:
         border: Optional[ArrayObject] = None,
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_uri` instead.
 
-            Use :meth:`add_uri` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("addURI", "add_uri", "3.0.0")
         return self.add_uri(pagenum, uri, rect, border)
@@ -2061,9 +2067,9 @@ class PdfWriter:
         *args: ZoomArgType,
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`add_link` instead.
 
-            Use :meth:`add_link` instead.
+        .. deprecated:: 1.28.0
         """
         deprecate_with_replacement(
             "addLink", "add_annotation(AnnotationBuilder.link(...))", "4.0.0"
@@ -2088,9 +2094,9 @@ class PdfWriter:
 
     def getPageLayout(self) -> Optional[LayoutType]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_layout` instead.
 
-            Use :py:attr:`page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getPageLayout", "page_layout", "3.0.0")
         return self._get_page_layout()
@@ -2158,9 +2164,9 @@ class PdfWriter:
 
     def setPageLayout(self, layout: LayoutType) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_layout` instead.
 
-            Use :py:attr:`page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "writer.setPageLayout(val)", "writer.page_layout = val", "3.0.0"
@@ -2199,9 +2205,9 @@ class PdfWriter:
     @property
     def pageLayout(self) -> Optional[LayoutType]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_layout` instead.
 
-            Use :py:attr:`page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("pageLayout", "page_layout", "3.0.0")
         return self.page_layout
@@ -2209,9 +2215,9 @@ class PdfWriter:
     @pageLayout.setter
     def pageLayout(self, layout: LayoutType) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_layout` instead.
 
-            Use :py:attr:`page_layout` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("pageLayout", "page_layout", "3.0.0")
         self.page_layout = layout
@@ -2233,18 +2239,18 @@ class PdfWriter:
 
     def getPageMode(self) -> Optional[PagemodeType]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getPageMode", "page_mode", "3.0.0")
         return self._get_page_mode()
 
     def set_page_mode(self, mode: PagemodeType) -> None:
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         if isinstance(mode, NameObject):
             mode_name: NameObject = mode
@@ -2258,9 +2264,9 @@ class PdfWriter:
 
     def setPageMode(self, mode: PagemodeType) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "writer.setPageMode(val)", "writer.page_mode = val", "3.0.0"
@@ -2297,9 +2303,9 @@ class PdfWriter:
     @property
     def pageMode(self) -> Optional[PagemodeType]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("pageMode", "page_mode", "3.0.0")
         return self.page_mode
@@ -2307,9 +2313,9 @@ class PdfWriter:
     @pageMode.setter
     def pageMode(self, mode: PagemodeType) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :py:attr:`page_mode` instead.
 
-            Use :py:attr:`page_mode` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("pageMode", "page_mode", "3.0.0")
         self.page_mode = mode
@@ -2587,7 +2593,7 @@ class PdfWriter:
         reader: PdfReader,
     ) -> IndirectObject:
         """
-        Clone the thread with only the applicable articles
+        Clone the thread with only the applicable articles.
 
         Args:
             thread:
@@ -2651,7 +2657,7 @@ class PdfWriter:
         reader: PdfReader,
     ) -> None:
         """
-        Add articles matching the defined criteria
+        Add articles matching the defined criteria.
 
         Args:
             fltr:
@@ -2825,7 +2831,7 @@ class PdfWriter:
             self._insert_filtered_outline(dest.childs, np, None)
 
     def close(self) -> None:
-        """To match the functions from Merger"""
+        """To match the functions from Merger."""
         return
 
     # @deprecation_bookmark(bookmark="outline_item")
@@ -2875,8 +2881,9 @@ class PdfWriter:
         self, reader: Union[None, PdfReader, IndirectObject] = None
     ) -> None:
         """
-        reset the translation table between reader and the writer object.
-        late cloning will create new independent objects
+        Reset the translation table between reader and the writer object.
+
+        Late cloning will create new independent objects.
 
         Args:
             reader: PdfReader or IndirectObject refering a PdfReader object.
@@ -2955,10 +2962,11 @@ class PdfWriter:
     ) -> None:
         """
         Set a page label to a range of pages.
-        Page indexes must be given starting from 0.
-        Labels must have a style, a prefix or both.
-        If to a range is not assigned any page label a decimal label starting
-        from 1 is applied.
+
+        Page indexes must be given
+        starting from 0. Labels must have a style, a prefix or both. If to a
+        range is not assigned any page label a decimal label starting from 1 is
+        applied.
 
         Args:
             page_index_from: page index of the beginning of the range starting from 0

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -50,7 +50,7 @@ class EncryptionDictAttributes:
 
 
 class UserAccessPermissions(IntFlag):
-    """TABLE 3.20 User access permissions"""
+    """TABLE 3.20 User access permissions."""
 
     R1 = 1
     R2 = 2
@@ -145,7 +145,7 @@ class PageAttributes:
 
 
 class FileSpecificationDictionaryEntries:
-    """TABLE 3.41 Entries in a file specification dictionary"""
+    """TABLE 3.41 Entries in a file specification dictionary."""
 
     Type = "/Type"
     FS = "/FS"  # The name of the file system to be used to interpret this file specification
@@ -261,7 +261,7 @@ class GoToActionArguments:
 
 
 class AnnotationDictionaryAttributes:
-    """TABLE 8.15 Entries common to all annotation dictionaries"""
+    """TABLE 8.15 Entries common to all annotation dictionaries."""
 
     Type = "/Type"
     Subtype = "/Subtype"
@@ -334,7 +334,7 @@ class FieldDictionaryAttributes:
 
 
 class CheckboxRadioButtonAttributes:
-    """TABLE 8.76 Field flags common to all field types"""
+    """TABLE 8.76 Field flags common to all field types."""
 
     Opt = "/Opt"  # Options, Optional
 
@@ -350,7 +350,7 @@ class CheckboxRadioButtonAttributes:
 
 
 class FieldFlag(IntFlag):
-    """TABLE 8.70 Field flags common to all field types"""
+    """TABLE 8.70 Field flags common to all field types."""
 
     READ_ONLY = 1
     REQUIRED = 2
@@ -424,7 +424,7 @@ class CatalogDictionary:
 
 
 class OutlineFontFlag(IntFlag):
-    """A class used as an enumerable flag for formatting an outline font"""
+    """A class used as an enumerable flag for formatting an outline font."""
 
     italic = 1
     bold = 2

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -194,10 +194,8 @@ class FlateDecode:
 
 
 class ASCIIHexDecode:
-    """
-    The ASCIIHexDecode filter decodes data that has been encoded in ASCII
-    hexadecimal form into a base-7 ASCII format.
-    """
+    """The ASCIIHexDecode filter decodes data that has been encoded in ASCII
+    hexadecimal form into a base-7 ASCII format."""
 
     @staticmethod
     def decode(
@@ -246,8 +244,11 @@ class ASCIIHexDecode:
 
 
 class LZWDecode:
-    """Taken from:
-    http://www.java2s.com/Open-Source/Java-Document/PDF/PDF-Renderer/com/sun/pdfview/decode/LZWDecode.java.htm
+    """
+    Taken from:
+
+    http://www.java2s.com/Open-Source/Java-Document/PDF/PDF-
+    Renderer/com/sun/pdfview/decode/LZWDecode.java.htm
     """
 
     class Decoder:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -97,10 +97,10 @@ class PdfObject(PdfObjectProtocol):
         self, clone: Any, pdf_dest: PdfWriterProtocol
     ) -> PdfObjectProtocol:
         """
-        reference the object within the _objects of pdf_dest only if
-        indirect_reference attribute exists (which means the objects
-        was already identified in xref/xobjstm)
-        if object has been already referenced do nothing
+        Reference the object within the _objects of pdf_dest only if
+        indirect_reference attribute exists (which means the objects was
+        already identified in xref/xobjstm) if object has been already
+        referenced do nothing.
 
         Args:
           clone:
@@ -152,7 +152,7 @@ class NullObject(PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "NullObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         return cast("NullObject", self._reference_clone(NullObject(), pdf_dest))
 
     def write_to_stream(
@@ -192,7 +192,7 @@ class BooleanObject(PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "BooleanObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         return cast(
             "BooleanObject", self._reference_clone(BooleanObject(self.value), pdf_dest)
         )
@@ -251,7 +251,7 @@ class IndirectObject(PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "IndirectObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         if self.pdf == pdf_dest and not force_duplicate:
             # Already duplicated and no extra duplication required
             return self
@@ -357,7 +357,7 @@ class FloatObject(decimal.Decimal, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "FloatObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         return cast("FloatObject", self._reference_clone(FloatObject(self), pdf_dest))
 
     def __repr__(self) -> str:
@@ -400,7 +400,7 @@ class NumberObject(int, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "NumberObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         return cast("NumberObject", self._reference_clone(NumberObject(self), pdf_dest))
 
     def as_numeric(self) -> int:
@@ -435,6 +435,7 @@ class NumberObject(int, PdfObject):
 class ByteStringObject(bytes, PdfObject):
     """
     Represents a string object where the text encoding could not be determined.
+
     This occurs quite often, as the PDF spec doesn't provide an alternate way to
     represent strings -- for example, the encryption data stored in files (like
     /O) is clearly not text, but is still stored in a "String" object.
@@ -446,7 +447,7 @@ class ByteStringObject(bytes, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "ByteStringObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         return cast(
             "ByteStringObject",
             self._reference_clone(ByteStringObject(bytes(self)), pdf_dest),
@@ -478,10 +479,11 @@ class ByteStringObject(bytes, PdfObject):
 
 class TextStringObject(str, PdfObject):
     """
-    Represents a string object that has been decoded into a real unicode string.
+    A string object that has been decoded into a real unicode string.
+
     If read from a PDF document, this string appeared to match the
-    PDFDocEncoding, or contained a UTF-16BE BOM mark to cause UTF-16 decoding to
-    occur.
+    PDFDocEncoding, or contained a UTF-16BE BOM mark to cause UTF-16 decoding
+    to occur.
     """
 
     def clone(
@@ -490,7 +492,7 @@ class TextStringObject(str, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "TextStringObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         obj = TextStringObject(self)
         obj.autodetect_pdfdocencoding = self.autodetect_pdfdocencoding
         obj.autodetect_utf16 = self.autodetect_utf16
@@ -501,12 +503,10 @@ class TextStringObject(str, PdfObject):
 
     @property
     def original_bytes(self) -> bytes:
-        """
-        It is occasionally possible that a text string object gets created where
+        """It is occasionally possible that a text string object gets created where
         a byte string object was expected due to the autodetection mechanism --
         if that occurs, this "original_bytes" property can be used to
-        back-calculate what the original encoded bytes were.
-        """
+        back-calculate what the original encoded bytes were."""
         return self.get_original_bytes()
 
     def get_original_bytes(self) -> bytes:
@@ -575,7 +575,7 @@ class NameObject(str, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "NameObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         return cast("NameObject", self._reference_clone(NameObject(self), pdf_dest))
 
     def write_to_stream(

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -82,7 +82,7 @@ class ArrayObject(list, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "ArrayObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         try:
             if self.indirect_reference.pdf == pdf_dest and not force_duplicate:  # type: ignore
                 return self
@@ -104,10 +104,7 @@ class ArrayObject(list, PdfObject):
         return cast("ArrayObject", arr)
 
     def items(self) -> Iterable[Any]:
-        """
-        Emulate DictionaryObject.items for a list
-        (index, object)
-        """
+        """Emulate DictionaryObject.items for a list (index, object)."""
         return enumerate(self)
 
     def write_to_stream(
@@ -165,7 +162,7 @@ class DictionaryObject(dict, PdfObject):
         force_duplicate: bool = False,
         ignore_fields: Union[Tuple[str, ...], List[str], None] = (),
     ) -> "DictionaryObject":
-        """clone object into pdf_dest"""
+        """Clone object into pdf_dest."""
         try:
             if self.indirect_reference.pdf == pdf_dest and not force_duplicate:  # type: ignore
                 return self
@@ -189,7 +186,7 @@ class DictionaryObject(dict, PdfObject):
         ignore_fields: Union[Tuple[str, ...], List[str]],
     ) -> None:
         """
-        Update the object from src
+        Update the object from src.
 
         Args:
             src: "DictionaryObject":
@@ -276,8 +273,8 @@ class DictionaryObject(dict, PdfObject):
     @property
     def xmp_metadata(self) -> Optional[PdfObject]:
         """
-        Retrieve XMP (Extensible Metadata Platform) data relevant to the
-        this object, if available.
+        Retrieve XMP (Extensible Metadata Platform) data relevant to the this
+        object, if available.
 
         Stability: Added in v1.12, will exist for all future v1.x releases.
 
@@ -285,7 +282,6 @@ class DictionaryObject(dict, PdfObject):
           Returns a {@link #xmp.XmpInformation XmlInformation} instance
           that can be used to access XMP metadata from the document.  Can also
           return None if no metadata was found on the document root.
-
         """
         from ..xmp import XmpInformation
 
@@ -303,9 +299,9 @@ class DictionaryObject(dict, PdfObject):
         self,
     ) -> Optional[PdfObject]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :meth:`xmp_metadata` instead.
 
-            Use :meth:`xmp_metadata` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("getXmpMetadata", "xmp_metadata", "3.0.0")
         return self.xmp_metadata
@@ -313,9 +309,9 @@ class DictionaryObject(dict, PdfObject):
     @property
     def xmpMetadata(self) -> Optional[PdfObject]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :meth:`xmp_metadata` instead.
 
-            Use :meth:`xmp_metadata` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("xmpMetadata", "xmp_metadata", "3.0.0")
         return self.xmp_metadata
@@ -657,9 +653,7 @@ class TreeObject(DictionaryObject):
         _reset_node_tree_relationship(child_obj)
 
     def remove_from_tree(self) -> None:
-        """
-        remove the object from the tree it is in
-        """
+        """Remove the object from the tree it is in."""
         if NameObject("/Parent") not in self:
             raise ValueError("Removed child does not appear to be a tree item")
         else:
@@ -1178,9 +1172,9 @@ class Field(TreeObject):
     @property
     def fieldType(self) -> Optional[NameObject]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :py:attr:`field_type` instead.
 
-            Use :py:attr:`field_type` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("fieldType", "field_type", "3.0.0")
         return self.field_type
@@ -1208,9 +1202,9 @@ class Field(TreeObject):
     @property
     def altName(self) -> Optional[str]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :py:attr:`alternate_name` instead.
 
-            Use :py:attr:`alternate_name` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("altName", "alternate_name", "3.0.0")
         return self.alternate_name
@@ -1218,8 +1212,9 @@ class Field(TreeObject):
     @property
     def mapping_name(self) -> Optional[str]:
         """
-        Read-only property accessing the mapping name of this field. This
-        name is used by pypdf as a key in the dictionary returned by
+        Read-only property accessing the mapping name of this field.
+
+        This name is used by pypdf as a key in the dictionary returned by
         :meth:`get_fields()<pypdf.PdfReader.get_fields>`
         """
         return self.get(FieldDictionaryAttributes.TM)
@@ -1227,26 +1222,25 @@ class Field(TreeObject):
     @property
     def mappingName(self) -> Optional[str]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :py:attr:`mapping_name` instead.
 
-            Use :py:attr:`mapping_name` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("mappingName", "mapping_name", "3.0.0")
         return self.mapping_name
 
     @property
     def flags(self) -> Optional[int]:
-        """
-        Read-only property accessing the field flags, specifying various
-        characteristics of the field (see Table 8.70 of the PDF 1.7 reference).
-        """
+        """Read-only property accessing the field flags, specifying various
+        characteristics of the field (see Table 8.70 of the PDF 1.7 reference)."""
         return self.get(FieldDictionaryAttributes.Ff)
 
     @property
     def value(self) -> Optional[Any]:
         """
-        Read-only property accessing the value of this field. Format
-        varies based on field type.
+        Read-only property accessing the value of this field.
+
+        Format varies based on field type.
         """
         return self.get(FieldDictionaryAttributes.V)
 
@@ -1258,9 +1252,9 @@ class Field(TreeObject):
     @property
     def defaultValue(self) -> Optional[Any]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :py:attr:`default_value` instead.
 
-            Use :py:attr:`default_value` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("defaultValue", "default_value", "3.0.0")
         return self.default_value
@@ -1269,17 +1263,18 @@ class Field(TreeObject):
     def additional_actions(self) -> Optional[DictionaryObject]:
         """
         Read-only property accessing the additional actions dictionary.
-        This dictionary defines the field's behavior in response to trigger events.
-        See Section 8.5.2 of the PDF 1.7 reference.
+
+        This dictionary defines the field's behavior in response to trigger
+        events. See Section 8.5.2 of the PDF 1.7 reference.
         """
         return self.get(FieldDictionaryAttributes.AA)
 
     @property
     def additionalActions(self) -> Optional[DictionaryObject]:  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :py:attr:`additional_actions` instead.
 
-            Use :py:attr:`additional_actions` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("additionalActions", "additional_actions", "3.0.0")
         return self.additional_actions
@@ -1288,6 +1283,7 @@ class Field(TreeObject):
 class Destination(TreeObject):
     """
     A class representing a destination within a PDF file.
+
     See section 8.2.1 of the PDF 1.6 reference.
 
     Args:
@@ -1298,7 +1294,6 @@ class Destination(TreeObject):
 
     Raises:
         PdfReadError: If destination type is invalid.
-
     """
 
     node: Optional[
@@ -1362,9 +1357,9 @@ class Destination(TreeObject):
 
     def getDestArray(self) -> "ArrayObject":  # deprecated
         """
-        .. deprecated:: 1.28.3
+        Use :py:attr:`dest_array` instead.
 
-            Use :py:attr:`dest_array` instead.
+        .. deprecated:: 1.28.3
         """
         deprecation_with_replacement("getDestArray", "dest_array", "3.0.0")
         return self.dest_array
@@ -1430,20 +1425,25 @@ class Destination(TreeObject):
 
     @property
     def color(self) -> Optional["ArrayObject"]:
-        """Read-only property accessing the color in (R, G, B) with values 0.0-1.0"""
+        """Read-only property accessing the color in (R, G, B) with values 0.0-1.0."""
         return self.get(
             "/C", ArrayObject([FloatObject(0), FloatObject(0), FloatObject(0)])
         )
 
     @property
     def font_format(self) -> Optional[OutlineFontFlag]:
-        """Read-only property accessing the font type. 1=italic, 2=bold, 3=both"""
+        """
+        Read-only property accessing the font type.
+
+        1=italic, 2=bold, 3=both
+        """
         return self.get("/F", 0)
 
     @property
     def outline_count(self) -> Optional[int]:
         """
         Read-only property accessing the outline count.
+
         positive = expanded
         negative = collapsed
         absolute value = number of visible descendents at all levels

--- a/pypdf/generic/_fit.py
+++ b/pypdf/generic/_fit.py
@@ -21,7 +21,7 @@ class Fit:
         zoom: Optional[float] = None,
     ) -> "Fit":
         """
-        Display the page designated by page, with the coordinates ( left , top )
+        Display the page designated by page, with the coordinates (left , top)
         positioned at the upper-left corner of the window and the contents
         of the page magnified by the factor zoom.
 
@@ -45,9 +45,11 @@ class Fit:
         """
         Display the page designated by page, with its contents magnified just
         enough to fit the entire page within the window both horizontally and
-        vertically. If the required horizontal and vertical magnification
-        factors are different, use the smaller of the two, centering the page
-        within the window in the other dimension.
+        vertically.
+
+        If the required horizontal and vertical magnification factors are
+        different, use the smaller of the two, centering the page within the
+        window in the other dimension.
         """
         return Fit(fit_type="/Fit")
 
@@ -85,7 +87,7 @@ class Fit:
         """
         Display the page designated by page , with its contents magnified
         just enough to fit the rectangle specified by the coordinates
-        left , bottom , right , and top entirely within the window
+        left, bottom, right, and top entirely within the window
         both horizontally and vertically.
 
         If the required horizontal and vertical magnification factors are
@@ -109,20 +111,22 @@ class Fit:
     @classmethod
     def fit_box(cls) -> "Fit":
         """
-        Display the page designated by page , with its contents magnified
-        just enough to fit its bounding box entirely within the window both
-        horizontally and vertically. If the required horizontal and vertical
-        magnification factors are different, use the smaller of the two,
-        centering the bounding box within the window in the other dimension.
+        Display the page designated by page , with its contents magnified just
+        enough to fit its bounding box entirely within the window both
+        horizontally and vertically.
+
+        If the required horizontal and vertical magnification factors are
+        different, use the smaller of the two, centering the bounding box
+        within the window in the other dimension.
         """
         return Fit(fit_type="/FitB")
 
     @classmethod
     def fit_box_horizontally(cls, top: Optional[float] = None) -> "Fit":
         """
-        Display the page designated by page , with the vertical coordinate
-        top positioned at the top edge of the window and the contents of the
-        page magnified just enough to fit the entire width of its bounding box
+        Display the page designated by page , with the vertical coordinate top
+        positioned at the top edge of the window and the contents of the page
+        magnified just enough to fit the entire width of its bounding box
         within the window.
 
         A null value for top specifies that the current value of that parameter
@@ -139,10 +143,10 @@ class Fit:
     @classmethod
     def fit_box_vertically(cls, left: Optional[float] = None) -> "Fit":
         """
-        Display the page designated by page , with the horizontal coordinate
-        left positioned at the left edge of the window and the contents of
-        the page magnified just enough to fit the entire height of its
-        bounding box within the window.
+        Display the page designated by page, with the horizontal coordinate
+        left positioned at the left edge of the window and the contents of the
+        page magnified just enough to fit the entire height of its bounding box
+        within the window.
 
         A null value for left specifies that the current value of that
         parameter is to be retained unchanged.

--- a/pypdf/generic/_rectangle.py
+++ b/pypdf/generic/_rectangle.py
@@ -8,12 +8,15 @@ from ._data_structures import ArrayObject
 
 class RectangleObject(ArrayObject):
     """
-    This class is used to represent *page boxes* in pypdf. These boxes include:
-        * :attr:`artbox <pypdf._page.PageObject.artbox>`
-        * :attr:`bleedbox <pypdf._page.PageObject.bleedbox>`
-        * :attr:`cropbox <pypdf._page.PageObject.cropbox>`
-        * :attr:`mediabox <pypdf._page.PageObject.mediabox>`
-        * :attr:`trimbox <pypdf._page.PageObject.trimbox>`
+    This class is used to represent *page boxes* in pypdf.
+
+    These boxes include:
+
+    * :attr:`artbox <pypdf._page.PageObject.artbox>`
+    * :attr:`bleedbox <pypdf._page.PageObject.bleedbox>`
+    * :attr:`cropbox <pypdf._page.PageObject.cropbox>`
+    * :attr:`mediabox <pypdf._page.PageObject.mediabox>`
+    * :attr:`trimbox <pypdf._page.PageObject.trimbox>`
     """
 
     def __init__(
@@ -114,10 +117,7 @@ class RectangleObject(ArrayObject):
 
     @property
     def lower_left(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        """
-        Property to read and modify the lower left coordinate of this box
-        in (x,y) form.
-        """
+        """Lower left coordinate of this box in (x,y) form."""
         return self.left, self.bottom
 
     @lower_left.setter
@@ -126,10 +126,7 @@ class RectangleObject(ArrayObject):
 
     @property
     def lower_right(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        """
-        Property to read and modify the lower right coordinate of this box
-        in (x,y) form.
-        """
+        """Lower right coordinate of this box in (x,y) form."""
         return self.right, self.bottom
 
     @lower_right.setter
@@ -138,10 +135,7 @@ class RectangleObject(ArrayObject):
 
     @property
     def upper_left(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        """
-        Property to read and modify the upper left coordinate of this box
-        in (x,y) form.
-        """
+        """Upper left coordinate of this box in (x,y) form."""
         return self.left, self.top
 
     @upper_left.setter
@@ -150,10 +144,7 @@ class RectangleObject(ArrayObject):
 
     @property
     def upper_right(self) -> Tuple[decimal.Decimal, decimal.Decimal]:
-        """
-        Property to read and modify the upper right coordinate of this box
-        in (x,y) form.
-        """
+        """Upper right coordinate of this box in (x,y) form."""
         return self.right, self.top
 
     @upper_right.setter

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -126,7 +126,6 @@ def create_string_object(
 
     Raises:
         TypeError: If string is not of type str or bytes.
-
     """
     if isinstance(string, str):
         return TextStringObject(string)

--- a/pypdf/pagerange.py
+++ b/pypdf/pagerange.py
@@ -31,7 +31,6 @@ class PageRange:
       -  to_slice() gives the equivalent slice.
       -  str() and repr() allow printing.
       -  indices(n) is like slice.indices(n).
-
     """
 
     def __init__(self, arg: Union[slice, "PageRange", str]) -> None:
@@ -43,6 +42,7 @@ class PageRange:
             where the brackets indicate optional ints.
         Remember, page indices start with zero.
         Page range expression examples:
+
             :     all pages.                   -1    last page.
             22    just the 23rd page.          :-1   all but the last page.
             0:3   the first three pages.       -2    second-to-last page.
@@ -114,8 +114,8 @@ class PageRange:
 
     def indices(self, n: int) -> Tuple[int, int, int]:
         """
-        Assuming a sequence of length n, calculate the start and stop
-        indices, and the stride length of the PageRange.
+        Assuming a sequence of length n, calculate the start and stop indices,
+        and the stride length of the PageRange.
 
         See help(slice.indices).
 

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -215,7 +215,6 @@ class XmpInformation(PdfObject):
 
     Raises:
       PdfReadError: if XML is invalid
-
     """
 
     def __init__(self, stream: ContentStream) -> None:
@@ -244,9 +243,9 @@ class XmpInformation(PdfObject):
         self, stream: StreamType, encryption_key: Union[None, str, bytes]
     ) -> None:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`write_to_stream` instead.
 
-            Use :meth:`write_to_stream` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
         self.write_to_stream(stream, encryption_key)
@@ -263,9 +262,9 @@ class XmpInformation(PdfObject):
         self, aboutUri: str, namespace: str, name: str
     ) -> Iterator[Any]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_element` instead.
 
-            Use :meth:`get_element` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement("getElement", "get_element", "3.0.0")
         return self.get_element(aboutUri, namespace, name)
@@ -285,9 +284,9 @@ class XmpInformation(PdfObject):
         self, aboutUri: str, namespace: str
     ) -> Iterator[Any]:  # deprecated
         """
-        .. deprecated:: 1.28.0
+        Use :meth:`get_nodes_in_namespace` instead.
 
-            Use :meth:`get_nodes_in_namespace` instead.
+        .. deprecated:: 1.28.0
         """
         deprecation_with_replacement(
             "getNodesInNamespace", "get_nodes_in_namespace", "3.0.0"
@@ -303,107 +302,79 @@ class XmpInformation(PdfObject):
 
     dc_contributor = property(_getter_bag(DC_NAMESPACE, "contributor"))
     """
-    Contributors to the resource (other than the authors). An unsorted
-    array of names.
+    Contributors to the resource (other than the authors).
+
+    An unsorted array of names.
     """
 
     dc_coverage = property(_getter_single(DC_NAMESPACE, "coverage"))
-    """
-    Text describing the extent or scope of the resource.
-    """
+    """Text describing the extent or scope of the resource."""
 
     dc_creator = property(_getter_seq(DC_NAMESPACE, "creator"))
-    """
-    A sorted array of names of the authors of the resource, listed in order
-    of precedence.
-    """
+    """A sorted array of names of the authors of the resource, listed in order
+    of precedence."""
 
     dc_date = property(_getter_seq(DC_NAMESPACE, "date", _converter_date))
     """
     A sorted array of dates (datetime.datetime instances) of significance to
-    the resource.  The dates and times are in UTC.
+    the resource.
+
+    The dates and times are in UTC.
     """
 
     dc_description = property(_getter_langalt(DC_NAMESPACE, "description"))
-    """
-    A language-keyed dictionary of textual descriptions of the content of the
-    resource.
-    """
+    """A language-keyed dictionary of textual descriptions of the content of the
+    resource."""
 
     dc_format = property(_getter_single(DC_NAMESPACE, "format"))
-    """
-    The mime-type of the resource.
-    """
+    """The mime-type of the resource."""
 
     dc_identifier = property(_getter_single(DC_NAMESPACE, "identifier"))
-    """
-    Unique identifier of the resource.
-    """
+    """Unique identifier of the resource."""
 
     dc_language = property(_getter_bag(DC_NAMESPACE, "language"))
-    """
-    An unordered array specifying the languages used in the resource.
-    """
+    """An unordered array specifying the languages used in the resource."""
 
     dc_publisher = property(_getter_bag(DC_NAMESPACE, "publisher"))
-    """
-    An unordered array of publisher names.
-    """
+    """An unordered array of publisher names."""
 
     dc_relation = property(_getter_bag(DC_NAMESPACE, "relation"))
-    """
-    An unordered array of text descriptions of relationships to other
-    documents.
-    """
+    """An unordered array of text descriptions of relationships to other
+    documents."""
 
     dc_rights = property(_getter_langalt(DC_NAMESPACE, "rights"))
-    """
-    A language-keyed dictionary of textual descriptions of the rights the
-    user has to this resource.
-    """
+    """A language-keyed dictionary of textual descriptions of the rights the
+    user has to this resource."""
 
     dc_source = property(_getter_single(DC_NAMESPACE, "source"))
-    """
-    Unique identifier of the work from which this resource was derived.
-    """
+    """Unique identifier of the work from which this resource was derived."""
 
     dc_subject = property(_getter_bag(DC_NAMESPACE, "subject"))
-    """
-    An unordered array of descriptive phrases or keywrods that specify the
-    topic of the content of the resource.
-    """
+    """An unordered array of descriptive phrases or keywrods that specify the
+    topic of the content of the resource."""
 
     dc_title = property(_getter_langalt(DC_NAMESPACE, "title"))
-    """
-    A language-keyed dictionary of the title of the resource.
-    """
+    """A language-keyed dictionary of the title of the resource."""
 
     dc_type = property(_getter_bag(DC_NAMESPACE, "type"))
-    """
-    An unordered array of textual descriptions of the document type.
-    """
+    """An unordered array of textual descriptions of the document type."""
 
     pdf_keywords = property(_getter_single(PDF_NAMESPACE, "Keywords"))
-    """
-    An unformatted text string representing document keywords.
-    """
+    """An unformatted text string representing document keywords."""
 
     pdf_pdfversion = property(_getter_single(PDF_NAMESPACE, "PDFVersion"))
-    """
-    The PDF file version, for example 1.0, 1.3.
-    """
+    """The PDF file version, for example 1.0, 1.3."""
 
     pdf_producer = property(_getter_single(PDF_NAMESPACE, "Producer"))
-    """
-    The name of the tool that created the PDF document.
-    """
+    """The name of the tool that created the PDF document."""
 
     xmp_create_date = property(
         _getter_single(XMP_NAMESPACE, "CreateDate", _converter_date)
     )
     """
-    The date and time the resource was originally created.  The date and
-    time are returned as a UTC datetime.datetime object.
+    The date and time the resource was originally created.
+
+    The date and time are returned as a UTC datetime.datetime object.
     """
 
     @property
@@ -420,8 +391,9 @@ class XmpInformation(PdfObject):
         _getter_single(XMP_NAMESPACE, "ModifyDate", _converter_date)
     )
     """
-    The date and time the resource was last modified.  The date and time
-    are returned as a UTC datetime.datetime object.
+    The date and time the resource was last modified.
+
+    The date and time are returned as a UTC datetime.datetime object.
     """
 
     @property
@@ -467,9 +439,7 @@ class XmpInformation(PdfObject):
         self.xmp_creator_tool = value
 
     xmpmm_document_id = property(_getter_single(XMPMM_NAMESPACE, "DocumentID"))
-    """
-    The common identifier for all versions and renditions of this resource.
-    """
+    """The common identifier for all versions and renditions of this resource."""
 
     @property
     def xmpmm_documentId(self) -> str:  # deprecated
@@ -482,10 +452,8 @@ class XmpInformation(PdfObject):
         self.xmpmm_document_id = value
 
     xmpmm_instance_id = property(_getter_single(XMPMM_NAMESPACE, "InstanceID"))
-    """
-    An identifier for a specific incarnation of a document, updated each
-    time a file is saved.
-    """
+    """An identifier for a specific incarnation of a document, updated each
+    time a file is saved."""
 
     @property
     def xmpmm_instanceId(self) -> str:  # deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,8 @@ exclude_lines = [
 
 [tool.ruff]
 line-length = 120
+
+[tool.docformatter]
+pre-summary-newline = true
+wrap-summaries = 0
+wrap-descriptions = 0

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -137,6 +137,7 @@ def test_read_string_from_stream_performance(benchmark):
     """
     This test simulates reading an embedded base64 image of 256kb.
     It should be faster than a second, even on ancient machines.
+
     Runs < 100ms on a 2019 notebook. Takes 10 seconds prior to #1350.
     """
     benchmark(read_string_from_stream_performance)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -35,9 +35,7 @@ filter_inputs = (
     ("predictor", "s"), list(cartesian_product([1], filter_inputs))
 )
 def test_FlateDecode(predictor, s):
-    """
-    Tests FlateDecode decode() and encode() methods.
-    """
+    """Tests FlateDecode decode() and encode() methods."""
     codec = FlateDecode()
     s = s.encode()
     encoded = codec.encode(s)
@@ -46,9 +44,11 @@ def test_FlateDecode(predictor, s):
 
 def test_FlateDecode_unsupported_predictor():
     """
-    Inputs an unsupported predictor (outside the [10, 15] range) checking
-    that PdfReadError() is raised. Once this predictor support is updated
-    in the future, this test case may be removed.
+    Inputs an unsupported predictor (outside the [10, 15] range) checking that
+    PdfReadError() is raised.
+
+    Once this predictor support is updated in the future, this test case may be
+    removed.
     """
     codec = FlateDecode()
     predictors = (-10, -1, 0, 9, 16, 20, 100)
@@ -109,16 +109,16 @@ def test_ASCIIHexDecode(data, expected):
     """
     Feeds a bunch of values to ASCIIHexDecode.decode() and ensures the
     correct output is returned.
+
     TODO What is decode() supposed to do for such inputs as ">>", ">>>" or
     any other not terminated by ">"? (For the latter case, an exception
     is currently raised.)
     """
-
     assert ASCIIHexDecode.decode(data) == expected
 
 
 def test_ASCIIHexDecode_no_eod():
-    """Ensuring an exception is raised when no EOD character is present"""
+    """Ensuring an exception is raised when no EOD character is present."""
     with pytest.raises(PdfStreamError) as exc:
         ASCIIHexDecode.decode("")
     assert exc.value.args[0] == "Unexpected EOD in ASCIIHexDecode"
@@ -146,9 +146,10 @@ def test_ASCII85Decode_with_overflow():
 def test_ASCII85Decode_five_zero_bytes():
     """
     From ISO 32000 (2008) §7.4.3:
-    «As a special case, if all five bytes are 0, they shall be represented
-    by the character with code 122 (z) instead of by five exclamation
-    points (!!!!!).»
+
+    «As a special case, if all five bytes are 0, they shall be represented by
+    the character with code 122 (z) instead of by five exclamation points
+    (!!!!!).»
     """
     inputs = ("z", "zz", "zzz")
     exp_outputs = (

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -464,7 +464,6 @@ def test_TextStringObject_autodetect_utf16():
 
 
 def test_remove_child_not_in_tree():
-
     tree = TreeObject()
     with pytest.raises(ValueError) as exc:
         tree.remove_child(ChildDummy())
@@ -472,7 +471,6 @@ def test_remove_child_not_in_tree():
 
 
 def test_remove_child_not_in_that_tree():
-
     tree = TreeObject()
     tree.indirect_reference = NullObject()
     child = TreeObject()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -82,8 +82,8 @@ def test_page_operations(pdf_path, password):
     """
     This test just checks if the operation throws an exception.
 
-    This should be done way more thoroughly: It should be checked if the
-    output is as expected.
+    This should be done way more thoroughly: It should be checked if the output
+    is as expected.
     """
     if pdf_path.startswith("http"):
         pdf_path = BytesIO(get_pdf_from_url(pdf_path, pdf_path.split("/")[-1]))
@@ -382,12 +382,12 @@ def test_extract_text_visitor_callbacks():
     This test uses GeoBase_NHNC1_Data_Model_UML_EN.pdf.
     It extracts the labels of package-boxes in Figure 2.
     It extracts the texts in table "REVISION HISTORY".
-
     """
     import logging
 
     class PositionedText:
-        """Specify a text with coordinates, font-dictionary and font-size.
+        """
+        Specify a text with coordinates, font-dictionary and font-size.
 
         The font-dictionary may be None in case of an unknown font.
         """
@@ -401,9 +401,11 @@ def test_extract_text_visitor_callbacks():
             self.font_size = font_size
 
         def get_base_font(self) -> str:
-            """Gets the base font of the text.
+            """
+            Gets the base font of the text.
 
-            Return UNKNOWN in case of an unknown font."""
+            Return UNKNOWN in case of an unknown font.
+            """
             if (self.font_dict is None) or "/BaseFont" not in self.font_dict:
                 return "UNKNOWN"
             return self.font_dict["/BaseFont"]
@@ -432,7 +434,8 @@ def test_extract_text_visitor_callbacks():
         Extracts texts and rectangles of a page of type pypdf._page.PageObject.
 
         This function supports simple coordinate transformations only.
-        The optional rect_filter-lambda can be used to filter wanted rectangles.
+        The optional rect_filter-lambda can be used to filter wanted
+        rectangles.
         rect_filter has Rectangle as argument and must return a boolean.
 
         It returns a tuple containing a list of extracted texts and

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -619,10 +619,8 @@ def test_get_destination_page_number():
 
 
 def test_do_not_get_stuck_on_large_files_without_start_xref():
-    """
-    Tests for the absence of a DoS bug, where a large file without an startxref
-    mark would cause the library to hang for minutes to hours
-    """
+    """Tests for the absence of a DoS bug, where a large file without an
+    startxref mark would cause the library to hang for minutes to hours."""
     start_time = time.time()
     broken_stream = BytesIO(b"\0" * 5 * 1000 * 1000)
     with pytest.raises(PdfReadError):
@@ -640,7 +638,6 @@ def test_decrypt_when_no_id():
 
     https://github.com/py-pdf/pypdf/issues/608
     """
-
     with open(RESOURCE_ROOT / "encrypted_doc_no_id.pdf", "rb") as inputfile:
         ipdf = PdfReader(inputfile)
         ipdf.decrypt("")
@@ -661,7 +658,7 @@ def test_reader_properties():
     [True, False],
 )
 def test_issue604(caplog, strict):
-    """Test with invalid destinations"""  # todo
+    """Test with invalid destinations."""  # todo
     with open(RESOURCE_ROOT / "issue-604.pdf", "rb") as f:
         pdf = None
         outline = None

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -80,10 +80,11 @@ def test_dropdown_items():
 
 def test_PdfReaderFileLoad():
     """
-    Test loading and parsing of a file. Extract text of the file and compare to expected
-    textual output. Expected outcome: file loads, text matches expected.
-    """
+    Test loading and parsing of a file.
 
+    Extract text of the file and compare to expected textual output. Expected
+    outcome: file loads, text matches expected.
+    """
     with open(RESOURCE_ROOT / "crazyones.pdf", "rb") as inputfile:
         # Load PDF file from file
         reader = PdfReader(inputfile)
@@ -112,7 +113,6 @@ def test_PdfReaderJpegImage():
 
     Expected outcome: file loads, image matches expected.
     """
-
     with open(RESOURCE_ROOT / "jpeg.pdf", "rb") as inputfile:
         # Load PDF file from file
         reader = PdfReader(inputfile)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -675,7 +675,6 @@ def test_add_link():
 
 def test_io_streams():
     """This is the example from the docs ("Streaming data")."""
-
     filepath = RESOURCE_ROOT / "pdflatex-outline.pdf"
     with open(filepath, "rb") as fh:
         bytes_stream = BytesIO(fh.read())
@@ -705,9 +704,7 @@ def test_regression_issue670():
 
 
 def test_issue301():
-    """
-    Test with invalid stream length object
-    """
+    """Test with invalid stream length object."""
     with open(RESOURCE_ROOT / "issue-301.pdf", "rb") as f:
         reader = PdfReader(f)
         writer = PdfWriter()
@@ -717,7 +714,7 @@ def test_issue301():
 
 
 def test_append_pages_from_reader_append():
-    """use append_pages_from_reader with a callable"""
+    """Use append_pages_from_reader with a callable."""
     with open(RESOURCE_ROOT / "issue-301.pdf", "rb") as f:
         reader = PdfReader(f)
         writer = PdfWriter()


### PR DESCRIPTION
See https://pypi.org/project/docformatter/

I tried pre-commit, but docformatter collides with black for docstrings of functions that contain a function:

```
-   repo: https://github.com/PyCQA/docformatter
    rev: v1.6.0.rc1
    hooks:
    -   id: docformatter
        name: Check docstring formatting
        args: [--in-place, --wrap-summaries=0, --wrap-descriptions=0, --pre-summary-newline]
```