### PR TITLE
BUG: Non-deterministic accidental object reuse

### DIFF
--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional, Tuple, Union
-from weakref import WeakKeyDictionary
 
 try:
     # Python 3.8+: https://peps.python.org/pep-0586
@@ -66,7 +65,7 @@ class PdfReaderProtocol(Protocol):  # deprecated
 
 class PdfWriterProtocol(Protocol):  # deprecated
     _objects: List[Any]
-    _id_translated: Dict[PdfReaderProtocol, Dict[int, int]]
+    _id_translated: "WeakKeyDictionary[Any, Dict[int, int]]"
 
     def get_object(self, indirect_reference: Any) -> Optional[PdfObjectProtocol]:
         ...

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -66,7 +66,7 @@ class PdfReaderProtocol(Protocol):  # deprecated
 
 class PdfWriterProtocol(Protocol):  # deprecated
     _objects: List[Any]
-    _id_translated: WeakKeyDictionary[PdfReaderProtocol, Dict[int, int]]
+    _id_translated: Dict[PdfReaderProtocol, Dict[int, int]]
 
     def get_object(self, indirect_reference: Any) -> Optional[PdfObjectProtocol]:
         ...

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional, Tuple, Union
+from weakref import WeakKeyDictionary
 
 try:
     # Python 3.8+: https://peps.python.org/pep-0586
@@ -65,7 +66,7 @@ class PdfReaderProtocol(Protocol):  # deprecated
 
 class PdfWriterProtocol(Protocol):  # deprecated
     _objects: List[Any]
-    _id_translated: Dict[int, Dict[int, int]]
+    _id_translated: WeakKeyDictionary[PdfReaderProtocol, Dict[int, int]]
 
     def get_object(self, indirect_reference: Any) -> Optional[PdfObjectProtocol]:
         ...

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -126,18 +126,18 @@ class PdfObject(PdfObjectProtocol):
             return clone
         i = len(pdf_dest._objects) + 1
         if ind is not None:
-            if id(ind.pdf) not in pdf_dest._id_translated:
-                pdf_dest._id_translated[id(ind.pdf)] = {}
+            if ind.pdf not in pdf_dest._id_translated:
+                pdf_dest._id_translated[ind.pdf] = {}
             if (
                 not force_duplicate
-                and ind.idnum in pdf_dest._id_translated[id(ind.pdf)]
+                and ind.idnum in pdf_dest._id_translated[ind.pdf]
             ):
                 obj = pdf_dest.get_object(
-                    pdf_dest._id_translated[id(ind.pdf)][ind.idnum]
+                    pdf_dest._id_translated[ind.pdf][ind.idnum]
                 )
                 assert obj is not None
                 return obj
-            pdf_dest._id_translated[id(ind.pdf)][ind.idnum] = i
+            pdf_dest._id_translated[ind.pdf][ind.idnum] = i
         pdf_dest._objects.append(clone)
         clone.indirect_reference = IndirectObject(i, 0, pdf_dest)
         return clone
@@ -277,11 +277,11 @@ class IndirectObject(PdfObject):
         if self.pdf == pdf_dest and not force_duplicate:
             # Already duplicated and no extra duplication required
             return self
-        if id(self.pdf) not in pdf_dest._id_translated:
-            pdf_dest._id_translated[id(self.pdf)] = {}
+        if self.pdf not in pdf_dest._id_translated:
+            pdf_dest._id_translated[self.pdf] = {}
 
-        if not force_duplicate and self.idnum in pdf_dest._id_translated[id(self.pdf)]:
-            dup = pdf_dest.get_object(pdf_dest._id_translated[id(self.pdf)][self.idnum])
+        if not force_duplicate and self.idnum in pdf_dest._id_translated[self.pdf]:
+            dup = pdf_dest.get_object(pdf_dest._id_translated[self.pdf][self.idnum])
         else:
             obj = self.get_object()
             # case observed : a pointed object can not be found

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1499,3 +1499,31 @@ def test_watermark():
     b = BytesIO()
     writer.write(b)
     assert len(b.getvalue()) < 2.1 * 1024 * 1024
+
+
+def test_merging_many_temporary_files():
+
+    def create_number_pdf(n) -> BytesIO:
+        from fpdf import FPDF
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("helvetica", "B", 16)
+        pdf.cell(40, 10, str(n))
+        byte_string = pdf.output()
+        return BytesIO(byte_string)
+
+    writer = PdfWriter()
+    for n in range(100):
+        reader = PdfReader(create_number_pdf(n))
+        for page in reader.pages:
+            # Should only be one page.
+            writer.add_page(page)
+
+    out = BytesIO()
+    writer.write(out)
+
+    out.seek(0)
+    reader = PdfReader(out)
+    for n, page in enumerate(reader.pages):
+        text = page.extract_text()
+        assert text == str(n)


### PR DESCRIPTION
The following section of code could sometimes have unintended effects where pages of an earlier integrated PDF file were used instead.

```python
writer = PdfWriter()

reader1 = PdfReader(some_file)
id_reader1 = id(reader1)
writer.add_page(reader1.pages[0])
del reader1

reader2 = PdfReader(other_file)
id_reader2 = id(reader2)
writer.add_page(reader2.pages[0])
del reader2

writer.write(third_file)
```

because the `reader1` is no longer in memory when `reader2` gets initialized, the area in memory is free, so `id_reader1` and `id_reader2` might end up having the same value.

Due to PyPDF using `id(reader)` internally for an object-cache, it sometimes happened that `writer.add_page(reader2.pages[0])` would result in duplicating `reader1.pages[0]` instead.

fixes #1788 .