### PR TITLE
BUG: Switch from trimbox to cropbox when merging pages

### DIFF
--- a/docs/user/cropping-and-transforming.md
+++ b/docs/user/cropping-and-transforming.md
@@ -191,3 +191,17 @@ writer = PdfWriter()
 writer.add_page(page)
 writer.write("out-pg-transform.pdf")
 ```
+
+### pypdf._page.MERGE_CROP_BOX
+
+`pypdf<=3.4.0` used to merge the other page with `trimbox`.
+
+`pypdf>3.4.0` changes this behavior to `cropbox`.
+
+In case anybody has good reasons to use/expect `trimbox`, please let me know via
+info@martin-thoma.de or via https://github.com/py-pdf/pypdf/pull/1622
+In the mean time, you can add the following code to get the old behavior:
+
+```python
+pypdf._page.MERGE_CROP_BOX = "trimbox"
+```

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -78,6 +78,7 @@ from .generic import (
 CUSTOM_RTL_MIN: int = -1
 CUSTOM_RTL_MAX: int = -1
 CUSTOM_RTL_SPECIAL_CHARS: List[int] = []
+MERGE_CROP_BOX = "cropbox"  # pypdf<=3.4.0 used 'trimbox'
 
 
 def set_custom_rtl(
@@ -844,7 +845,7 @@ class PageObject(DictionaryObject):
         page2content = page2.get_contents()
         if page2content is not None:
             page2content = ContentStream(page2content, self.pdf)
-            rect = page2.trimbox
+            rect = getattr(page2, MERGE_CROP_BOX)
             page2content.operations.insert(
                 0,
                 (
@@ -972,7 +973,7 @@ class PageObject(DictionaryObject):
         page2content = page2.get_contents()
         if page2content is not None:
             page2content = ContentStream(page2content, self.pdf)
-            rect = page2.trimbox
+            rect = getattr(page2, MERGE_CROP_BOX)
             page2content.operations.insert(
                 0,
                 (


### PR DESCRIPTION
@pubpub-zz Continuing our discussion from https://github.com/py-pdf/pypdf/pull/879 and #1426 :-)

I'm not sure if exposing this that prominently is a good idea or if we should simply change it... but allowing people to easily switch back would potentially enable people to still get the old behavior if they need to

I also don't know if `MERGE_CROP_BOX` is a good name for this attribute.