### PR TITLE
ROB: Accept DictionaryObject in /D of NamedDestination

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -778,6 +778,8 @@ class PdfReader:
         else:  # case where Dests is in root catalog (PDF 1.7 specs, §2 about PDF1.1
             for k__, v__ in tree.items():
                 val = v__.get_object()
+                if isinstance(val, DictionaryObject):
+                    val = val["/D"].get_object()
                 dest = self._build_destination(k__, val)
                 if dest is not None:
                     retval[k__] = dest

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1350,3 +1350,11 @@ def test_iss1689():
     name = "iss1689.pdf"
     in_pdf = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     in_pdf.pages[0]
+
+
+@pytest.mark.enable_socket()
+def test_iss1710():
+    url = "https://nlp.stanford.edu/IR-book/pdf/irbookonlinereading.pdf"
+    name = "irbookonlinereading.pdf"
+    in_pdf = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    in_pdf.outline


### PR DESCRIPTION
accepts destination stored in "/D" of a dictionaryObject in accordance with §2 page 584

fixes #1710