### PR TITLE
BUG: Check for AcroForm and ensure it is not None

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2921,7 +2921,7 @@ class PdfWriter:
                     pag[NameObject("/Annots")] = lst
                 self.clean_page(pag)
 
-        if "/AcroForm" in cast(DictionaryObject, reader.trailer["/Root"]):
+        if "/AcroForm" in _ro and _ro['/AcroForm'] is not None:
             if "/AcroForm" not in self._root_object:
                 self._root_object[NameObject("/AcroForm")] = self._add_object(
                     cast(


### PR DESCRIPTION
I have a PDF that when read in non-strict mode, yields a "/AcroFrom" = None. This gates the block to ensure the block is skipped. Without it, the clone() call a few lines down will error with 
```
AttributeError: 'NoneType' object has no attribute 'clone'
```