### PR TITLE
TST: Deprecation warnings/errors

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -72,7 +72,7 @@ StrByteType = Union[str, StreamType]
 
 DEPR_MSG_NO_REPLACEMENT = "{} is deprecated and will be removed in pypdf {}."
 DEPR_MSG_NO_REPLACEMENT_HAPPENED = "{} is deprecated and was removed in pypdf {}."
-DEPR_MSG = "{} is deprecated and will be removed in pypdf 3.0.0. Use {} instead."
+DEPR_MSG = "{} is deprecated and will be removed in pypdf {}. Use {} instead."
 DEPR_MSG_HAPPENED = "{} is deprecated and was removed in pypdf {}. Use {} instead."
 
 
@@ -387,7 +387,7 @@ def deprecate_with_replacement(
     old_name: str, new_name: str, removed_in: str = "3.0.0"
 ) -> None:
     """Raise an exception that a feature will be removed, but has a replacement."""
-    deprecate(DEPR_MSG.format(old_name, new_name, removed_in), 4)
+    deprecate(DEPR_MSG.format(old_name, removed_in, new_name), 4)
 
 
 def deprecation_with_replacement(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,9 @@ from pypdf._utils import (
     File,
     _get_max_pdf_version_header,
     _human_readable_bytes,
+    deprecate_with_replacement,
     deprecation_bookmark,
+    deprecation_no_replacement,
     mark_location,
     matrix_multiply,
     read_block_backwards,
@@ -228,6 +230,30 @@ def test_deprecation_bookmark():
         foo(old_param=12, new_param=13)
     expected_msg = "old_param is deprecated as an argument. Use new_param instead"
     assert exc.value.args[0] == expected_msg
+
+
+def test_deprecate_with_replacement():
+    def foo() -> None:
+        deprecate_with_replacement("foo", "bar", removed_in="4.3.2")
+        pass
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="foo is deprecated and will be removed in pypdf 4.3.2. Use bar instead.",
+    ):
+        foo()
+
+
+def test_deprecation_no_replacement():
+    def foo() -> None:
+        deprecation_no_replacement("foo", removed_in="4.3.2")
+        pass
+
+    with pytest.raises(
+        DeprecationError,
+        match="foo is deprecated and was removed in pypdf 4.3.2.",
+    ):
+        foo()
 
 
 @pytest.mark.enable_socket()


### PR DESCRIPTION
BUG: `deprecate_with_replacement` was potentially giving the wrong error message (version 3.0.0 instead of the actual version)