### PR TITLE
DOC: fix typo on extract text page

### DIFF
--- a/docs/user/extract-text.md
+++ b/docs/user/extract-text.md
@@ -105,6 +105,7 @@ Unfortunately in complicated PDF documents the coordinates given to the visitor-
 ## Why Text Extraction is hard
 
 ### Unclear Objective
+
 Extracting text from a PDF can be pretty tricky. In several cases there is no
 clear answer what the expected result should look like:
 
@@ -162,7 +163,7 @@ Specifically, there is no information what the header, footer, page numbers,
 tables, and paragraphs are. The visual appearence is there and people might
 find heuristics to make educated guesses, but there is no way of being certain.
 
-This is a shortcomming of the PDF file format, not of pypdf.
+This is a shortcoming of the PDF file format, not of pypdf.
 
 It would be possible to apply machine learning on PDF documents to make good
 heuristics, but that will not be part of pypdf. However, pypdf could be used to
@@ -227,7 +228,6 @@ Hence I would distinguish three types of PDF documents:
   in the background of the image. Hence you can copy the text, but it still looks
   like a scan. If you zoom in enough, you can recognize pixels.
 
-
 ### Can we just always use OCR?
 
 You might now wonder if it makes sense to just always use OCR software. If the
@@ -245,8 +245,6 @@ comes to characters which are easy to confuse such as `oO0ö`.
 
 pypdf also has an edge when it comes to characters which are rare, e.g.
 🤰. OCR software will not be able to recognize smileys correctly.
-
-
 
 ## Attempts to prevent text extraction
 


### PR DESCRIPTION
`s/shortcomming/shortcoming/` - https://www.merriam-webster.com/dictionary/shortcoming

I also added / removed some spacing around headers so that there's a unified one space before and after all headers on the page.