### PR TITLE
DEV: Automate the release process

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -138,16 +138,6 @@ jobs:
         working-directory: /tmp
         run: python -c "import pypdf;print(pypdf.__version__)"
 
-      # - name: Release to pypi if tagged.
-      #   if: startsWith(github.ref, 'refs/tags')
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Create GitHub release if tagged.
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
-
   coverage:
     name: Combine & check coverage.
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   build_and_publish:
+    # this doesn't make sense if you don't have the PyPI secret
+    if: github.repository == 'py-pdf/pypdf'
+    name: Publish a new version of pypdf
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +31,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flit
 
-      - name: Build and Publish Package
+      - name: Publish Package to PyPI🚀
         env:
           FLIT_USERNAME: '__token__'
           FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
@@ -42,7 +45,7 @@ jobs:
         run: |
           latest_tag=$(git describe --tags --abbrev=0)
           tag_body=$(git tag -l "${latest_tag}" --format='%(contents:body)')
-      - name: Create GitHub Release
+      - name: Create GitHub Release 🚀
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@
 # and it's decided what should be in the release.
 # This action only ensures the release is done with the proper contents
 # and that it's announced with a Github release.
-name: Build and Publish Python Package to PyPI
+name: Publish Python Package to PyPI
 on:
   push:
     tags:
@@ -36,9 +36,9 @@ jobs:
           FLIT_USERNAME: '__token__'
           FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
         run: |
-          git fetch --tags
+          git fetch --tags --force
           latest_tag=$(git describe --tags --abbrev=0)
-          flit publish --repository pypi --tag $latest_tag
+          flit publish
 
       # Create the Github Page
       - name: Prepare variables

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Version ${{ github.ref }}
           draft: false
           prerelease: false
           body: ${{ steps.build_and_publish.outputs.tag_body }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,10 @@ jobs:
     steps:
       # Ensure it's on PyPI
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
@@ -36,14 +36,16 @@ jobs:
           FLIT_USERNAME: '__token__'
           FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
         run: |
-          git fetch --tags --force
-          latest_tag=$(git describe --tags --abbrev=0)
           flit publish
 
       # Create the Github Page
       - name: Prepare variables
+        id: prepare_variables
         run: |
+          git fetch --tags --force
           latest_tag=$(git describe --tags --abbrev=0)
+          echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
+          echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
           tag_body=$(git tag -l "${latest_tag}" --format='%(contents:body)')
       - name: Create GitHub Release 🚀
         uses: actions/create-release@v1
@@ -51,7 +53,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Version ${{ github.ref }}
+          release_name: Version ${{ env.latest_tag }}, ${{ env.date }}
           draft: false
           prerelease: false
-          body: ${{ steps.build_and_publish.outputs.tag_body }}
+          body: Body is ${{ env.tag_body }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,54 @@
+# This action assumes that there is a REL-commit which already has a
+# Markdown-formatted git tag. Hence the CHANGELOG is already adjusted
+# and it's decided what should be in the release.
+# This action only ensures the release is done with the proper contents
+# and that it's announced with a Github release.
+name: Build and Publish Python Package to PyPI
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Ensure it's on PyPI
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install Flit
+        run: |
+          python -m pip install --upgrade pip
+          pip install flit
+
+      - name: Build and Publish Package
+        env:
+          FLIT_USERNAME: '__token__'
+          FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
+        run: |
+          git fetch --tags
+          latest_tag=$(git describe --tags --abbrev=0)
+          flit publish --repository pypi --tag $latest_tag
+
+      # Create the Github Page
+      - name: Prepare variables
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0)
+          tag_body=$(git tag -l "${latest_tag}" --format='%(contents:body)')
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+          body: ${{ steps.build_and_publish.outputs.tag_body }}


### PR DESCRIPTION
This PR has two goals:

* Ensure that I, as a maintainer, do releases more consistently and with less effort.
* Enable other trusted members of the pypdf community and the py-pdf organization to make releases to PyPI. That should typically not be done, but is a last resort in case I become inactive.

What was done:

* A new repository secret `FLIT_PASSWORD` was created via PyPI. It is a PyPI token for pypdf.
* A Github Action `release.yaml` (this PR) was created.

## Hints

To ensure that you can write Markdown-style git tags, you can do this:

```
git config --global core.commentChar ";" 
```

## Testing

I used pdfly for that. Looks mostly fine. It especially published to PyPI.
See "TODO" for what is missing.

## TODO

* Make the release have rendered Markdown. I think I struggle with the fact that the body is a multi-line string ... maybe :thinking: 
* Ensure the package is only pushed if it passes our test suite

## Resources

* https://github.com/actions/create-release
* https://flit.pypa.io/en/stable/cmdline.html#envvar-FLIT_INDEX_URL
* https://git-scm.com/docs/git-config#Documentation/git-config.txt-corecommentChar

Closes #1836