### PR TITLE
MAINT: Install pytest-socket in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
 	pillow
 	pytest
 	pytest-cov
+	pytest-socket
 	pycryptodome
 commands =
 	py{36,37,38,39,310,py3}: pytest tests --cov --cov-report term-missing -vv --no-cov-on-fail {posargs}


### PR DESCRIPTION
I found this was required to run the tests with tox in #1884.