### PR TITLE
STY: Ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,18 @@ ignore = [
     "D101",  # Missing docstring in public class
     "D102", # Missing docstring in public method
     "D103",  # Missing docstring in public function
-    "SLF001",
-    "PLR", "PTH123", "FBT", "PT", "N", "ARG", "TRY", "S", "EM", "RET", "TID",
+    "PLR2004", # Magic value
+    "PLR0913",  # Too many arguments to function call
+    "PLR0912", # Too many branches
+    "PLR0915", # Too many statements
+    "PLR0911",  # Too many return statements
+    "SLF001",  # Private member accessed
+    "FBT001", # Boolean positional arg in function definition
+    "FBT002", # Boolean default value in function definition
+    "FBT003", # Boolean positional value in function call
+    "PT011", # `pytest.raises(ValueError)` is too broad, set the `match`
+    "PT012",  # `pytest.raises()` block should contain a single simple statement
+    "PTH123", "N", "ARG", "TRY", "S", "EM", "RET", "TID",
     "C901", "PGH", "DTZ", "TCH", "B", "G", "BLE", "SIM", "E", "INP", "A", "RUF",
     "PLW", "PLE"
 ]

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -10,8 +10,8 @@ from pypdf.errors import PdfReadWarning
 from . import get_pdf_from_url
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_compute_space_width():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/923/923406.pdf"
     name = "tika-923406.pdf"
@@ -21,8 +21,8 @@ def test_compute_space_width():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_parse_to_unicode_process_rg():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/959/959173.pdf"
     name = "tika-959173.pdf"
@@ -36,7 +36,7 @@ def test_parse_to_unicode_process_rg():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_parse_encoding_advanced_encoding_not_implemented():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/957/957144.pdf"
     name = "tika-957144.pdf"
@@ -47,7 +47,7 @@ def test_parse_encoding_advanced_encoding_not_implemented():
             page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_get_font_width_from_default():  # L40
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/908/908104.pdf"
     name = "tika-908104.pdf"
@@ -56,7 +56,7 @@ def test_get_font_width_from_default():  # L40
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_multiline_bfrange():
     # non regression test for iss_1285
     url = (
@@ -77,7 +77,7 @@ def test_multiline_bfrange():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_bfchar_on_2_chars():
     # iss #1293
     url = (
@@ -90,7 +90,7 @@ def test_bfchar_on_2_chars():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_ascii_charset():
     # iss #1312
     url = "https://github.com/py-pdf/pypdf/files/9472500/main.pdf"
@@ -99,7 +99,7 @@ def test_ascii_charset():
     assert "/a" not in reader.pages[0].extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1370():
     url = "https://github.com/py-pdf/pypdf/files/9667138/cmap1370.pdf"
     name = "cmap1370.pdf"
@@ -107,7 +107,7 @@ def test_iss1370():
     reader.pages[0].extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1379():
     url = "https://github.com/py-pdf/pypdf/files/9712729/02voc.pdf"
     name = "02voc.pdf"
@@ -115,7 +115,7 @@ def test_iss1379():
     reader.pages[2].extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1533():
     url = "https://github.com/py-pdf/pypdf/files/10376149/iss1533.pdf"
     name = "iss1533.pdf"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -202,7 +202,7 @@ def test_CCITTFaxDecode():
     )
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @patch("pypdf._reader.logger_warning")
 def test_decompress_zlib_error(mock_logger_warning):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/952/952445.pdf"
@@ -215,18 +215,18 @@ def test_decompress_zlib_error(mock_logger_warning):
     )
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_lzw_decode_neg1():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/921/921632.pdf"
     name = "tika-921632.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    page = reader.pages[47]
     with pytest.raises(PdfReadError) as exc:
-        for page in reader.pages:
-            page.extract_text()
+        page.extract_text()
     assert exc.value.args[0] == "Missed the stop code in LZWDecode!"
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_issue_399():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/976/976970.pdf"
     name = "tika-976970.pdf"
@@ -234,7 +234,7 @@ def test_issue_399():
     reader.pages[1].extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_image_without_imagemagic():
     with patch.dict(sys.modules):
         sys.modules["PIL"] = None

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -583,7 +583,7 @@ def test_remove_child_in_tree():
     tree.empty_tree()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_dict_read_from_stream(caplog):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/984/984877.pdf"
     name = "tika-984877.pdf"
