### PR TITLE
DOC: Clarify which requirements file is needed to run the tests

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -2,7 +2,7 @@
 
 pypdf uses [`pytest`](https://docs.pytest.org/en/7.1.x/) for testing.
 
-To run the tests you need to install the ci requirements by running `pip install -r requirements/ci.txt` or
+To run the tests you need to install the CI (Continuous Integration) requirements by running `pip install -r requirements/ci.txt` or
 `pip install -r requirements/ci-3.11.txt` if running python 3.11.
 
 ## De-selecting groups of tests

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -2,6 +2,9 @@
 
 pypdf uses [`pytest`](https://docs.pytest.org/en/7.1.x/) for testing.
 
+To run the tests you need to install the ci requirements by running `pip install -r requirements/ci.txt` or
+`pip install -r requirements/ci-3.11.txt` if running python 3.11.
+
 ## De-selecting groups of tests
 
 pypdf makes use of the following pytest markers:


### PR DESCRIPTION
With just the dev requirements installed, pytest fails to run and exits with `pytest: error: unrecognized arguments: --disable-socket` due to `pytest-socket` and `pytest-timeout` not being in the dev requirements.