### PR TITLE
Prevent infinite loop while scanning whitespace

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -150,6 +150,8 @@ def skip_over_whitespace(stream: StreamType) -> bool:
     cnt = 0
     while tok in WHITESPACES:
         tok = stream.read(1)
+        if tok == b"":
+            raise Exception("unexpected end of file")
         cnt += 1
     return cnt > 1
 
@@ -160,6 +162,8 @@ def skip_over_comment(stream: StreamType) -> None:
     if tok == b"%":
         while tok not in (b"\n", b"\r"):
             tok = stream.read(1)
+            if tok == b"":
+                raise Exception("unexpected end of file")
 
 
 def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -132,6 +132,8 @@ def read_non_whitespace(stream: StreamType) -> bytes:
     tok = stream.read(1)
     while tok in WHITESPACES:
         tok = stream.read(1)
+        if tok == b"":
+            raise Exception("unexpected end of file")
     return tok
 
 


### PR DESCRIPTION
Issue number #1693

I failed to construct a pdf that exploits this. First noticed the issue in pyHanko that maintains a heavily modified for of this lib.