### PR TITLE
MAINT: Move generation of file identifiers to a method

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1006,7 +1006,7 @@ class PdfWriter:
 
     def _compute_document_identifier_from_content(self) -> ByteStringObject:
         stream = BytesIO()
-        self._write_header(stream)
+        self._write_pdf_structure(stream)
         stream.seek(0)
         return ByteStringObject(_rolling_checksum(stream).encode("utf8"))
 
@@ -1145,7 +1145,7 @@ class PdfWriter:
         # copying in a new copy of the page object.
         self._sweep_indirect_references(self._root)
 
-        object_positions = self._write_header(stream)
+        object_positions = self._write_pdf_structure(stream)
         xref_location = self._write_xref_table(stream, object_positions)
         self._write_trailer(stream)
         stream.write(b_(f"\nstartxref\n{xref_location}\n%%EOF\n"))  # eof
@@ -1180,7 +1180,7 @@ class PdfWriter:
 
         return my_file, stream
 
-    def _write_header(self, stream: StreamType) -> List[int]:
+    def _write_pdf_structure(self, stream: StreamType) -> List[int]:
         object_positions = []
         stream.write(self.pdf_header + b"\n")
         stream.write(b"%\xE2\xE3\xCF\xD3\n")

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -33,7 +33,6 @@ import decimal
 import enum
 import logging
 import re
-import secrets
 import struct
 import time
 import uuid
@@ -998,6 +997,10 @@ class PdfWriter:
         )
         self.clone_document_from_reader(reader, after_page_append)
 
+    def _compute_document_identifier_from_content(self) -> ByteStringObject:
+        # TODO: Actually compute it from content!
+        return ByteStringObject(md5((repr(time.time())).encode("utf8")).digest())
+
     def generate_file_identifiers(self) -> None:
         """
         Generate an identifier for the PDF that will be written.
@@ -1005,11 +1008,11 @@ class PdfWriter:
         The only point of this is ensuring uniqueness. Reproducibility is not
         required; see 14.4 "File Identifiers".
         """
-        secrets_generator = secrets.SystemRandom()
-        ID_1 = ByteStringObject(md5((repr(time.time())).encode("utf8")).digest())
-        ID_2 = ByteStringObject(
-            md5((repr(secrets_generator.uniform(0, 1))).encode("utf8")).digest()
-        )
+        if hasattr(self, "_ID") and self._ID and len(self._ID) == 2:
+            ID_1 = self._ID[0]
+        else:
+            ID_1 = self._compute_document_identifier_from_content()
+        ID_2 = self._compute_document_identifier_from_content()
         self._ID = ArrayObject((ID_1, ID_2))
 
     def encrypt(

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -974,7 +974,7 @@ class PdfWriter:
         self.clone_reader_document_root(reader)
         self._info = reader.trailer[TK.INFO].clone(self).indirect_reference  # type: ignore
         try:
-            self._ID = reader.trailer[TK.ID].clone(self)  # type: ignore
+            self._ID = cast(ArrayObject, reader.trailer[TK.ID].clone(self))  # type: ignore
         except KeyError:
             pass
         if callable(after_page_append):

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -64,6 +64,8 @@ def test_basic_features(tmp_path):
     password = "secret"
     with pytest.warns(UserWarning, match="pypdf only implements RC4 encryption"):
         writer.encrypt(password)
+        # doing it twice should not change anything
+        writer.encrypt(password)
 
     # finally, write "output" to pypdf-output.pdf
     write_path = tmp_path / "pypdf-output.pdf"


### PR DESCRIPTION
## For Reviewers

I'm uncertain if we want to re-generate this even if it's present when we encrypt the file.

### How other libraries compute /ID

pdfrw: Not at all

PyMuPDF:

* Parameter `"no_new_id"` in `Document.save`: Use it to suppress updating the second item of the document ``/ID`` which in PDF indicates that the original file has been updated. If the PDF has no ``/ID`` at all yet, then no new one will be created either.
* creation of PDF documents: they will now always carry a PDF identification (``/ID`` field) in the document trailer. See https://github.com/pymupdf/PyMuPDF/issues/691