### PR TITLE
BUG: Ignore UTF-8 decode errors

### DIFF
--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -104,7 +104,7 @@ def read_string_from_stream(
                     # line break was escaped:
                     tok = b""
                 else:
-                    msg = rf"Unexpected escaped string: {tok.decode('utf8','ignore')}"
+                    msg = f"Unexpected escaped string: {tok.decode('utf-8','ignore')}"
                     logger_warning(msg, __name__)
         txt.append(tok)
     return create_string_object(b"".join(txt), forced_encoding)

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -104,7 +104,7 @@ def read_string_from_stream(
                     # line break was escaped:
                     tok = b""
                 else:
-                    msg = rf"Unexpected escaped string: {tok.decode('utf8')}"
+                    msg = rf"Unexpected escaped string: {tok.decode('utf8','ignore')}"
                     logger_warning(msg, __name__)
         txt.append(tok)
     return create_string_object(b"".join(txt), forced_encoding)


### PR DESCRIPTION
> Problem
Some pdfs contain Latin characters, and when trying to read them using pypdf, it throws the following exception.|

```Traceback (most recent call last):
    text = page.extract_text()
  File "/Users/.pyenv/versions/3.10.3/lib/python3.10/site-packages/pypdf/_page.py", line 1851, in extract_text
    return self._extract_text(
  File "/Users/.pyenv/versions/3.10.3/lib/python3.10/site-packages/pypdf/_page.py", line 1356, in _extract_text
    content = ContentStream(content, pdf, "bytes")
  File "/Users/.pyenv/versions/3.10.3/lib/python3.10/site-packages/pypdf/generic/_data_structures.py", line 877, in __init__
    self.__parse_content_stream(stream_bytes)
  File "/Users/.pyenv/versions/3.10.3/lib/python3.10/site-packages/pypdf/generic/_data_structures.py", line 943, in __parse_content_stream
    operands.append(read_object(stream, None, self.forced_encoding))
  File "/Users/.pyenv/versions/3.10.3/lib/python3.10/site-packages/pypdf/generic/_data_structures.py", line 1053, in read_object
    return read_string_from_stream(stream, forced_encoding)
  File "/Users/.pyenv/versions/3.10.3/lib/python3.10/site-packages/pypdf/generic/_utils.py", line 107, in read_string_from_stream
    msg = rf"Unexpected escaped string: {tok.decode('utf8')}"
    ```