### PR TITLE
DEV: Add body to created GitHub release

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -165,26 +165,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-
-  release-test:
-    name: Test release flow
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Prepare variables
-        id: prepare_variables
-        run: |
-          git fetch --tags --force
-          latest_tag=$(git describe --tags --abbrev=0)
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
-          echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
-          echo "tag_body<<$EOF" >> "$GITHUB_ENV"
-          git tag -l "${latest_tag}" --format='%(contents:body)' >> "$GITHUB_ENV"
-          echo "$EOF" >> "$GITHUB_ENV"
-      - run: echo "latest_tag is ${{ env.latest_tag }}"
-      - run: echo "Body is ${{ env.tag_body }}"

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -173,10 +173,11 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Prepare variables
         id: prepare_variables
         run: |
-          git fetch
           git fetch --tags --force
           latest_tag=$(git describe --tags --abbrev=0)
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -176,6 +176,7 @@ jobs:
       - name: Prepare variables
         id: prepare_variables
         run: |
+          git fetch
           git fetch --tags --force
           latest_tag=$(git describe --tags --abbrev=0)
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -184,7 +184,7 @@ jobs:
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
           echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
           echo "tag_body<<$EOF" >> "$GITHUB_ENV"
-          git tag -l "${latest_tag}"" --format='%(contents:body)' >> "$GITHUB_ENV"
+          git tag -l "${latest_tag}" --format='%(contents:body)' >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"
       - run: echo "latest_tag is ${{ env.latest_tag }}"
       - run: echo "Body is ${{ env.tag_body }}"

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -165,3 +165,21 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+
+  release-test:
+    name: Test release flow
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Prepare variables
+        id: prepare_variables
+        run: |
+          git fetch --tags --force
+          latest_tag=$(git describe --tags --abbrev=0)
+          echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
+          echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+          echo "tag_body=$(git tag -l ${latest_tag} --format='%(contents:body)')" >> "$GITHUB_ENV"
+      - run: echo "latest_tag is ${{ env.latest_tag }}"
+      - run: echo "Body is ${{ env.tag_body }}"

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -180,8 +180,11 @@ jobs:
         run: |
           git fetch --tags --force
           latest_tag=$(git describe --tags --abbrev=0)
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
           echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
-          echo "tag_body=$(git tag -l ${latest_tag} --format='%(contents:body)')" >> "$GITHUB_ENV"
+          echo "tag_body<<$EOF" >> "$GITHUB_ENV"
+          git tag -l "${latest_tag}"" --format='%(contents:body)' >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
       - run: echo "latest_tag is ${{ env.latest_tag }}"
       - run: echo "Body is ${{ env.tag_body }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,7 @@ jobs:
           latest_tag=$(git describe --tags --abbrev=0)
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
           echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "tag_body<<$EOF" >> "$GITHUB_ENV"
           git tag -l "${latest_tag}" --format='%(contents:body)' >> "$GITHUB_ENV"
           echo "$EOF" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,4 +56,4 @@ jobs:
           release_name: Version ${{ env.latest_tag }}, ${{ env.date }}
           draft: false
           prerelease: false
-          body: Body is ${{ env.tag_body }}
+          body: ${{ env.tag_body }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,9 @@ jobs:
           latest_tag=$(git describe --tags --abbrev=0)
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
           echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
-          echo "tag_body=$(git tag -l ${latest_tag} --format='%(contents:body)')" >> "$GITHUB_ENV"
+          echo "tag_body<<$EOF" >> "$GITHUB_ENV"
+          git tag -l "${latest_tag}" --format='%(contents:body)' >> "$GITHUB_ENV"
+          echo "$EOF" >> "$GITHUB_ENV"
       - name: Create GitHub Release 🚀
         uses: actions/create-release@v1
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           latest_tag=$(git describe --tags --abbrev=0)
           echo "latest_tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_ENV"
           echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
-          tag_body=$(git tag -l "${latest_tag}" --format='%(contents:body)')
+          echo "tag_body=$(git tag -l ${latest_tag} --format='%(contents:body)')" >> "$GITHUB_ENV"
       - name: Create GitHub Release 🚀
         uses: actions/create-release@v1
         env:


### PR DESCRIPTION
Closes #1971 

PR fixes that new GitHub releases were lacking a body, where this was due to the fact that we were not outputting `tag_body` to `$GITHUB_ENV` so that it wasn't available in follow-up steps. However, because the body is a multiline string, we've got to wrap it in special syntax to get it to work (see [docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string) for example).

See https://github.com/py-pdf/pypdf/actions/runs/5601580443/jobs/10245662760?pr=1985 as an example test run that shows it working in a test workflow.