### PR TITLE
ROB: Let _build_destination skip in case of missing /D key

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -792,7 +792,6 @@ class PdfReader:
                 if isinstance(value, DictionaryObject) and "/D" in value:
                     value = value["/D"]
                 else:
-                    # Not an Array
                     continue
                 dest = self._build_destination(key, value)  # type: ignore
                 if dest is not None:
@@ -803,7 +802,6 @@ class PdfReader:
                 if isinstance(val, DictionaryObject) and "/D" in val:
                     val = val["/D"].get_object()
                 else:
-                    # Not an array
                     continue
                 dest = self._build_destination(k__, val) # type: ignore
                 if dest is not None:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -789,9 +789,10 @@ class PdfReader:
                 except IndexError:
                     break
                 i += 1
-                if isinstance(value, DictionaryObject) and "/D" in value:
+                if isinstance(value, DictionaryObject):
+                  if "/D" in value:
                     value = value["/D"]
-                else:
+                  else:
                     continue
                 dest = self._build_destination(key, value)  # type: ignore
                 if dest is not None:
@@ -799,10 +800,11 @@ class PdfReader:
         else:  # case where Dests is in root catalog (PDF 1.7 specs, §2 about PDF1.1
             for k__, v__ in tree.items():
                 val = v__.get_object()
-                if isinstance(val, DictionaryObject) and "/D" in val:
-                    val = val["/D"].get_object()
-                else:
-                    continue
+                if isinstance(val, DictionaryObject):
+                    if "/D" in val:
+                      val = val["/D"].get_object()
+                    else:
+                      continue
                 dest = self._build_destination(k__, val) # type: ignore
                 if dest is not None:
                     retval[k__] = dest

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -791,15 +791,21 @@ class PdfReader:
                 i += 1
                 if isinstance(value, DictionaryObject) and "/D" in value:
                     value = value["/D"]
+                else:
+                    # Not an Array
+                    continue
                 dest = self._build_destination(key, value)  # type: ignore
                 if dest is not None:
                     retval[key] = dest
         else:  # case where Dests is in root catalog (PDF 1.7 specs, §2 about PDF1.1
             for k__, v__ in tree.items():
                 val = v__.get_object()
-                if isinstance(val, DictionaryObject):
+                if isinstance(val, DictionaryObject) and "/D" in val:
                     val = val["/D"].get_object()
-                dest = self._build_destination(k__, val)
+                else:
+                    # Not an array
+                    continue
+                dest = self._build_destination(k__, val) # type: ignore
                 if dest is not None:
                     retval[k__] = dest
         return retval


### PR DESCRIPTION
Calling _build_destination with a dictionary can cause it to error if the code which slices the array is executed. This skips the scenario where DictionaryObject does not have a "/D" key and is currently passed to _build_destination.