### PR TITLE
BUG: Cope with different ISO date length

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -59,6 +59,7 @@ from ._utils import (
     deprecation_no_replacement,
     deprecation_with_replacement,
     logger_warning,
+    parse_iso8824_date,
     read_non_whitespace,
     read_previous_line,
     read_until_whitespace,
@@ -239,12 +240,7 @@ class DocumentInformation(DictionaryObject):
     @property
     def creation_date(self) -> Optional[datetime]:
         """Read-only property accessing the document's creation date."""
-        text = self._get_text(DI.CREATION_DATE)
-        if text is None:
-            return None
-        return datetime.strptime(
-            text.replace("Z", "+").replace("'", ""), "D:%Y%m%d%H%M%S%z"
-        )
+        return parse_iso8824_date(self._get_text(DI.CREATION_DATE))
 
     @property
     def creation_date_raw(self) -> Optional[str]:
@@ -263,12 +259,7 @@ class DocumentInformation(DictionaryObject):
 
         The date and time the document was most recently modified.
         """
-        text = self._get_text(DI.MOD_DATE)
-        if text is None:
-            return None
-        return datetime.strptime(
-            text.replace("Z", "+").replace("'", ""), "D:%Y%m%d%H%M%S%z"
-        )
+        return parse_iso8824_date(self._get_text(DI.MOD_DATE))
 
     @property
     def modification_date_raw(self) -> Optional[str]:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -77,7 +77,7 @@ DEPR_MSG = "{} is deprecated and will be removed in pypdf {}. Use {} instead."
 DEPR_MSG_HAPPENED = "{} is deprecated and was removed in pypdf {}. Use {} instead."
 
 
-def parse_iso8824_date(text: str) -> Optional[datetime]:
+def parse_iso8824_date(text: Optional[str]) -> Optional[datetime]:
     orgtext = text
     if text is None:
         return None

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -33,6 +33,7 @@ import functools
 import logging
 import warnings
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from io import DEFAULT_BUFFER_SIZE, BytesIO
 from os import SEEK_CUR
 from typing import (
@@ -74,6 +75,38 @@ DEPR_MSG_NO_REPLACEMENT = "{} is deprecated and will be removed in pypdf {}."
 DEPR_MSG_NO_REPLACEMENT_HAPPENED = "{} is deprecated and was removed in pypdf {}."
 DEPR_MSG = "{} is deprecated and will be removed in pypdf {}. Use {} instead."
 DEPR_MSG_HAPPENED = "{} is deprecated and was removed in pypdf {}. Use {} instead."
+
+
+def parse_iso8824_date(text: str) -> Optional[datetime]:
+    orgtext = text
+    if text is None:
+        return None
+    if text[0].isdigit():
+        text = "D:" + text
+    if text.endswith(("Z", "z")):
+        text += "0000"
+    text = text.replace("z", "+").replace("Z", "+").replace("'", "")
+    i = max(text.find("+"), text.find("-"))
+    if i > 0 and i != len(text) - 5:
+        text += "00"
+    for f in (
+        "D:%Y",
+        "D:%Y%m",
+        "D:%Y%m%d",
+        "D:%Y%m%d%H",
+        "D:%Y%m%d%H%M",
+        "D:%Y%m%d%H%M%S",
+        "D:%Y%m%d%H%M%S%z",
+    ):
+        try:
+            d = datetime.strptime(text, f)  # noqa: DTZ007
+        except ValueError:
+            continue
+        else:
+            if text[-5:] == "+0000":
+                d = d.replace(tzinfo=timezone.utc)
+            return d
+    raise ValueError(f"Can not convert date: {orgtext}")
 
 
 def _get_max_pdf_version_header(header1: bytes, header2: bytes) -> bytes:


### PR DESCRIPTION
ensure compatiblity with all optional date fields formats as specified in pdf  1.7 spec

closes #1996
closes #1972