### PR TITLE
TST: Use fixtures to create files in temporary folders

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -778,11 +778,7 @@ class PdfWriter:
                 cast(DictionaryObject, parent["/Parent"])
             )
             if qualified_parent is not None:
-                return (
-                    qualified_parent
-                    + "."
-                    + cast(str, parent["/T"])
-                )
+                return qualified_parent + "." + cast(str, parent["/T"])
         return cast(str, parent["/T"])
 
     def update_page_form_field_values(
@@ -2728,8 +2724,6 @@ class PdfWriter:
 
         if "/B" not in excluded_fields:
             self.add_filtered_articles("", srcpages, reader)
-
-        return
 
     def _add_articles_thread(
         self,

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -754,7 +754,6 @@ class StreamObject(DictionaryObject):
         except Exception:
             pass
         super()._clone(src, pdf_dest, force_duplicate, ignore_fields)
-        return
 
     def hash_value_data(self) -> bytes:
         data = super().hash_value_data()
@@ -986,7 +985,6 @@ class ContentStream(DecodedStreamObject):
         self.forced_encoding = cast("ContentStream", src).forced_encoding
         # no need to call DictionaryObjection or anything
         # like super(DictionaryObject,self)._clone(src, pdf_dest, force_duplicate, ignore_fields)
-        return
 
     def __parse_content_stream(self, stream: StreamType) -> None:
         stream.seek(0, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,9 @@ import pytest
 def pdf_file_path(tmp_path_factory):
     fn = tmp_path_factory.mktemp("pypdf-data") / f"{uuid.uuid4()}.pdf"
     return fn
+
+
+@pytest.fixture(scope="session")
+def txt_file_path(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("pypdf-data") / f"{uuid.uuid4()}.txt"
+    return fn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Fixtures that are available automatically for all tests."""
+
+import uuid
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def pdf_file_path(tmp_path_factory):
+    fn = tmp_path_factory.mktemp("pypdf-data") / f"{uuid.uuid4()}.pdf"
+    return fn

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -678,7 +678,7 @@ def test_bool_repr(tmp_path):
 
 @pytest.mark.enable_socket()
 @patch("pypdf._reader.logger_warning")
-def test_issue_997(mock_logger_warning):
+def test_issue_997(mock_logger_warning, pdf_file_path):
     url = (
         "https://github.com/py-pdf/pypdf/files/8908874/"
         "Exhibit_A-2_930_Enterprise_Zone_Tax_Credits_final.pdf"
@@ -686,9 +686,8 @@ def test_issue_997(mock_logger_warning):
     name = "gh-issue-997.pdf"
 
     merger = PdfMerger()
-    merged_filename = "tmp-out.pdf"
     merger.append(BytesIO(get_pdf_from_url(url, name=name)))  # here the error raises
-    with open(merged_filename, "wb") as f:
+    with open(pdf_file_path, "wb") as f:
         merger.write(f)
     merger.close()
 
@@ -696,21 +695,17 @@ def test_issue_997(mock_logger_warning):
 
     # Strict
     merger = PdfMerger(strict=True)
-    merged_filename = "tmp-out.pdf"
     with pytest.raises(PdfReadError) as exc:
         merger.append(
             BytesIO(get_pdf_from_url(url, name=name))
         )  # here the error raises
     assert exc.value.args[0] == "Could not find object."
-    with open(merged_filename, "wb") as f:
+    with open(pdf_file_path, "wb") as f:
         merger.write(f)
     merger.close()
 
-    # cleanup
-    Path(merged_filename).unlink()
 
-
-def test_annotation_builder_free_text():
+def test_annotation_builder_free_text(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -746,14 +741,11 @@ def test_annotation_builder_free_text():
     writer.add_annotation(0, free_text_annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_polygon():
+def test_annotation_builder_polygon(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -774,14 +766,11 @@ def test_annotation_builder_polygon():
     writer.add_annotation(0, annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_polyline():
+def test_annotation_builder_polyline(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -802,14 +791,11 @@ def test_annotation_builder_polyline():
     writer.add_annotation(0, annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_line():
+def test_annotation_builder_line(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -827,14 +813,11 @@ def test_annotation_builder_line():
     writer.add_annotation(0, line_annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_square():
+def test_annotation_builder_square(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -854,14 +837,11 @@ def test_annotation_builder_square():
     writer.add_annotation(0, square_annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf-square.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_circle():
+def test_annotation_builder_circle(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -882,14 +862,11 @@ def test_annotation_builder_circle():
     writer.add_annotation(0, circle_annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf-circle.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_link():
+def test_annotation_builder_link(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "outline-without-title.pdf"
     reader = PdfReader(pdf_path)
@@ -940,14 +917,11 @@ def test_annotation_builder_link():
         writer.add_page(page)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf-link.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
-    Path(target).unlink()  # comment this out for manual inspection
 
-
-def test_annotation_builder_text():
+def test_annotation_builder_text(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "outline-without-title.pdf"
     reader = PdfReader(pdf_path)
@@ -964,11 +938,8 @@ def test_annotation_builder_text():
     writer.add_annotation(0, text_annotation)
 
     # Assert: You need to inspect the file manually
-    target = "annotated-pdf-popup.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
-
-    Path(target).unlink()  # comment this out for manual inspection
 
 
 def test_checkboxradiobuttonattributes_opt():

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -298,19 +298,17 @@ def test_merge_write_closed_fh():
     assert exc.value.args[0] == err_closed
 
 
-def test_merge_write_closed_fh_with_writer():
+def test_merge_write_closed_fh_with_writer(pdf_file_path):
     merger = pypdf.PdfWriter()
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     merger.append(pdf_path)
 
     merger.close()
-    merger.write("stream1.pdf")
+    merger.write(pdf_file_path)
     merger.add_metadata({"author": "Martin Thoma"})
     merger.set_page_layout("/SinglePage")
     merger.set_page_mode("/UseNone")
     merger.add_outline_item("An outline item", 0)
-
-    Path("stream1.pdf").unlink()
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -314,214 +314,172 @@ def test_merge_write_closed_fh_with_writer():
 
 
 @pytest.mark.enable_socket()
-def test_trim_outline_list():
+def test_trim_outline_list(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/995/995175.pdf"
     name = "tika-995175.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_trim_outline_list_with_writer():
+def test_trim_outline_list_with_writer(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/995/995175.pdf"
     name = "tika-995175.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_zoom():
+def test_zoom(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/994/994759.pdf"
     name = "tika-994759.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_zoom_with_writer():
+def test_zoom_with_writer(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/994/994759.pdf"
     name = "tika-994759.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_zoom_xyz_no_left():
+def test_zoom_xyz_no_left(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/933/933322.pdf"
     name = "tika-933322.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_zoom_xyz_no_left_with_writer():
+def test_zoom_xyz_no_left_with_writer(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/933/933322.pdf"
     name = "tika-933322.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_outline_item():
+def test_outline_item(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/997/997511.pdf"
     name = "tika-997511.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test_outline_item_with_writer():
+def test_outline_item_with_writer(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/997/997511.pdf"
     name = "tika-997511.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test_trim_outline():
+def test_trim_outline(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/982/982336.pdf"
     name = "tika-982336.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test_trim_outline_with_writer():
+def test_trim_outline_with_writer(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/982/982336.pdf"
     name = "tika-982336.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test1():
+def test1(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/923/923621.pdf"
     name = "tika-923621.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test1_with_writer():
+def test1_with_writer(pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/923/923621.pdf"
     name = "tika-923621.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test_sweep_recursion1():
+def test_sweep_recursion1(pdf_file_path):
     # TODO: This test looks like an infinite loop.
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
     name = "tika-924546.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
 
-    reader2 = PdfReader("tmp-merger-do-not-commit.pdf")
+    reader2 = PdfReader(pdf_file_path)
     reader2.pages
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test_sweep_recursion1_with_writer():
+def test_sweep_recursion1_with_writer(pdf_file_path):
     # TODO: This test looks like an infinite loop.
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
     name = "tika-924546.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
 
-    reader2 = PdfReader("tmp-merger-do-not-commit.pdf")
+    reader2 = PdfReader(pdf_file_path)
     reader2.pages
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
@@ -540,18 +498,15 @@ def test_sweep_recursion1_with_writer():
         ),
     ],
 )
-def test_sweep_recursion2(url, name):
+def test_sweep_recursion2(url, name, pdf_file_path):
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
 
-    reader2 = PdfReader("tmp-merger-do-not-commit.pdf")
+    reader2 = PdfReader(pdf_file_path)
     reader2.pages
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
@@ -570,54 +525,45 @@ def test_sweep_recursion2(url, name):
         ),
     ],
 )
-def test_sweep_recursion2_with_writer(url, name):
+def test_sweep_recursion2_with_writer(url, name, pdf_file_path):
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
 
-    reader2 = PdfReader("tmp-merger-do-not-commit.pdf")
+    reader2 = PdfReader(pdf_file_path)
     reader2.pages
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_sweep_indirect_list_newobj_is_none(caplog):
+def test_sweep_indirect_list_newobj_is_none(caplog, pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/906/906769.pdf"
     name = "tika-906769.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
     # used to be: assert "Object 21 0 not defined." in caplog.text
 
-    reader2 = PdfReader("tmp-merger-do-not-commit.pdf")
+    reader2 = PdfReader(pdf_file_path)
     reader2.pages
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()
-def test_sweep_indirect_list_newobj_is_none_with_writer(caplog):
+def test_sweep_indirect_list_newobj_is_none_with_writer(caplog, pdf_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/906/906769.pdf"
     name = "tika-906769.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
-    merger.write("tmp-merger-do-not-commit.pdf")
+    merger.write(pdf_file_path)
     merger.close()
     # used to be: assert "Object 21 0 not defined." in caplog.text
 
-    reader2 = PdfReader("tmp-merger-do-not-commit.pdf")
+    reader2 = PdfReader(pdf_file_path)
     reader2.pages
-
-    # cleanup
-    Path("tmp-merger-do-not-commit.pdf").unlink()
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -779,7 +779,7 @@ def test_annotation_getter():
     }
 
 
-def test_annotation_setter():
+def test_annotation_setter(pdf_file_path):
     # Arange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -833,12 +833,8 @@ def test_annotation_setter():
     arr.append(ind_obj)
 
     # Assert manually
-    target = "annot-out.pdf"
-    with open(target, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
-
-    # Cleanup
-    Path(target).unlink()  # remove for testing
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -390,14 +390,14 @@ def test_get_page_of_encrypted_file(pdffile, password, should_fail):
         ),
     ],
 )
-def test_get_form(src, expected, expected_get_fields):
+def test_get_form(src, expected, expected_get_fields, txt_file_path):
     """Check if we can read out form data."""
     src = RESOURCE_ROOT / src
     reader = PdfReader(src)
     fields = reader.get_form_text_fields()
     assert fields == expected
 
-    with open("tmp-fields-report.txt", "w") as f:
+    with open(txt_file_path, "w") as f:
         fields = reader.get_fields(fileobj=f)
     assert fields == expected_get_fields
     if fields:
@@ -415,9 +415,6 @@ def test_get_form(src, expected, expected_get_fields):
                 field.default_value,
                 field.additional_actions,
             ]
-
-    # cleanup
-    Path("tmp-fields-report.txt").unlink()
 
 
 @pytest.mark.parametrize(
@@ -957,16 +954,13 @@ def test_metadata_is_none():
 
 
 @pytest.mark.enable_socket()
-def test_get_fields_read_write_report():
+def test_get_fields_read_write_report(txt_file_path):
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/909/909655.pdf"
     name = "tika-909655.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    with open("tmp-fields-report.txt", "w") as fp:
+    with open(txt_file_path, "w") as fp:
         fields = reader.get_fields(fileobj=fp)
     assert fields
-
-    # cleanup
-    Path("tmp-fields-report.txt").unlink()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -316,7 +316,7 @@ def test_orientations():
         ),
     ],
 )
-def test_overlay(base_path, overlay_path):
+def test_overlay(pdf_file_path, base_path, overlay_path):
     if base_path.startswith("http"):
         base_path = BytesIO(get_pdf_from_url(base_path, name="tika-935981.pdf"))
     else:
@@ -330,11 +330,8 @@ def test_overlay(base_path, overlay_path):
     for page in reader.pages:
         page.merge_page(overlay)
         writer.add_page(page)
-    with open("dont_commit_overlay.pdf", "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
-
-    # Cleanup
-    Path("dont_commit_overlay.pdf").unlink()  # remove for manual inspection
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -290,7 +290,7 @@ def test_writer_operation_by_new_usage(write_data_here, needs_cleanup):
         "reportlab-inline-image.pdf",
     ],
 )
-def test_remove_images(input_path):
+def test_remove_images(pdf_file_path, input_path):
     pdf_path = RESOURCE_ROOT / input_path
 
     reader = PdfReader(pdf_path)
@@ -301,18 +301,14 @@ def test_remove_images(input_path):
     writer.remove_images()
 
     # finally, write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_writer_removed_image.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
-    with open(tmp_filename, "rb") as input_stream:
+    with open(pdf_file_path, "rb") as input_stream:
         reader = PdfReader(input_stream)
         if input_path == "side-by-side-subfig.pdf":
             extracted_text = reader.pages[0].extract_text()
             assert "Lorem ipsum dolor sit amet" in extracted_text
-
-    # Cleanup
-    Path(tmp_filename).unlink()
 
 
 @pytest.mark.parametrize(
@@ -436,7 +432,7 @@ def test_write_metadata():
     Path(tmp_filename).unlink()
 
 
-def test_fill_form():
+def test_fill_form(pdf_file_path):
     reader = PdfReader(RESOURCE_ROOT / "form.pdf")
     writer = PdfWriter()
 
@@ -459,11 +455,8 @@ def test_fill_form():
     )
 
     # write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_filled_pdf.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
-
-    Path(tmp_filename).unlink()  # cleanup
 
 
 def test_fill_form_with_qualified():
@@ -709,18 +702,14 @@ def test_io_streams():
         writer.write(output_stream)
 
 
-def test_regression_issue670():
-    tmp_file = "dont_commit_issue670.pdf"
+def test_regression_issue670(pdf_file_path):
     filepath = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(filepath, strict=False)
     for _ in range(2):
         writer = PdfWriter()
         writer.add_page(reader.pages[0])
-        with open(tmp_file, "wb") as f_pdf:
+        with open(pdf_file_path, "wb") as f_pdf:
             writer.write(f_pdf)
-
-    # cleanup
-    Path(tmp_file).unlink()
 
 
 def test_issue301():
@@ -745,18 +734,14 @@ def test_append_pages_from_reader_append():
 
 @pytest.mark.enable_socket()
 @pytest.mark.slow()
-def test_sweep_indirect_references_nullobject_exception():
+def test_sweep_indirect_references_nullobject_exception(pdf_file_path):
     # TODO: Check this more closely... this looks weird
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
     name = "tika-924666.pdf"
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     merger = PdfMerger()
     merger.append(reader)
-    tmp_file = "tmp-merger-do-not-commit.pdf"
-    merger.write(tmp_file)
-
-    # cleanup
-    Path(tmp_file).unlink()
+    merger.write(pdf_file_path)
 
 
 @pytest.mark.enable_socket()
@@ -775,19 +760,16 @@ def test_sweep_indirect_references_nullobject_exception():
         ("https://github.com/py-pdf/pypdf/files/10715624/test.pdf", "iss1627.pdf"),
     ],
 )
-def test_some_appends(url, name):
+def test_some_appends(pdf_file_path, url, name):
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    tmp_file = "tmp-merger-do-not-commit.pdf"
     # PdfMerger
     merger = PdfMerger()
     merger.append(reader)
-    merger.write(tmp_file)
+    merger.write(pdf_file_path)
     # PdfWriter
     merger = PdfWriter()
     merger.append(reader)
-    merger.write(tmp_file)
-    # cleanup
-    Path(tmp_file).unlink()
+    merger.write(pdf_file_path)
 
 
 def test_pdf_header():

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -318,7 +318,7 @@ def test_remove_images(pdf_file_path, input_path):
         "reportlab-inline-image.pdf",
     ],
 )
-def test_remove_text(input_path):
+def test_remove_text(input_path, pdf_file_path):
     pdf_path = RESOURCE_ROOT / input_path
 
     reader = PdfReader(pdf_path)
@@ -329,15 +329,11 @@ def test_remove_text(input_path):
     writer.remove_text()
 
     # finally, write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_writer_removed_text.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
-    # Cleanup
-    Path(tmp_filename).unlink()
 
-
-def test_remove_text_all_operators():
+def test_remove_text_all_operators(pdf_file_path):
     stream = (
         b"BT "
         b"/F0 36 Tf "
@@ -395,15 +391,11 @@ def test_remove_text_all_operators():
     writer.remove_text()
 
     # finally, write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_writer_removed_text.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
-    # Cleanup
-    Path(tmp_filename).unlink()
 
-
-def test_write_metadata():
+def test_write_metadata(pdf_file_path):
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
 
     reader = PdfReader(pdf_path)
@@ -419,17 +411,13 @@ def test_write_metadata():
     writer.add_metadata({"/Title": "The Crazy Ones"})
 
     # finally, write data to pypdf-output.pdf
-    tmp_filename = "dont_commit_writer_added_metadata.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
     # Check if the title was set
-    reader = PdfReader(tmp_filename)
+    reader = PdfReader(pdf_file_path)
     metadata = reader.metadata
     assert metadata.get("/Title") == "The Crazy Ones"
-
-    # Cleanup
-    Path(tmp_filename).unlink()
 
 
 def test_fill_form(pdf_file_path):
@@ -481,7 +469,7 @@ def test_fill_form_with_qualified():
     ("use_128bit", "user_password", "owner_password"),
     [(True, "userpwd", "ownerpwd"), (False, "userpwd", "ownerpwd")],
 )
-def test_encrypt(use_128bit, user_password, owner_password):
+def test_encrypt(use_128bit, user_password, owner_password, pdf_file_path):
     reader = PdfReader(RESOURCE_ROOT / "form.pdf")
     writer = PdfWriter()
 
@@ -496,44 +484,40 @@ def test_encrypt(use_128bit, user_password, owner_password):
     )
 
     # write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_encrypted.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
     # Test that the data is not there in clear text
-    with open(tmp_filename, "rb") as input_stream:
+    with open(pdf_file_path, "rb") as input_stream:
         data = input_stream.read()
     assert b"foo" not in data
 
     # Test the user password (str):
-    reader = PdfReader(tmp_filename, password="userpwd")
+    reader = PdfReader(pdf_file_path, password="userpwd")
     new_text = reader.pages[0].extract_text()
     assert reader.metadata.get("/Producer") == "pypdf"
     assert new_text == orig_text
 
     # Test the owner password (str):
-    reader = PdfReader(tmp_filename, password="ownerpwd")
+    reader = PdfReader(pdf_file_path, password="ownerpwd")
     new_text = reader.pages[0].extract_text()
     assert reader.metadata.get("/Producer") == "pypdf"
     assert new_text == orig_text
 
     # Test the user password (bytes):
-    reader = PdfReader(tmp_filename, password=b"userpwd")
+    reader = PdfReader(pdf_file_path, password=b"userpwd")
     new_text = reader.pages[0].extract_text()
     assert reader.metadata.get("/Producer") == "pypdf"
     assert new_text == orig_text
 
     # Test the owner password (stbytesr):
-    reader = PdfReader(tmp_filename, password=b"ownerpwd")
+    reader = PdfReader(pdf_file_path, password=b"ownerpwd")
     new_text = reader.pages[0].extract_text()
     assert reader.metadata.get("/Producer") == "pypdf"
     assert new_text == orig_text
 
-    # Cleanup
-    Path(tmp_filename).unlink()
 
-
-def test_add_outline_item():
+def test_add_outline_item(pdf_file_path):
     reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
     writer = PdfWriter()
 
@@ -546,15 +530,11 @@ def test_add_outline_item():
     writer.add_outline_item("Another", 2, outline_item, None, False, False, Fit.fit())
 
     # write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_outline_item.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
-    # Cleanup
-    Path(tmp_filename).unlink()
 
-
-def test_add_named_destination():
+def test_add_named_destination(pdf_file_path):
     reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
     writer = PdfWriter()
     assert writer.get_named_dest_root() == []
@@ -585,15 +565,11 @@ def test_add_named_destination():
     assert exc.value.args[0] == "pdf must be self"
 
     # write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_named_destination.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
-    # Cleanup
-    Path(tmp_filename).unlink()
 
-
-def test_add_uri():
+def test_add_uri(pdf_file_path):
     reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
     writer = PdfWriter()
 
@@ -626,15 +602,11 @@ def test_add_uri():
     )
 
     # write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_uri.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
-    # Cleanup
-    Path(tmp_filename).unlink()
 
-
-def test_add_link():
+def test_add_link(pdf_file_path):
     reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
     writer = PdfWriter()
 
@@ -678,12 +650,8 @@ def test_add_link():
         )
 
     # write "output" to pypdf-output.pdf
-    tmp_filename = "dont_commit_link.pdf"
-    with open(tmp_filename, "wb") as output_stream:
+    with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
-
-    # Cleanup
-    Path(tmp_filename).unlink()
 
 
 def test_io_streams():
@@ -784,7 +752,7 @@ def test_pdf_header():
     assert writer.pdf_header == b"%PDF-1.6"
 
 
-def test_write_dict_stream_object():
+def test_write_dict_stream_object(pdf_file_path):
     stream = (
         b"BT "
         b"/F0 36 Tf "
@@ -808,8 +776,7 @@ def test_write_dict_stream_object():
     page_object[NameObject("/Test")] = stream_object
 
     page_object = writer.add_page(page_object)
-    tmp_file = "tmp-writer-do-not-commit.pdf"
-    with open(tmp_file, "wb") as fp:
+    with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
 
     for k, v in page_object.items():
@@ -826,8 +793,6 @@ def test_write_dict_stream_object():
     for k, v in writer._idnum_hash.items():
         assert v.pdf == writer
         assert k in objects_hash, "Missing %s" % v
-
-    Path(tmp_file).unlink()
 
 
 def test_add_single_annotation(pdf_file_path):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -830,7 +830,7 @@ def test_write_dict_stream_object():
     Path(tmp_file).unlink()
 
 
-def test_add_single_annotation():
+def test_add_single_annotation(pdf_file_path):
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
     page = reader.pages[0]
@@ -853,13 +853,10 @@ def test_add_single_annotation():
         "/T": "moose",
     }
     writer.add_annotation(0, annot_dict)
-    # Assert manually
-    target = "annot-single-out.pdf"
-    with open(target, "wb") as fp:
-        writer.write(fp)
 
-    # Cleanup
-    Path(target).unlink()  # comment out for testing
+    # Inspect manually by adding 'assert False' and viewing the PDF
+    with open(pdf_file_path, "wb") as fp:
+        writer.write(fp)
 
 
 def test_deprecation_bookmark_decorator():
@@ -876,7 +873,7 @@ def test_deprecation_bookmark_decorator():
 
 
 @pytest.mark.samples()
-def test_colors_in_outline_item():
+def test_colors_in_outline_item(pdf_file_path):
     reader = PdfReader(SAMPLE_ROOT / "004-pdflatex-4-pages/pdflatex-4-pages.pdf")
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
@@ -885,17 +882,13 @@ def test_colors_in_outline_item():
     writer.add_outline_item("Second Outline Item", page_number=3, color="#800080")
     writer.add_outline_item("Third Outline Item", page_number=4, color=purple_rgb)
 
-    target = "tmp-named-color-outline.pdf"
-    with open(target, "wb") as f:
+    with open(pdf_file_path, "wb") as f:
         writer.write(f)
 
-    reader2 = PdfReader(target)
+    reader2 = PdfReader(pdf_file_path)
     for outline_item in reader2.outline:
         # convert float to string because of mutability
         assert [str(c) for c in outline_item.color] == [str(p) for p in purple_rgb]
-
-    # Cleanup
-    Path(target).unlink()  # comment out for testing
 
 
 @pytest.mark.samples()
@@ -1036,9 +1029,8 @@ def test_append_multiple():
 
 
 @pytest.mark.samples()
-def test_set_page_label():
+def test_set_page_label(pdf_file_path):
     src = RESOURCE_ROOT / "GeoBase_NHNC1_Data_Model_UML_EN.pdf"  # File without labels
-    target = "pypdf-output.pdf"
     reader = PdfReader(src)
 
     expected = [
@@ -1073,8 +1065,8 @@ def test_set_page_label():
     writer.set_page_label(11, 11, "/r")
     writer.set_page_label(12, 13, "/R")
     writer.set_page_label(17, 18, "/R")
-    writer.write(target)
-    assert PdfReader(target).page_labels == expected
+    writer.write(pdf_file_path)
+    assert PdfReader(pdf_file_path).page_labels == expected
 
     writer = PdfWriter()  # Same labels, different set order
     writer.clone_document_from_reader(reader)
@@ -1084,8 +1076,8 @@ def test_set_page_label():
     writer.set_page_label(0, 1, "/r")
     writer.set_page_label(12, 13, "/R")
     writer.set_page_label(11, 11, "/r")
-    writer.write(target)
-    assert PdfReader(target).page_labels == expected
+    writer.write(pdf_file_path)
+    assert PdfReader(pdf_file_path).page_labels == expected
 
     # Tests labels assigned only in the middle
     # Tests label assigned to a range already containing labled ranges
@@ -1095,8 +1087,8 @@ def test_set_page_label():
     writer.set_page_label(3, 4, "/a")
     writer.set_page_label(5, 5, "/A")
     writer.set_page_label(2, 6, "/r")
-    writer.write(target)
-    assert PdfReader(target).page_labels[: len(expected)] == expected
+    writer.write(pdf_file_path)
+    assert PdfReader(pdf_file_path).page_labels[: len(expected)] == expected
 
     # Tests labels assigned inside a previously existing range
     expected = ["1", "2", "i", "a", "b", "A", "1", "1", "2"]
@@ -1106,8 +1098,8 @@ def test_set_page_label():
     writer.set_page_label(2, 6, "/r")
     writer.set_page_label(3, 4, "/a")
     writer.set_page_label(5, 5, "/A")
-    writer.write(target)
-    assert PdfReader(target).page_labels[: len(expected)] == expected
+    writer.write(pdf_file_path)
+    assert PdfReader(pdf_file_path).page_labels[: len(expected)] == expected
 
     # Tests invalid user input
     writer = PdfWriter()
@@ -1131,12 +1123,11 @@ def test_set_page_label():
     ):
         writer.set_page_label(0, 5, "/r", start=-1)
 
-    Path(target).unlink()
+    pdf_file_path.unlink()
 
     src = (
         SAMPLE_ROOT / "009-pdflatex-geotopo/GeoTopo.pdf"
     )  # File with pre existing labels
-    target = "pypdf-output.pdf"
     reader = PdfReader(src)
 
     # Tests adding labels to existing ones
@@ -1144,22 +1135,21 @@ def test_set_page_label():
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
     writer.set_page_label(2, 3, "/A")
-    writer.write(target)
-    assert PdfReader(target).page_labels[: len(expected)] == expected
+    writer.write(pdf_file_path)
+    assert PdfReader(pdf_file_path).page_labels[: len(expected)] == expected
 
     # Tests replacing existing lables
     expected = ["A", "B", "1", "1", "2"]
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
     writer.set_page_label(0, 1, "/A")
-    writer.write(target)
-    assert PdfReader(target).page_labels[: len(expected)] == expected
+    writer.write(pdf_file_path)
+    assert PdfReader(pdf_file_path).page_labels[: len(expected)] == expected
 
-    Path(target).unlink()
+    pdf_file_path.unlink()
 
     # Tests prefix and start.
     src = RESOURCE_ROOT / "issue-604.pdf"  # File without page labels
-    target = "page_labels_test.pdf"
     reader = PdfReader(src)
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
@@ -1171,9 +1161,7 @@ def test_set_page_label():
     writer.set_page_label(11, 21, "/D", prefix="PAP-")
     writer.set_page_label(22, 30, "/D", prefix="FOLL-")
     writer.set_page_label(31, 39, "/D", prefix="HURT-")
-    writer.write(target)
-
-    Path(target).unlink()  # comment to see result
+    writer.write(pdf_file_path)
 
 
 @pytest.mark.enable_socket()


### PR DESCRIPTION
On the positive side:
+ Tests become easier to read
+ Files cleanup cannot be forgotten
+ Tests can be copy-pasted into the docs

Neutral:
o If the test run fails, you can see where the file was written
  and it's not directly deleted

Negative:
- If the run does not fail (loudly) but you want to inspect the generated PDF, you have to 'assert False' or similar. That is harder to figure out than commenting out a Path.unlink() line