### PR TITLE
ENH: Add reader.attachments public interface

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ You can contribute to `pypdf on GitHub <https://github.com/py-pdf/pypdf>`_.
    user/metadata
    user/extract-text
    user/extract-images
+   user/extract-attachments
    user/encryption-decryption
    user/merging-pdfs
    user/cropping-and-transforming

--- a/docs/user/extract-attachments.md
+++ b/docs/user/extract-attachments.md
@@ -1,0 +1,15 @@
+# Extract Attachments
+
+PDF documents can contain attachments. Attachments have a name, but it might not
+be unique.
+
+```python
+from pypdf import PdfReader
+
+reader = PdfReader("example.pdf")
+
+for name, attachment_loader in reader.attachments:
+    for i, content in enumerate(attachment_loader.reader()):
+        with open(f"{name}-{i}", "wb") as fp:
+            fp.write(content)
+```

--- a/docs/user/extract-attachments.md
+++ b/docs/user/extract-attachments.md
@@ -8,8 +8,8 @@ from pypdf import PdfReader
 
 reader = PdfReader("example.pdf")
 
-for name, attachment_loader in reader.attachments:
-    for i, content in enumerate(attachment_loader.reader()):
+for name, content_list in reader.attachments:
+    for i, content in enumerate(content_list):
         with open(f"{name}-{i}", "wb") as fp:
             fp.write(content)
 ```

--- a/docs/user/extract-attachments.md
+++ b/docs/user/extract-attachments.md
@@ -1,7 +1,10 @@
 # Extract Attachments
 
 PDF documents can contain attachments. Attachments have a name, but it might not
-be unique.
+be unique. For this reason, the value of `reader.attachments["attachment_name"]`
+is a list.
+
+You can extract all attachments like this:
 
 ```python
 from pypdf import PdfReader

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -2130,6 +2130,12 @@ class PdfReader:
         interim[NameObject("/T")] = TextStringObject(name)
         return interim
 
+    @property
+    def attachments(self) -> Dict[str, "LazyAttachmentLoader"]:
+        return {
+            name: LazyAttachmentLoader(name, self) for name in self._list_attachments()
+        }
+
     def _list_attachments(self) -> List[str]:
         """
         Retrieves the list of filenames of file attachments.
@@ -2202,6 +2208,18 @@ class PdfReader:
                 else:
                     attachments[name] = f_data
         return attachments
+
+
+class LazyAttachmentLoader:
+    def __init__(self, name: str, reader: PdfReader) -> None:
+        self.name = name
+        self._reader = reader
+
+    def read(self) -> List[bytes]:
+        out = self._reader._get_attachments(self.name)[self.name]
+        if isinstance(out, list):
+            return out
+        return [out]
 
 
 class PdfFileReader(PdfReader):  # deprecated

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -39,6 +39,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -2166,7 +2167,7 @@ class PdfReader:
                 attachments_names.append(f)
         return attachments_names
 
-    def _get_attachment_list(self, name) -> List[bytes]:
+    def _get_attachment_list(self, name: str) -> List[bytes]:
         out = self._get_attachments(name)[name]
         if isinstance(out, list):
             return out
@@ -2221,17 +2222,17 @@ class PdfReader:
 
 
 class LazyDict(Mapping):
-    def __init__(self, *args, **kw):
+    def __init__(self, *args: Any, **kw: Any) -> None:
         self._raw_dict = dict(*args, **kw)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         func, arg = self._raw_dict.__getitem__(key)
         return func(arg)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         return iter(self._raw_dict)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._raw_dict)
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1234,9 +1234,9 @@ def test_attachments():
     assert att["foobar2.txt"] == [b"foobarcontent2", b"2nd_foobarcontent"]
 
     # Let's do both cases with the public interface:
-    assert reader.attachments["foobar.txt"].read()[0] == b"foobarcontent"
-    assert reader.attachments["foobar2.txt"].read()[0] == b"foobarcontent2"
-    assert reader.attachments["foobar2.txt"].read()[1] == b"2nd_foobarcontent"
+    assert reader.attachments["foobar.txt"][0] == b"foobarcontent"
+    assert reader.attachments["foobar2.txt"][0] == b"foobarcontent2"
+    assert reader.attachments["foobar2.txt"][1] == b"2nd_foobarcontent"
 
 
 @pytest.mark.external


### PR DESCRIPTION
Add `PdfReader.attachments -> Dict[attachment_name, LazyLoader]` as a public interface.
`LazyLoader.read()` returns a list of bytes.

The heavy-lifting was done by @pubpub-zz  in #1611