### PR TITLE
BUG: Handle missing /Alternate in indexed/ICCbased colorspaces

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -661,7 +661,7 @@ def _get_imagemode(
     elif color_space[0] == "/Indexed":
         color_space = color_space[1].get_object()
         if isinstance(color_space, list):
-            color_space = color_space[1].get_object()["/Alternate"]
+            color_space = color_space[1].get_object().get("/Alternate", "")
         color_components = 1 if "Gray" in color_space else 2
         if not (isinstance(color_space, str) and "Gray" in color_space):
             color_space = "palette"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -394,3 +394,13 @@ def test_iss1863():
     for p in reader.pages:
         for i in p.images:
             i.name
+
+
+@pytest.mark.enable_socket()
+def test_read_images():
+    url = "https://www.selbst.de/paidcontent/dl/64733/72916"
+    name = "selbst.72916.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    page = reader.pages[0]
+    for _ in page.images:
+        pass

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1417,14 +1417,3 @@ def test_iss1825():
     reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
     page = reader.pages[0]
     page.extract_text()
-
-
-@pytest.mark.enable_socket()
-@pytest.mark.xfail(reason="Raises KeyError: '/Alternate'")
-def test_read_images():
-    url = "https://www.selbst.de/paidcontent/dl/64733/72916"
-    name = "selbst.72916.pdf"
-    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    page = reader.pages[0]
-    for _ in page.images:
-        pass


### PR DESCRIPTION
fixes #1893

applies the same solution as for original ICCbased