### PR TITLE
BUG: Pass logging parameters correctly in set_need_appearances_writer

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -323,7 +323,7 @@ class PdfWriter:
             need_appearances = NameObject(InteractiveFormDictEntries.NeedAppearances)
             self._root_object[CatalogDictionary.ACRO_FORM][need_appearances] = BooleanObject(True)  # type: ignore
         except Exception as exc:
-            logger.error("set_need_appearances_writer() catch : ", repr(exc))
+            logger.error("set_need_appearances_writer() catch : %s", repr(exc))
 
     def add_page(
         self,


### PR DESCRIPTION
Without this, the logging module logs another error: TypeError: not all arguments converted during string formatting