### PR TITLE
ROB: Prevent loop in Cloning

### DIFF
--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -73,6 +73,9 @@ class PdfWriterProtocol(Protocol):  # deprecated
     def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO]:
         ...
 
+    def _add_object(self, obj: Any) -> Any:
+        ...
+
     @property
     def pages(self) -> List[Any]:
         ...

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -277,9 +277,9 @@ class IndirectObject(PdfObject):
                 obj = NullObject()
                 assert isinstance(self, (IndirectObject,))
                 obj.indirect_reference = self
-            dup = obj.clone(pdf_dest, force_duplicate, ignore_fields)
-        assert dup is not None
-        assert dup.indirect_reference is not None
+            dup = pdf_dest._add_object(
+                obj.clone(pdf_dest, force_duplicate, ignore_fields)
+            )
         return dup.indirect_reference
 
     @property

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -280,6 +280,9 @@ class IndirectObject(PdfObject):
             dup = pdf_dest._add_object(
                 obj.clone(pdf_dest, force_duplicate, ignore_fields)
             )
+        # asserts added to prevent errors in mypy
+        assert dup is not None
+        assert dup.indirect_reference is not None
         return dup.indirect_reference
 
     @property

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -750,7 +750,9 @@ class StreamObject(DictionaryObject):
             if decoded_self is None:
                 self.decoded_self = None
             else:
-                self.decoded_self = decoded_self.clone(pdf_dest, True, ignore_fields)  # type: ignore[assignment]
+                self.decoded_self = decoded_self.clone(
+                    pdf_dest, force_duplicate, ignore_fields
+                )  # type: ignore[assignment]
         except Exception:
             pass
         super()._clone(src, pdf_dest, force_duplicate, ignore_fields)

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -750,9 +750,10 @@ class StreamObject(DictionaryObject):
             if decoded_self is None:
                 self.decoded_self = None
             else:
-                self.decoded_self = decoded_self.clone(
-                    pdf_dest, force_duplicate, ignore_fields
-                )  # type: ignore[assignment]
+                self.decoded_self = cast(
+                    "DecodedStreamObject",
+                    decoded_self.clone(pdf_dest, force_duplicate, ignore_fields),
+                )
         except Exception:
             pass
         super()._clone(src, pdf_dest, force_duplicate, ignore_fields)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1292,3 +1292,14 @@ def test_iss1723():
     in_pdf = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     out_pdf = PdfWriter()
     out_pdf.append(in_pdf, (3, 5))
+
+
+@pytest.mark.enable_socket()
+def test_iss1767():
+    # test with a pdf which is buggy because the object 389,0 exists 3 times:
+    # twice to define catalog and one as an XObject inducing a loop when
+    # cloning
+    url = "https://github.com/py-pdf/pypdf/files/11138472/test.pdf"
+    name = "iss1723.pdf"
+    in_pdf = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    PdfWriter(clone_from=in_pdf)


### PR DESCRIPTION
fixes  #1767
the issue is due to object 589/0 : this object corresponds to 2 object the file trailer but also an XObject corresponding to the filled text ("test") because of that the object tries to be duplicated inducing the loop. This loop is not normal and I've fixed as a robustness improvement. If you run your code the text "test" will be missing as it is hidden by the trailer object.