### PR TITLE
DOC: Use append instead of add_page

### DIFF
--- a/docs/user/forms.md
+++ b/docs/user/forms.md
@@ -21,7 +21,7 @@ writer = PdfWriter()
 page = reader.pages[0]
 fields = reader.get_fields()
 
-writer.add_page(page)
+writer.append(reader)
 
 writer.update_page_form_field_values(
     writer.pages[0], {"fieldname": "some filled in text"}


### PR DESCRIPTION
Update docs to use append rather than add_page so that the PDF structure is copied. This ensures the form structure is kept which is necessary for some PDFs.

See #1790
Closes #1792
Closes #1804