### PR TITLE
ENH: Add transform method to Transformation

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -209,6 +209,25 @@ class Transformation:
             matrix[2][1],
         )
 
+    def transform(self, m: "Transformation") -> "Transformation":
+        """
+        Apply one transformation to another.
+
+        Args:
+            m: a Transformation to apply.
+
+        Returns:
+            A new ``Transformation`` instance
+
+        Example:
+            >>> from pypdf import Transformation
+            >>> op = Transformation((1, 0, 0, -1, 0, height)) # vertical mirror
+            >>> op = Transformation().transform(Transformation((-1, 0, 0, 1, iwidth, 0))) # horizontal mirror
+            >>> page.add_transformation(op)
+        """
+        ctm = Transformation.compress(matrix_multiply(self.matrix, m.matrix))
+        return Transformation(ctm)
+
     def translate(self, tx: float = 0, ty: float = 0) -> "Transformation":
         """
         Translate the contents of a page.

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -102,7 +102,7 @@ def test_page_operations(pdf_path, password):
     assert abs(t.ctm[4] + 100) < 0.01
     assert abs(t.ctm[5] - 50) < 0.01
 
-    transformation = Transformation().rotate(90).scale(1).translate(1, 1)
+    transformation = Transformation().rotate(90).scale(1).translate(1, 1).transform(Transformation((1, 0, 0, -1, 0, 0)))
     page.add_transformation(transformation, expand=True)
     page.add_transformation((1, 0, 0, 0, 0, 0))
     page.scale(2, 2)
@@ -171,6 +171,14 @@ def test_transformation_equivalence2():
     w.append(reader_add)
     w.pages[0].merge_transformed_page(
         reader_base.pages[0], Transformation(), True, True
+    )
+    # No special assert: Visual check the page has been  increased and all is visible (box+graph)
+
+    w = PdfWriter()
+    w.append(reader_add)
+    height = reader_add.pages[0].mediabox.height
+    w.pages[0].merge_transformed_page(
+        reader_base.pages[0], Transformation().transform(Transformation((1, 0, 0, -1, 0, height))), False, False
     )
     # No special assert: Visual check the page has been  increased and all is visible (box+graph)
 


### PR DESCRIPTION
I am the maintainer of [PSUtils](https://github.com/rrthomas/psutils). I am adding PDF support, and rewriting the code in Python. pyPDF was a significant motivation for the choice of language, so thanks for that!

I need to express vertical and horizontal page flips, and the simplest way to achieve this seemed to be to add a general `transform` method to `Transformation` (I need all the different sorts of transformations to be applied repeatedly to the same page, so it's easier to change a `Transformation` than to make multiple copies of a page and transform that.) I have done this in the simplest way I could; it might be desired for the method to take a `CompressedTransformationMatrix` too.

If you agree to add an API something like this, I'll happily add some tests. (At the moment I just tested it with my experimental PSUtils code.)