### PR TITLE
Check for existence of "/AcroForm/Fields" during merge

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2920,7 +2920,7 @@ class PdfWriter:
                 self.clean_page(pag)
 
         if "/AcroForm" in _ro and _ro["/AcroForm"] is not None:
-            if "/AcroForm" not in self._root_object:
+            if "/AcroForm" not in self._root_object or "/Fields" not in self._root_object["/AcroForm"]: # type: ignore
                 self._root_object[NameObject("/AcroForm")] = self._add_object(
                     cast(
                         DictionaryObject,


### PR DESCRIPTION
Fixes a potential KeyError when accessing "/AcroForm/Fields".

When deciding if "/AcroForm" should be copied over during a merge, it is assumed that the root object's "/AcroForm" comes with a "/Fields" sub-field, which wasn't the case for me and raised a KeyError in the else-branch below. This checks for the existence of the full path before deciding if "/AcroForm" should be copied or not and prevents the KeyError.

Although at a second glance I'm unsure why this works, unless I'm misunderstanding the `clone()`-API, the code is instructing to ignore the "/Fields"-field when cloning the object.