@@ -597,7 +597,7 @@ def test_dict_read_from_stream(caplog):
     )
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_parse_content_stream_peek_percentage():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/985/985770.pdf"
     name = "tika-985770.pdf"
@@ -607,7 +607,7 @@ def test_parse_content_stream_peek_percentage():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_read_inline_image_no_has_q():
     # pdf/df7e1add3156af17a372bc165e47a244.pdf
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/998/998719.pdf"
@@ -618,7 +618,7 @@ def test_read_inline_image_no_has_q():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_read_inline_image_loc_neg_1():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/935/935066.pdf"
     name = "tika-935066.pdf"
@@ -628,8 +628,8 @@ def test_read_inline_image_loc_neg_1():
         page.extract_text()
 
 
-@pytest.mark.slow
-@pytest.mark.enable_socket
+@pytest.mark.slow()
+@pytest.mark.enable_socket()
 def test_text_string_write_to_stream():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924562.pdf"
     name = "tika-924562.pdf"
@@ -639,7 +639,7 @@ def test_text_string_write_to_stream():
         page.compress_content_streams()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_name_object_read_from_stream_unicode_error():  # L588
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/974/974966.pdf"
     name = "tika-974966.pdf"
@@ -649,7 +649,7 @@ def test_name_object_read_from_stream_unicode_error():  # L588
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_bool_repr(tmp_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/932/932449.pdf"
     name = "tika-932449.pdf"
@@ -669,7 +669,7 @@ def test_bool_repr(tmp_path):
     )
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @patch("pypdf._reader.logger_warning")
 def test_issue_997(mock_logger_warning):
     url = (
@@ -1046,7 +1046,7 @@ def test_cloning(caplog):
     assert isinstance(obj21.get("/Test2"), IndirectObject)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_append_with_indirectobject_not_pointing(caplog):
     """
     reported in #1631

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -313,7 +313,7 @@ def test_merge_write_closed_fh_with_writer():
     Path("stream1.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_trim_outline_list():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/995/995175.pdf"
     name = "tika-995175.pdf"
@@ -327,7 +327,7 @@ def test_trim_outline_list():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_trim_outline_list_with_writer():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/995/995175.pdf"
     name = "tika-995175.pdf"
@@ -341,7 +341,7 @@ def test_trim_outline_list_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_zoom():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/994/994759.pdf"
     name = "tika-994759.pdf"
@@ -355,7 +355,7 @@ def test_zoom():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_zoom_with_writer():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/994/994759.pdf"
     name = "tika-994759.pdf"
@@ -369,7 +369,7 @@ def test_zoom_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_zoom_xyz_no_left():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/933/933322.pdf"
     name = "tika-933322.pdf"
@@ -383,7 +383,7 @@ def test_zoom_xyz_no_left():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_zoom_xyz_no_left_with_writer():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/933/933322.pdf"
     name = "tika-933322.pdf"
@@ -397,7 +397,7 @@ def test_zoom_xyz_no_left_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_outline_item():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/997/997511.pdf"
     name = "tika-997511.pdf"
@@ -411,8 +411,8 @@ def test_outline_item():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_outline_item_with_writer():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/997/997511.pdf"
     name = "tika-997511.pdf"
@@ -426,8 +426,8 @@ def test_outline_item_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_trim_outline():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/982/982336.pdf"
     name = "tika-982336.pdf"
@@ -441,8 +441,8 @@ def test_trim_outline():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_trim_outline_with_writer():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/982/982336.pdf"
     name = "tika-982336.pdf"
@@ -456,8 +456,8 @@ def test_trim_outline_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test1():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/923/923621.pdf"
     name = "tika-923621.pdf"
@@ -471,8 +471,8 @@ def test1():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test1_with_writer():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/923/923621.pdf"
     name = "tika-923621.pdf"
@@ -486,8 +486,8 @@ def test1_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_sweep_recursion1():
     # TODO: This test looks like an infinite loop.
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
@@ -505,8 +505,8 @@ def test_sweep_recursion1():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_sweep_recursion1_with_writer():
     # TODO: This test looks like an infinite loop.
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
@@ -524,8 +524,8 @@ def test_sweep_recursion1_with_writer():
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -554,8 +554,8 @@ def test_sweep_recursion2(url, name):
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -584,7 +584,7 @@ def test_sweep_recursion2_with_writer(url, name):
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_sweep_indirect_list_newobj_is_none(caplog):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/906/906769.pdf"
     name = "tika-906769.pdf"
@@ -602,7 +602,7 @@ def test_sweep_indirect_list_newobj_is_none(caplog):
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_sweep_indirect_list_newobj_is_none_with_writer(caplog):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/906/906769.pdf"
     name = "tika-906769.pdf"
@@ -620,7 +620,7 @@ def test_sweep_indirect_list_newobj_is_none_with_writer(caplog):
     Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1145():
     # issue with FitH destination with null param
     url = "https://github.com/py-pdf/pypdf/files/9164743/file-0.pdf"
@@ -630,7 +630,7 @@ def test_iss1145():
     merger.close()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1145_with_writer():
     # issue with FitH destination with null param
     url = "https://github.com/py-pdf/pypdf/files/9164743/file-0.pdf"
@@ -680,7 +680,7 @@ def test_deprecation_bookmark_decorator_output_with_writer():
         merger.merge(0, reader, import_bookmarks=True)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1344(caplog):
     url = "https://github.com/py-pdf/pypdf/files/9549001/input.pdf"
     name = "iss1344.pdf"
@@ -695,7 +695,7 @@ def test_iss1344(caplog):
     assert r.threads is None
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1344_with_writer(caplog):
     url = "https://github.com/py-pdf/pypdf/files/9549001/input.pdf"
     name = "iss1344.pdf"
@@ -708,7 +708,7 @@ def test_iss1344_with_writer(caplog):
     assert "adresse où le malade peut être visité" in p.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_articles_with_writer(caplog):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "924666.pdf"

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -44,7 +44,7 @@ def get_all_sample_files():
 all_files_meta = get_all_sample_files()
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 @pytest.mark.parametrize(
     "meta",
     [m for m in all_files_meta["data"] if not m["encrypted"]],
@@ -61,8 +61,8 @@ def test_read(meta):
     assert len(reader.pages) == meta["pages"]
 
 
-@pytest.mark.samples
-@pytest.mark.enable_socket
+@pytest.mark.samples()
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("pdf_path", "password"),
     [
@@ -203,7 +203,7 @@ def compare_dict_objects(d1, d2):
             assert d1[k] == d2[k]
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_page_transformations():
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -278,12 +278,10 @@ def test_page_rotation():
     # test transfer_rotate_to_content
     page.rotation -= 90
     page.transfer_rotation_to_content()
-    assert (
-        abs(float(page.mediabox.left) - 0) < 0.1
-        and abs(float(page.mediabox.bottom) - 0) < 0.1
-        and abs(float(page.mediabox.right) - 792) < 0.1
-        and abs(float(page.mediabox.top) - 612) < 0.1
-    )
+    assert abs(float(page.mediabox.left) - 0) < 0.1
+    assert abs(float(page.mediabox.bottom) - 0) < 0.1
+    assert abs(float(page.mediabox.right) - 792) < 0.1
+    assert abs(float(page.mediabox.top) - 612) < 0.1
 
 
 def test_page_indirect_rotation():
@@ -335,7 +333,7 @@ def test_multi_language():
     set_custom_rtl(-1, -1, [])  # to prevent further errors
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_extract_text_single_quote_op():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/964/964029.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name="tika-964029.pdf")))
@@ -343,7 +341,7 @@ def test_extract_text_single_quote_op():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_no_ressources_on_text_extract():
     url = "https://github.com/py-pdf/pypdf/files/9428434/TelemetryTX_EM.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name="tika-964029.pdf")))
@@ -351,7 +349,7 @@ def test_no_ressources_on_text_extract():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss_1142():
     # check fix for problem of context save/restore (q/Q)
     url = "https://github.com/py-pdf/pypdf/files/9150656/ST.2019.PDF"
@@ -369,8 +367,8 @@ def test_iss_1142():
     assert txt.find("郑州分公司") > 0
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -402,8 +400,8 @@ def test_extract_text_page_pdf(url, name):
         page.extract_text()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_extract_text_page_pdf_impossible_decode_xform(caplog):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972962.pdf"
     name = "tika-972962.pdf"
@@ -414,8 +412,8 @@ def test_extract_text_page_pdf_impossible_decode_xform(caplog):
     assert warn_msgs == [""]  # text extraction recognise no text
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_extract_text_operator_t_star():  # L1266, L1267
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/967/967943.pdf"
     name = "tika-967943.pdf"
@@ -860,7 +858,7 @@ def test_annotation_setter():
     Path(target).unlink()  # remove for testing
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.xfail(reason="#1091")
 def test_text_extraction_issue_1091():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/966/966635.pdf"
@@ -872,7 +870,7 @@ def test_text_extraction_issue_1091():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_empyt_password_1088():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/941/941536.pdf"
     name = "tika-941536.pdf"
@@ -881,17 +879,17 @@ def test_empyt_password_1088():
     len(reader.pages)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_old_habibi():
     # this habibi has som multiple characters associated with the h
     reader = PdfReader(SAMPLE_ROOT / "015-arabic/habibi.pdf")
     txt = reader.pages[0].extract_text()  # very odd file
-    assert (
-        "habibi" in txt and "حَبيبي" in txt
-    )  # extract from acrobat reader "حَبيبي habibi􀀃􀏲􀎒􀏴􀎒􀎣􀋴
+    # extract from acrobat reader "حَبيبي habibi􀀃􀏲􀎒􀏴􀎒􀎣􀋴
+    assert "habibi" in txt
+    assert "حَبيبي" in txt
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 def test_read_link_annotation():
     reader = PdfReader(SAMPLE_ROOT / "016-libre-office-link/libre-office-link.pdf")
     assert len(reader.pages[0].annotations) == 1
@@ -921,7 +919,7 @@ def test_read_link_annotation():
     assert annot == expected
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_no_resources():
     url = "https://github.com/py-pdf/pypdf/files/9572045/108.pdf"
     name = "108.pdf"
@@ -1094,7 +1092,7 @@ def test_merge_page_resources_smoke_test():
     assert relevant_operations == expected_operations
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_merge_transformed_page_into_blank():
     url = "https://github.com/py-pdf/pypdf/files/10768334/badges_3vjrh_7LXDZ_1-1.pdf"
     name = "badges_3vjrh_7LXDZ_1.pdf"

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -68,7 +68,7 @@ def test_number2uppercase_letter():
         number2uppercase_letter(-1)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_index2label(caplog):
     url = "https://github.com/py-pdf/pypdf/files/10773829/waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf"
     name = "waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf"

--- a/tests/test_pagerange.py
+++ b/tests/test_pagerange.py
@@ -82,7 +82,7 @@ def test_parse_filename_page_ranges_err():
 
 
 @pytest.mark.parametrize(
-    "a, b, expected",
+    ("a", "b", "expected"),
     [
         (PageRange(slice(0, 5)), PageRange(slice(2, 10)), slice(0, 10)),
         (PageRange(slice(0, 5)), PageRange(slice(2, 3)), slice(0, 5)),
@@ -97,7 +97,7 @@ def test_addition(a, b, expected):
 
 
 @pytest.mark.parametrize(
-    "a, b",
+    ("a", "b"),
     [
         (PageRange(slice(0, 5)), PageRange(slice(7, 10))),
         (PageRange(slice(7, 10)), PageRange(slice(0, 5))),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -110,7 +110,7 @@ def test_read_metadata(pdf_path, expected):
             assert metadict["/Title"] == docinfo.title
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 @pytest.mark.parametrize(
     "pdf_path", [SAMPLE_ROOT / "017-unreadable-meta-data/unreadablemetadata.pdf"]
 )
@@ -179,7 +179,7 @@ def test_get_outline(src, outline_elements):
     assert len(outline) == outline_elements
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 @pytest.mark.parametrize(
     ("src", "expected_images"),
     [
@@ -633,7 +633,7 @@ def test_do_not_get_stuck_on_large_files_without_start_xref():
     assert parse_duration < 60
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_decrypt_when_no_id():
     """
     Decrypt an encrypted file that's missing the 'ID' value in its trailer.
@@ -755,7 +755,7 @@ def test_convertToInt_deprecated():
         assert convertToInt(b"\x01", 8) == 1
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss925():
     url = "https://github.com/py-pdf/pypdf/files/8796328/1.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name="iss925.pdf")))
@@ -811,7 +811,7 @@ def test_read_not_binary_mode(caplog):
     assert normalize_warnings(caplog.text) == [msg]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.skipif(not HAS_PYCRYPTODOME, reason="No pycryptodome")
 def test_read_form_416():
     url = (
@@ -850,7 +850,7 @@ def test_form_topname_with_and_without_acroform(caplog):
     assert "have a non-expected parent" in caplog.text
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_extract_text_xref_issue_2(caplog):
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/981/981961.pdf"
@@ -861,8 +861,8 @@ def test_extract_text_xref_issue_2(caplog):
     assert normalize_warnings(caplog.text) == [msg]
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_extract_text_xref_issue_3(caplog):
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/977/977774.pdf"
@@ -873,7 +873,7 @@ def test_extract_text_xref_issue_3(caplog):
     assert normalize_warnings(caplog.text) == [msg]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_extract_text_pdf15():
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/976/976030.pdf"
@@ -882,7 +882,7 @@ def test_extract_text_pdf15():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_extract_text_xref_table_21_bytes_clrf():
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/956/956939.pdf"
@@ -891,7 +891,7 @@ def test_extract_text_xref_table_21_bytes_clrf():
         page.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_get_fields():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972486.pdf"
     name = "tika-972486.pdf"
@@ -902,7 +902,7 @@ def test_get_fields():
     assert dict(fields["c1-1"]) == ({"/FT": "/Btn", "/T": "c1-1"})
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_get_full_qualified_fields():
     url = "https://github.com/py-pdf/pypdf/files/10142389/fields_with_dots.pdf"
     name = "fields_with_dots.pdf"
@@ -922,7 +922,7 @@ def test_get_full_qualified_fields():
     assert fields["customer.name"]["/T"] == "name"
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.filterwarnings("ignore::pypdf.errors.PdfReadWarning")
 def test_get_fields_read_else_block():
     # covers also issue 1089
@@ -931,7 +931,7 @@ def test_get_fields_read_else_block():
     PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_get_fields_read_else_block2():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/914/914902.pdf"
     name = "tika-914902.pdf"
@@ -940,7 +940,7 @@ def test_get_fields_read_else_block2():
     assert fields is None
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.filterwarnings("ignore::pypdf.errors.PdfReadWarning")
 def test_get_fields_read_else_block3():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/957/957721.pdf"
@@ -948,7 +948,7 @@ def test_get_fields_read_else_block3():
     PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_metadata_is_none():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/963/963692.pdf"
     name = "tika-963692.pdf"
@@ -956,7 +956,7 @@ def test_metadata_is_none():
     assert reader.metadata is None
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_get_fields_read_write_report():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/909/909655.pdf"
     name = "tika-909655.pdf"
@@ -981,7 +981,7 @@ def test_xfa(src):
     assert reader.xfa is None
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_xfa_non_empty():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/942/942050.pdf"
     name = "tika-942050.pdf"
@@ -997,7 +997,7 @@ def test_xfa_non_empty():
 
 
 @pytest.mark.parametrize(
-    "src,pdf_header",
+    ("src", "pdf_header"),
     [
         (RESOURCE_ROOT / "attachment.pdf", "%PDF-1.5"),
         (RESOURCE_ROOT / "crazyones.pdf", "%PDF-1.5"),
@@ -1009,7 +1009,7 @@ def test_header(src, pdf_header):
     assert reader.pdf_header == pdf_header
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_outline_color():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
     name = "tika-924546.pdf"
@@ -1017,7 +1017,7 @@ def test_outline_color():
     assert reader.outline[0].color == [0, 0, 1]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_outline_font_format():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
     name = "tika-924546.pdf"
@@ -1038,7 +1038,7 @@ def get_outline_property(outline, attribute_name: str):
     return results
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 def test_outline_title_issue_1121():
     reader = PdfReader(SAMPLE_ROOT / "014-outlines/mistitled_outlines_example.pdf")
 
@@ -1085,7 +1085,7 @@ def test_outline_title_issue_1121():
     ]
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 def test_outline_count():
     reader = PdfReader(SAMPLE_ROOT / "014-outlines/mistitled_outlines_example.pdf")
 
@@ -1144,7 +1144,7 @@ def test_outline_missing_title(caplog):
     assert reader.outline[0]["/Title"] == ""
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_named_destination():
     # 1st case : the named_dest are stored directly as a dictionnary, PDF1.1 style
     url = "https://github.com/py-pdf/pypdf/files/9197028/lorem_ipsum.pdf"
@@ -1163,7 +1163,7 @@ def test_named_destination():
     # TODO : case to be added
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_outline_with_missing_named_destination():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/913/913678.pdf"
     name = "tika-913678.pdf"
@@ -1172,7 +1172,7 @@ def test_outline_with_missing_named_destination():
     assert reader.outline[1][0].title.startswith("Report for 2002AZ3B: Microbial")
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_outline_with_empty_action():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
     name = "tika-924546.pdf"
@@ -1189,7 +1189,7 @@ def test_outline_with_invalid_destinations():
     assert len(reader.outline) == 9
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_PdfReaderMultipleDefinitions(caplog):
     # iss325
     url = "https://github.com/py-pdf/pypdf/files/9176644/multipledefs.pdf"
@@ -1215,7 +1215,7 @@ def test_get_page_number_by_indirect():
     reader._get_page_number_by_indirect(1)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_corrupted_xref_table():
     # issue #1292
     url = "https://github.com/py-pdf/pypdf/files/9444747/BreezeManual.orig.pdf"
@@ -1228,7 +1228,7 @@ def test_corrupted_xref_table():
     reader.pages[0].extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_reader(caplog):
     # iss #1273
     url = "https://github.com/py-pdf/pypdf/files/9464742/shiv_resume.pdf"
@@ -1246,7 +1246,7 @@ def test_reader(caplog):
     assert caplog.text == ""
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_zeroing_xref():
     # iss #328
     url = (
@@ -1258,7 +1258,7 @@ def test_zeroing_xref():
     len(reader.pages)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_thread():
     url = (
         "https://github.com/py-pdf/pypdf/files/9066120/"
@@ -1274,7 +1274,7 @@ def test_thread():
     assert len(reader.threads) >= 1
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_build_outline_item(caplog):
     url = "https://github.com/py-pdf/pypdf/files/9464742/shiv_resume.pdf"
     name = "shiv_resume.pdf"
@@ -1302,7 +1302,7 @@ def test_build_outline_item(caplog):
     assert "Unexpected destination 2" in exc.value.args[0]
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 @pytest.mark.parametrize(
     ("src", "page_labels"),
     [
@@ -1326,7 +1326,7 @@ def test_page_labels(src, page_labels):
     assert PdfReader(src).page_labels[:max_indices] == page_labels[:max_indices]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1559():
     url = "https://github.com/py-pdf/pypdf/files/10441992/default.pdf"
     name = "iss1559.pdf"
@@ -1335,7 +1335,7 @@ def test_iss1559():
         p.extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1652():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10818844/tt.pdf"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -238,7 +238,7 @@ def test_deprecation_bookmark():
     assert exc.value.args[0] == expected_msg
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_escapedcode_followed_by_int():
     # iss #1294
     url = (

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -178,8 +178,8 @@ def test_rotate_45():
         assert exc.value.args[0] == "Rotation angle must be a multiple of 90"
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("enable", "url", "pages"),
     [
@@ -260,7 +260,7 @@ def test_extract_textbench(enable, url, pages, print_result=False):
         pass
 
 
-@pytest.mark.slow
+@pytest.mark.slow()
 def test_orientations():
     p = PdfReader(RESOURCE_ROOT / "test Orient.pdf").pages[0]
     with pytest.warns(DeprecationWarning):
@@ -301,8 +301,8 @@ def test_orientations():
         ), f"extract_text({req}) => {rst}"
 
 
-@pytest.mark.samples
-@pytest.mark.enable_socket
+@pytest.mark.samples()
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("base_path", "overlay_path"),
     [
@@ -337,8 +337,8 @@ def test_overlay(base_path, overlay_path):
     Path("dont_commit_overlay.pdf").unlink()  # remove for manual inspection
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -357,7 +357,7 @@ def test_merge_with_warning(tmp_path, url, name):
     merger.write(tmp_path / "tmp.merged.pdf")
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -375,7 +375,7 @@ def test_merge(tmp_path, url, name):
     merger.write(tmp_path / "tmp.merged.pdf")
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -391,7 +391,7 @@ def test_get_metadata(url, name):
     reader.metadata
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name", "strict", "exception"),
     [
@@ -477,7 +477,7 @@ def test_extract_text(url, name, strict, exception):
         assert ex_info.value.args[0] == exc_text
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -499,8 +499,8 @@ def test_compress_raised(url, name):
         page.compress_content_streams()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("url", "name", "strict"),
     [
@@ -530,7 +530,7 @@ def test_compress(url, name, strict):
         page.compress_content_streams()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -551,7 +551,7 @@ def test_get_fields_warns(tmp_path, caplog, url, name):
     assert normalize_warnings(caplog.text) == ["Object 2 0 not defined."]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -571,7 +571,7 @@ def test_get_fields_no_warning(tmp_path, url, name):
     assert len(retrieved_fields) == 10
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_scale_rectangle_indirect_object():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/999/999944.pdf"
     name = "tika-999944.pdf"
@@ -604,15 +604,15 @@ def test_merge_output(caplog):
         expected_data = fp.read()
     if actual != expected_data:
         # See https://github.com/pytest-dev/pytest/issues/9124
-        assert (
-            False
-        ), f"len(actual) = {len(actual):,} vs len(expected) = {len(expected_data):,}"
+        pytest.fail(
+            f"len(actual) = {len(actual):,} vs len(expected) = {len(expected_data):,}"
+        )
 
     # Cleanup
     merger.close()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -683,7 +683,7 @@ def test_image_extraction(url, name):
                 Path(filepath).unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_image_extraction_strict():
     # Emits log messages
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/914/914102.pdf"
@@ -711,7 +711,7 @@ def test_image_extraction_strict():
                 Path(filepath).unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -745,7 +745,7 @@ def test_image_extraction2(url, name):
                 Path(filepath).unlink()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -765,7 +765,7 @@ def test_get_outline(url, name):
     reader.outline
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -785,7 +785,7 @@ def test_get_xfa(url, name):
     reader.xfa
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name", "strict"),
     [
@@ -818,7 +818,7 @@ def test_get_fonts(url, name, strict):
         page._get_fonts()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name", "strict"),
     [
@@ -876,7 +876,7 @@ def test_get_xmp(url, name, strict):
         xmp_info.custom_properties
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_tounicode_is_identity():
     url = "https://github.com/py-pdf/pypdf/files/9998335/FP_Thesis.pdf"
     name = "FP_Thesis.pdf"
@@ -885,7 +885,7 @@ def test_tounicode_is_identity():
     reader.pages[0].extract_text()
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_append_forms():
     # from #1538
     writer = PdfWriter()
@@ -910,7 +910,7 @@ def test_append_forms():
     ) + len(reader2.get_form_text_fields())
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_extra_test_iss1541():
     url = "https://github.com/py-pdf/pypdf/files/10418158/tst_iss1541.pdf"
     name = "tst_iss1541.pdf"
@@ -943,7 +943,7 @@ def test_extra_test_iss1541():
     assert exc.value.args[0] == "Unexpected end of stream"
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_fields_returning_stream():
     """This problem was reported in #424"""
     url = "https://github.com/mstamy2/PyPDF2/files/1948267/Simple.form.pdf"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -284,10 +284,10 @@ def test_writer_operation_by_new_usage(write_data_here, needs_cleanup):
 
 
 @pytest.mark.parametrize(
-    ("input_path",),
+    "input_path",
     [
-        ("side-by-side-subfig.pdf",),
-        ("reportlab-inline-image.pdf",),
+        "side-by-side-subfig.pdf",
+        "reportlab-inline-image.pdf",
     ],
 )
 def test_remove_images(input_path):
@@ -316,10 +316,10 @@ def test_remove_images(input_path):
 
 
 @pytest.mark.parametrize(
-    ("input_path",),
+    "input_path",
     [
-        ("side-by-side-subfig.pdf",),
-        ("reportlab-inline-image.pdf",),
+        "side-by-side-subfig.pdf",
+        "reportlab-inline-image.pdf",
     ],
 )
 def test_remove_text(input_path):
@@ -725,8 +725,8 @@ def test_append_pages_from_reader_append():
         writer.write(o)
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 def test_sweep_indirect_references_nullobject_exception():
     # TODO: Check this more closely... this looks weird
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
@@ -741,8 +741,8 @@ def test_sweep_indirect_references_nullobject_exception():
     Path(tmp_file).unlink()
 
 
-@pytest.mark.enable_socket
-@pytest.mark.slow
+@pytest.mark.enable_socket()
+@pytest.mark.slow()
 @pytest.mark.parametrize(
     ("url", "name"),
     [
@@ -819,7 +819,7 @@ def test_write_dict_stream_object():
             assert str(v.get_object()) == str(stream_object)
             break
     else:
-        assert False, "/Test not found"
+        pytest.fail("/Test not found")
 
     # Check that every key in _idnum_hash is correct
     objects_hash = [o.hash_value() for o in writer._objects]
@@ -875,7 +875,7 @@ def test_deprecation_bookmark_decorator():
         writer.add_outline_item_dict(bookmark=outline_item)
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 def test_colors_in_outline_item():
     reader = PdfReader(SAMPLE_ROOT / "004-pdflatex-4-pages/pdflatex-4-pages.pdf")
     writer = PdfWriter()
@@ -898,7 +898,7 @@ def test_colors_in_outline_item():
     Path(target).unlink()  # comment out for testing
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 def test_write_empty_stream():
     reader = PdfReader(SAMPLE_ROOT / "004-pdflatex-4-pages/pdflatex-4-pages.pdf")
     writer = PdfWriter()
@@ -950,7 +950,7 @@ def test_startup_dest():
     pdf_file_writer.open_destination = None
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss471():
     url = "https://github.com/py-pdf/pypdf/files/9139245/book.pdf"
     name = "book_471.pdf"
@@ -963,7 +963,7 @@ def test_iss471():
     )
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_reset_translation():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"
@@ -999,7 +999,7 @@ def test_threads_empty():
     assert thr == thr2
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_append_without_annots_and_articles():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"
@@ -1018,7 +1018,7 @@ def test_append_without_annots_and_articles():
     assert len(writer.threads) >= 1
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_append_multiple():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"
@@ -1033,7 +1033,7 @@ def test_append_multiple():
     assert pages[-1] not in pages[0:-1]  # page not repeated
 
 
-@pytest.mark.samples
+@pytest.mark.samples()
 def test_set_page_label():
     src = RESOURCE_ROOT / "GeoBase_NHNC1_Data_Model_UML_EN.pdf"  # File without labels
     target = "pypdf-output.pdf"
@@ -1174,7 +1174,7 @@ def test_set_page_label():
     Path(target).unlink()  # comment to see result
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1601():
     url = "https://github.com/py-pdf/pypdf/files/10579503/badges-38.pdf"
     name = "badge-38.pdf"
@@ -1243,7 +1243,7 @@ def test_attachments():
     assert reader.attachments["foobar2.txt"][1] == b"2nd_foobarcontent"
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_iss1614():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10669995/broke.pdf"
@@ -1258,7 +1258,7 @@ def test_iss1614():
     out_pdf.append(in_pdf)
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_new_removes():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10807951/tt.pdf"

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -88,7 +88,7 @@ def test_identity(x):
     assert pypdf.xmp._identity(x) == x
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 @pytest.mark.parametrize(
     ("url", "name", "xmpmm_instance_id"),
     [
@@ -107,7 +107,7 @@ def test_xmpmm(url, name, xmpmm_instance_id):
     assert xmp_metadata.xmpmm_instance_id == xmpmm_instance_id
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_dc_description():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/953/953770.pdf"
     name = "tika-953770.pdf"
@@ -122,7 +122,7 @@ def test_dc_description():
     }
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_dc_creator():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/953/953770.pdf"
     name = "tika-953770.pdf"
@@ -133,7 +133,7 @@ def test_dc_creator():
     assert xmp_metadata.dc_creator == ["U.S. Fish and Wildlife Service"]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_custom_properties():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/986/986065.pdf"
     name = "tika-986065.pdf"
@@ -144,7 +144,7 @@ def test_custom_properties():
     assert xmp_metadata.custom_properties == {"Style": "Searchable Image (Exact)"}
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_dc_subject():
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/959/959519.pdf"
     name = "tika-959519.pdf"
@@ -175,7 +175,7 @@ def test_dc_subject():
     ]
 
 
-@pytest.mark.enable_socket
+@pytest.mark.enable_socket()
 def test_issue585():
     url = "https://github.com/py-pdf/pypdf/files/5536984/test.pdf"
     name = "pypdf-5536984.pdf"


### PR DESCRIPTION
* Use parenthesis for pytest markers: `@pytest.mark.slow` ->  `@pytest.mark.slow()`
* Make `pytest.raises` blocks smaller
* Make assert statements smaller
* Use [pytest.fail](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-fail) instead of `assert False`