### PR TITLE
DOC: Fix "fill form" documentation

### DIFF
--- a/docs/user/forms.md
+++ b/docs/user/forms.md
@@ -18,11 +18,7 @@ from pypdf import PdfReader, PdfWriter
 reader = PdfReader("form.pdf")
 writer = PdfWriter()
 
-page = reader.pages[0]
-fields = reader.get_fields()
-
-writer.add_page(page)
-
+writer.append_pages_from_reader(reader)
 writer.update_page_form_field_values(
     writer.pages[0], {"fieldname": "some filled in text"}
 )


### PR DESCRIPTION
The previous version will not work for Adobe forms such as [f914](https://www.irs.gov/pub/irs-pdf/f941.pdf) used by IRS. The filled form would create an error when opened by Adobe pdf reader "This document enabled extended features in Adobe Acrobat Reader.  The document has been changed since it was created and use of extended features is no longer available." as described in this [issue](https://github.com/py-pdf/pypdf/issues/1268#issuecomment-1226704221).

By creating an empty `PdfWriter` and `append_pages_from_reader` can circumvent this problem, and tested in version 3.7.0.
