### PR TITLE
MAINT: Clean residual Python2 code

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -355,10 +355,6 @@ def hexencode(b: bytes) -> bytes:
     return coded[0]
 
 
-def hex_str(num: int) -> str:
-    return hex(num).replace("L", "")
-
-
 WHITESPACES = (b" ", b"\n", b"\r", b"\t", b"\x00")
 
 

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -38,7 +38,6 @@ from .._utils import (
     StreamType,
     b_,
     deprecation_with_replacement,
-    hex_str,
     hexencode,
     logger_warning,
     read_non_whitespace,
@@ -344,7 +343,7 @@ class IndirectObject(PdfObject):
         r = read_non_whitespace(stream)
         if r != b"R":
             raise PdfReadError(
-                f"Error reading indirect object reference at byte {hex_str(stream.tell())}"
+                f"Error reading indirect object reference at byte {hex(stream.tell())}"
             )
         return IndirectObject(int(idnum), int(generation), pdf)
 

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -41,7 +41,6 @@ from .._utils import (
     b_,
     deprecate_with_replacement,
     deprecation_with_replacement,
-    hex_str,
     logger_warning,
     read_non_whitespace,
     read_until_regex,
@@ -390,7 +389,7 @@ class DictionaryObject(dict, PdfObject):
         tmp = stream.read(2)
         if tmp != b"<<":
             raise PdfReadError(
-                f"Dictionary read error at byte {hex_str(stream.tell())}: "
+                f"Dictionary read error at byte {hex(stream.tell())}: "
                 "stream must begin with '<<'"
             )
         data: Dict[Any, Any] = {}
@@ -428,7 +427,7 @@ class DictionaryObject(dict, PdfObject):
                 # multiple definitions of key not permitted
                 msg = (
                     f"Multiple definitions in dictionary at byte "
-                    f"{hex_str(stream.tell())} for key {key}"
+                    f"{hex(stream.tell())} for key {key}"
                 )
                 if pdf is not None and pdf.strict:
                     raise PdfReadError(msg)
@@ -491,7 +490,7 @@ class DictionaryObject(dict, PdfObject):
                     stream.seek(pos, 0)
                     raise PdfReadError(
                         "Unable to find 'endstream' marker after stream at byte "
-                        f"{hex_str(stream.tell())} (nd='{ndstream!r}', end='{end!r}')."
+                        f"{hex(stream.tell())} (nd='{ndstream!r}', end='{end!r}')."
                     )
         else:
             stream.seek(pos, 0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,10 +90,6 @@ def test_mark_location():
     Path("pypdf_pdfLocation.txt").unlink()  # cleanup
 
 
-def test_hex_str():
-    assert pypdf._utils.hex_str(10) == "0xa"
-
-
 @pytest.mark.parametrize(
     ("input_str", "expected"),
     [


### PR DESCRIPTION
There are `int` and `long` in Python2, hex a `long` value will get a suffix 'L', which is no longer in Python3.