### PR TITLE
BUG: Allow decryption with empty password for AlgV5

### DIFF
--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -82,6 +82,8 @@ try:
             return iv + aes.encrypt(data)
 
         def decrypt(self, data: bytes) -> bytes:
+            if len(data) == 0:
+                return data
             iv = data[:16]
             data = data[16:]
             aes = AES.new(self.key, AES.MODE_CBC, iv)


### PR DESCRIPTION
Fix bug "Incorrect IV length (it must be 16 bytes long) " due to len(data) == 0 on some encrypted PDF files.