### PR TITLE
ROB: Handle missing /Type entry in Page tree

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1191,8 +1191,8 @@ class PdfReader:
         if PA.TYPE in pages:
             t = pages[PA.TYPE]  # type: ignore
 
-        # if pdf has no type, contents present means it is a page
-        if PG.CONTENTS in pages:
+        # if pdf has no type, considered as a page if /Kids is missing
+        if PA.KIDS not in pages:
             t = "/Page"
 
         if t == "/Pages":

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1187,12 +1187,13 @@ class PdfReader:
             pages = catalog["/Pages"].get_object()  # type: ignore
             self.flattened_pages = []
 
-        t = "/Pages"
         if PA.TYPE in pages:
             t = pages[PA.TYPE]  # type: ignore
         # if pdf has no type, considered as a page if /Kids is missing
-        if PA.KIDS not in pages:
+        elif PA.KIDS not in pages:
             t = "/Page"
+        else:
+            t = "/Pages"
 
         if t == "/Pages":
             for attr in inheritable_page_attributes:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1190,7 +1190,6 @@ class PdfReader:
         t = "/Pages"
         if PA.TYPE in pages:
             t = pages[PA.TYPE]  # type: ignore
-
         # if pdf has no type, considered as a page if /Kids is missing
         if PA.KIDS not in pages:
             t = "/Page"

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1191,6 +1191,10 @@ class PdfReader:
         if PA.TYPE in pages:
             t = pages[PA.TYPE]  # type: ignore
 
+        # if pdf has no type, contents present means it is a page
+        if PG.CONTENTS in pages:
+            t = "/Page"
+
         if t == "/Pages":
             for attr in inheritable_page_attributes:
                 if attr in pages:

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -102,7 +102,13 @@ def test_page_operations(pdf_path, password):
     assert abs(t.ctm[4] + 100) < 0.01
     assert abs(t.ctm[5] - 50) < 0.01
 
-    transformation = Transformation().rotate(90).scale(1).translate(1, 1).transform(Transformation((1, 0, 0, -1, 0, 0)))
+    transformation = (
+        Transformation()
+        .rotate(90)
+        .scale(1)
+        .translate(1, 1)
+        .transform(Transformation((1, 0, 0, -1, 0, 0)))
+    )
     page.add_transformation(transformation, expand=True)
     page.add_transformation((1, 0, 0, 0, 0, 0))
     page.scale(2, 2)
@@ -178,7 +184,10 @@ def test_transformation_equivalence2():
     w.append(reader_add)
     height = reader_add.pages[0].mediabox.height
     w.pages[0].merge_transformed_page(
-        reader_base.pages[0], Transformation().transform(Transformation((1, 0, 0, -1, 0, height))), False, False
+        reader_base.pages[0],
+        Transformation().transform(Transformation((1, 0, 0, -1, 0, height))),
+        False,
+        False,
     )
     # No special assert: Visual check the page has been  increased and all is visible (box+graph)
 
@@ -1111,3 +1120,10 @@ def test_pages_printing():
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
     assert str(reader.pages) == "[PageObject(0)]"
+
+
+def test_pdf_pages_missing_type():
+    pdf_path = RESOURCE_ROOT / "crazyones.pdf"
+    reader = PdfReader(pdf_path)
+    del reader.trailer["/Root"]["/Pages"]["/Kids"][0].get_object()["/Type"]
+    reader.pages[0]


### PR DESCRIPTION
Fixes https://github.com/py-pdf/pypdf/issues/500
these PDF are not compliant with Standard (Type is mandatory in page tree nodes however Acrobat Reader can open them
Robustness improved
criteria to consider it as a page  : /Kids missing