### PR TITLE
TST: Mark new external tests appropriately

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1090,6 +1090,7 @@ def test_merge_page_resources_smoke_test():
     assert relevant_operations == expected_operations
 
 
+@pytest.mark.external
 def test_merge_transformed_page_into_blank():
     url = "https://github.com/py-pdf/pypdf/files/10540507/visitcard.pdf"
     name = "visitcard.pdf"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -911,6 +911,7 @@ def test_append_forms():
     ) + len(reader2.get_form_text_fields())
 
 
+@pytest.mark.external
 def test_extra_test_iss1541():
     url = "https://github.com/py-pdf/pypdf/files/10418158/tst_iss1541.pdf"
     name = "tst_iss1541.pdf"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1154,6 +1154,7 @@ def test_set_page_label():
     os.remove(target)  # comment to see result
 
 
+@pytest.mark.external
 def test_iss1601():
     url = "https://github.com/py-pdf/pypdf/files/10579503/badges-38.pdf"
     name = "badge-38.pdf"
@@ -1177,6 +1178,7 @@ def test_iss1601():
     )
 
 
+@pytest.mark.external
 def test_iss1614():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10669995/broke.pdf"


### PR DESCRIPTION
It would be great if future tests could be marked appropriately, as they break the debian build daemons and CI, neither of which have direct access to the Internet.