### PR TITLE
DOC: Expand file size explanations

### DIFF
--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -30,7 +30,7 @@ It depends on the PDF how well this works, but we have seen an 86% file
 reduction (from 5.7 MB to 0.8 MB) within a real PDF.
 
 
-## Remove images
+## Removing Images
 
 
 ```python
@@ -75,3 +75,7 @@ with open("out.pdf", "wb") as f:
 
 Using this method, we have seen a reduction by 70% (from 11.8 MB to 3.5 MB)
 with a real PDF.
+
+## Removing Sources
+
+Often times when deleting pages, the source will persist. This will reduce the page count, while marginally reducing the file size. This issue can arise with poor pdf formatting such as when all pages are linked to the same resource.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -78,9 +78,10 @@ with a real PDF.
 
 ## Removing Sources
 
-When a page is removed from page list, the source will remain in the PDF file. The data may be still be used somewhere else.
+When a page is removed from the page list, its content will still be present in the PDF file. This means that the data may still be used elsewhere.
 
-Hence just removing a page from the page list will reduce the page count, but not the file size. 
-To not include the code, the pages should not be added using `PdfWriter.append()` selecting the good pages only
-- Issues can arise with poor PDF formatting such as when all pages are linked to the same resource, making dropping references useless since there is one source for all pages.
-- Cropping is an ineffective way of reducing the file size, as the external part of the source image will still be present. Just the viewboxes are adjusted.
+Simply removing a page from the page list will reduce the page count but not the file size. In order to exclude the content completely, the pages should not be added to the PDF using the PdfWriter.append() function. Instead, only the desired pages should be selected for inclusion.
+
+There can be issues with poor PDF formatting, such as when all pages are linked to the same resource. In such cases, dropping references to specific pages becomes useless because there is only one source for all pages.
+
+Cropping is an ineffective method for reducing the file size because it only adjusts the viewboxes and not the external parts of the source image. Therefore, the content that is no longer visible will still be present in the PDF.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -78,6 +78,7 @@ with a real PDF.
 
 ## Removing Sources
 
-Often times when deleting pages, the source will persist. This will reduce the page count, while marginally reducing the file size. Make sure to remove all refrences to objects inorder to remove the sources. 
+When a page is deleting (removed from page list), the source will persist(the data may be still be used somewhere else). This will reduce the page count, while not reducing the file size. 
+To not include the code, the pages should not be added using `PdfWriter.append()` selecting the good pages only
 - Issues can arise with poor pdf formatting such as when all pages are linked to the same resource, making dropping refrences useless since there is 1 source for all pages.
 - Cropping / (adjust viewboxes) is an innefective way of reducing filesize, as the source image will remain unchanged.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -78,4 +78,6 @@ with a real PDF.
 
 ## Removing Sources
 
-Often times when deleting pages, the source will persist. This will reduce the page count, while marginally reducing the file size. This issue can arise with poor pdf formatting such as when all pages are linked to the same resource.
+Often times when deleting pages, the source will persist. This will reduce the page count, while marginally reducing the file size. Make sure to remove all refrences to objects inorder to remove the sources. 
+- Issues can arise with poor pdf formatting such as when all pages are linked to the same resource, making dropping refrences useless since there is 1 source for all pages.
+- Cropping / (adjust viewboxes) is an innefective way of reducing filesize, as the source image will remain unchanged.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -78,7 +78,9 @@ with a real PDF.
 
 ## Removing Sources
 
-When a page is deleting (removed from page list), the source will persist(the data may be still be used somewhere else). This will reduce the page count, while not reducing the file size. 
+When a page is removed from page list, the source will remain in the PDF file. The data may be still be used somewhere else.
+
+Hence just removing a page from the page list will reduce the page count, but not the file size. 
 To not include the code, the pages should not be added using `PdfWriter.append()` selecting the good pages only
 - Issues can arise with poor pdf formatting such as when all pages are linked to the same resource, making dropping refrences useless since there is 1 source for all pages.
 - Cropping / (adjust viewboxes) is an innefective way of reducing filesize, as the external part of the source image will still be present.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -83,4 +83,4 @@ When a page is removed from page list, the source will remain in the PDF file. T
 Hence just removing a page from the page list will reduce the page count, but not the file size. 
 To not include the code, the pages should not be added using `PdfWriter.append()` selecting the good pages only
 - Issues can arise with poor pdf formatting such as when all pages are linked to the same resource, making dropping refrences useless since there is 1 source for all pages.
-- Cropping / (adjust viewboxes) is an innefective way of reducing filesize, as the external part of the source image will still be present.
+- Cropping is an ineffective way of reducing the file size, as the external part of the source image will still be present. Just the viewboxes are adjusted.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -82,5 +82,5 @@ When a page is removed from page list, the source will remain in the PDF file. T
 
 Hence just removing a page from the page list will reduce the page count, but not the file size. 
 To not include the code, the pages should not be added using `PdfWriter.append()` selecting the good pages only
-- Issues can arise with poor pdf formatting such as when all pages are linked to the same resource, making dropping refrences useless since there is 1 source for all pages.
+- Issues can arise with poor PDF formatting such as when all pages are linked to the same resource, making dropping references useless since there is one source for all pages.
 - Cropping is an ineffective way of reducing the file size, as the external part of the source image will still be present. Just the viewboxes are adjusted.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -81,4 +81,4 @@ with a real PDF.
 When a page is deleting (removed from page list), the source will persist(the data may be still be used somewhere else). This will reduce the page count, while not reducing the file size. 
 To not include the code, the pages should not be added using `PdfWriter.append()` selecting the good pages only
 - Issues can arise with poor pdf formatting such as when all pages are linked to the same resource, making dropping refrences useless since there is 1 source for all pages.
-- Cropping / (adjust viewboxes) is an innefective way of reducing filesize, as the source image will remain unchanged.
+- Cropping / (adjust viewboxes) is an innefective way of reducing filesize, as the external part of the source image will still be present.

--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -80,7 +80,7 @@ with a real PDF.
 
 When a page is removed from the page list, its content will still be present in the PDF file. This means that the data may still be used elsewhere.
 
-Simply removing a page from the page list will reduce the page count but not the file size. In order to exclude the content completely, the pages should not be added to the PDF using the PdfWriter.append() function. Instead, only the desired pages should be selected for inclusion.
+Simply removing a page from the page list will reduce the page count but not the file size. In order to exclude the content completely, the pages should not be added to the PDF using the PdfWriter.append() function. Instead, only the desired pages should be selected for inclusion (note: [PR #1843](https://github.com/py-pdf/pypdf/pull/1843) will add a page deletion feature).
 
 There can be issues with poor PDF formatting, such as when all pages are linked to the same resource. In such cases, dropping references to specific pages becomes useless because there is only one source for all pages.
 


### PR DESCRIPTION
Closes https://github.com/py-pdf/pypdf/issues/1786

Changing the viewboxes ("cropping") has no impact on file size
Removing complete pages only has an impact if the connected resources are also removed