### PR TITLE
TST: Compare extracted images against ground truth

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -19,9 +19,10 @@ from pypdf.filters import (
     CCITTFaxDecode,
     FlateDecode,
 )
-from pypdf.generic import ArrayObject, DictionaryObject, NumberObject
+from pypdf.generic import ArrayObject, DictionaryObject, NameObject, NumberObject
 
 from . import get_pdf_from_url
+from .test_images import image_similarity
 
 filter_inputs = (
     # "", '', """""",
@@ -288,6 +289,31 @@ def test_issue_1737():
 
 
 @pytest.mark.enable_socket()
+def test_pa_image_extraction():
+    """
+    PNG images with PA mode can be extracted.
+
+    This is a regression test for issue #1801
+    """
+    url = "https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf"
+    name = "issue-1801.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+
+    page0 = reader.pages[0]
+    images = page0.images
+    assert len(images) == 1
+    assert images[0].name == "Im1.png"
+
+    # Ensure visual appearence
+    data = get_pdf_from_url(
+        "https://user-images.githubusercontent.com/"
+        "1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png",
+        "issue-1801.png",
+    )
+    assert data == images[0].data
+
+
+@pytest.mark.enable_socket()
 def test_1bit_image_extraction():
     """Cf issue #1814"""
     url = "https://github.com/py-pdf/pypdf/files/11336817/grimm10.pdf"
@@ -311,6 +337,45 @@ def test_png_transparency_reverse():
     _img = Image.open(BytesIO(data.data))
     assert ".jp2" in data.name
     # assert list(img.getdata()) == list(refimg.getdata())
+
+
+@pytest.mark.enable_socket()
+def test_iss1787():
+    """Cf issue #1787"""
+    url = "https://github.com/py-pdf/pypdf/files/11219022/pdf_font_garbled.pdf"
+    name = "pdf_font_garbled.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    url_png = "https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png"
+    name_png = "watermark1.png"
+    refimg = Image.open(
+        BytesIO(get_pdf_from_url(url_png, name=name_png))
+    )  # not a pdf but it works
+    data = reader.pages[0].images[0]
+    img = Image.open(BytesIO(data.data))
+    assert ".png" in data.name
+    assert list(img.getdata()) == list(refimg.getdata())
+    obj = data.indirect_reference.get_object()
+    obj["/DecodeParms"][NameObject("/Columns")] = NumberObject(1000)
+    obj.decoded_self = None
+    with pytest.raises(PdfReadError) as exc:
+        reader.pages[0].images[0]
+    assert exc.value.args[0] == "Image data is not rectangular"
+
+
+@pytest.mark.enable_socket()
+def test_rgba():
+    """Decode rgb with transparency"""
+    url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf"
+    name = "tika-972174.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    url_png = "https://user-images.githubusercontent.com/4083478/238288207-b77dd38c-34b4-4f4f-810a-bf9db7ca0414.png"
+    name_png = "tika-972174_p0-im0.png"
+    data = reader.pages[0].images[0]
+    assert ".jp2" in data.name
+    assert (
+        image_similarity(data.image, BytesIO(get_pdf_from_url(url_png, name=name_png)))
+        > 0.99
+    )
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -363,6 +363,23 @@ def test_iss1787():
 
 
 @pytest.mark.enable_socket()
+def test_tiff_predictor():
+    """Decode Tiff Predictor 2 Images"""
+    url = "https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf"
+    name = "tika-977609.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    url_png = "https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png"
+    name_png = "tifimage.png"
+    refimg = Image.open(
+        BytesIO(get_pdf_from_url(url_png, name=name_png))
+    )  # not a pdf but it works
+    data = reader.pages[0].images[0]
+    img = Image.open(BytesIO(data.data))
+    assert ".png" in data.name
+    assert list(img.getdata()) == list(refimg.getdata())
+
+
+@pytest.mark.enable_socket()
 def test_rgba():
     """Decode rgb with transparency"""
     url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -389,10 +389,10 @@ def test_rgba():
     name_png = "tika-972174_p0-im0.png"
     data = reader.pages[0].images[0]
     assert ".jp2" in data.name
-    assert (
-        image_similarity(data.image, BytesIO(get_pdf_from_url(url_png, name=name_png)))
-        > 0.99
+    similarity = image_similarity(
+        data.image, BytesIO(get_pdf_from_url(url_png, name=name_png))
     )
+    assert similarity > 0.99
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -19,7 +19,7 @@ from pypdf.filters import (
     CCITTFaxDecode,
     FlateDecode,
 )
-from pypdf.generic import ArrayObject, DictionaryObject, NameObject, NumberObject
+from pypdf.generic import ArrayObject, DictionaryObject, NumberObject
 
 from . import get_pdf_from_url
 
@@ -288,31 +288,6 @@ def test_issue_1737():
 
 
 @pytest.mark.enable_socket()
-def test_pa_image_extraction():
-    """
-    PNG images with PA mode can be extracted.
-
-    This is a regression test for issue #1801
-    """
-    url = "https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf"
-    name = "issue-1801.pdf"
-    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-
-    page0 = reader.pages[0]
-    images = page0.images
-    assert len(images) == 1
-    assert images[0].name == "Im1.png"
-
-    # Ensure visual appearence
-    data = get_pdf_from_url(
-        "https://user-images.githubusercontent.com/"
-        "1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png",
-        "issue-1801.png",
-    )
-    assert data == images[0].data
-
-
-@pytest.mark.enable_socket()
 def test_1bit_image_extraction():
     """Cf issue #1814"""
     url = "https://github.com/py-pdf/pypdf/files/11336817/grimm10.pdf"
@@ -336,66 +311,6 @@ def test_png_transparency_reverse():
     _img = Image.open(BytesIO(data.data))
     assert ".jp2" in data.name
     # assert list(img.getdata()) == list(refimg.getdata())
-
-
-@pytest.mark.enable_socket()
-def test_iss1787():
-    """Cf issue #1787"""
-    url = "https://github.com/py-pdf/pypdf/files/11219022/pdf_font_garbled.pdf"
-    name = "pdf_font_garbled.pdf"
-    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    url_png = "https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png"
-    name_png = "watermark1.png"
-    refimg = Image.open(
-        BytesIO(get_pdf_from_url(url_png, name=name_png))
-    )  # not a pdf but it works
-    data = reader.pages[0].images[0]
-    img = Image.open(BytesIO(data.data))
-    assert ".png" in data.name
-    assert list(img.getdata()) == list(refimg.getdata())
-    obj = data.indirect_reference.get_object()
-    obj["/DecodeParms"][NameObject("/Columns")] = NumberObject(1000)
-    obj.decoded_self = None
-    with pytest.raises(PdfReadError) as exc:
-        reader.pages[0].images[0]
-    assert exc.value.args[0] == "Image data is not rectangular"
-
-
-@pytest.mark.enable_socket()
-def test_tiff_predictor():
-    """Decode Tiff Predictor 2 Images"""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf"
-    name = "tika-977609.pdf"
-    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    url_png = "https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png"
-    name_png = "tifimage.png"
-    refimg = Image.open(
-        BytesIO(get_pdf_from_url(url_png, name=name_png))
-    )  # not a pdf but it works
-    data = reader.pages[0].images[0]
-    img = Image.open(BytesIO(data.data))
-    assert ".png" in data.name
-    assert list(img.getdata()) == list(refimg.getdata())
-
-
-@pytest.mark.enable_socket()
-def test_rgba():
-    """Decode rgb with transparency"""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf"
-    name = "tika-972174.pdf"
-    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    url_png = "https://user-images.githubusercontent.com/4083478/238288207-b77dd38c-34b4-4f4f-810a-bf9db7ca0414.png"
-    name_png = "tika-972174_p0-im0.png"
-    refimg = Image.open(
-        BytesIO(get_pdf_from_url(url_png, name=name_png))
-    )  # not a pdf but it works
-    data = reader.pages[0].images[0]
-    assert ".jp2" in data.name
-    diff = ImageChops.difference(data.image, refimg)
-    d = sqrt(
-        sum([(a * a + b * b + c * c + d * d) for a, b, c, d in diff.getdata()])
-    ) / (diff.size[0] * diff.size[1])
-    assert d < 0.01
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -23,11 +23,12 @@ RESOURCE_ROOT = PROJECT_ROOT / "resources"
 SAMPLE_ROOT = PROJECT_ROOT / "sample-files"
 
 
-def open_image(path: Union[Path, Image.Image]) -> Image.Image:
+def open_image(path: Union[Path, Image.Image, BytesIO]) -> Image.Image:
     if isinstance(path, Image.Image):
         img = path
     else:
-        assert path.exists()
+        if isinstance(path, Path):
+            assert path.exists()
         with Image.open(path) as img:
             img = (
                 img.copy()
@@ -36,7 +37,7 @@ def open_image(path: Union[Path, Image.Image]) -> Image.Image:
 
 
 def image_similarity(
-    path1: Union[Path, Image.Image], path2: Union[Path, Image.Image]
+    path1: Union[Path, Image.Image, BytesIO], path2: Union[Path, Image.Image, BytesIO]
 ) -> float:
     """
     Check image similarity.

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -92,8 +92,24 @@ def test_image_new_property():
             "/Im2",
             SAMPLE_ROOT / "009-pdflatex-geotopo/page-23-Im2.png",
         ),
-        # (SAMPLE_ROOT / "009-pdflatex-geotopo/GeoTopo.pdf", 30, '/Fm22',
-        #  SAMPLE_ROOT / "009-pdflatex-geotopo/page-30-Fm22.png"),
+        (
+            SAMPLE_ROOT / "003-pdflatex-image/pdflatex-image.pdf",
+            0,
+            "/Im1",
+            SAMPLE_ROOT / "003-pdflatex-image/page-0-Im1.jpg",
+        ),
+        (
+            SAMPLE_ROOT / "018-base64-image/base64image.pdf",
+            0,
+            "/QuickPDFImd32aa1ab",
+            SAMPLE_ROOT / "018-base64-image/page-0-QuickPDFImd32aa1ab.png",
+        ),
+        (
+            SAMPLE_ROOT / "019-grayscale-image/grayscale-image.pdf",
+            0,
+            "/X0",
+            SAMPLE_ROOT / "019-grayscale-image/page-0-X0.png",
+        ),
     ],
 )
 @pytest.mark.samples()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -23,6 +23,18 @@ RESOURCE_ROOT = PROJECT_ROOT / "resources"
 SAMPLE_ROOT = PROJECT_ROOT / "sample-files"
 
 
+def open_image(path: Union[Path, Image.Image]) -> Image.Image:
+    if isinstance(path, Image.Image):
+        img = path
+    else:
+        assert path.exists()
+        with Image.open(path) as img:
+            img = (
+                img.copy()
+            )  # Opened image should be copied to avoid issues with file closing
+    return img
+
+
 def image_similarity(
     path1: Union[Path, Image.Image], path2: Union[Path, Image.Image]
 ) -> float:
@@ -35,14 +47,8 @@ def image_similarity(
     This can be used to ensure visual similarity.
     """
     # Open the images using Pillow
-    if isinstance(path1, Image.Image):
-        image1 = path1
-    else:
-        image1 = Image.open(path1)
-    if isinstance(path2, Image.Image):
-        image2 = path2
-    else:
-        image2 = Image.open(path2)
+    image1 = open_image(path1)
+    image2 = open_image(path2)
 
     # Check if the images have the same dimensions
     if image1.size != image2.size:

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -166,20 +166,3 @@ def test_image_extraction(src, page_index, image_key, expected):
         with open(f"page-{page_index}-{actual_image.name}", "wb") as fp:
             fp.write(actual_image.data)
     assert image_similarity(BytesIO(actual_image.data), expected) >= 0.99
-
-
-@pytest.mark.enable_socket()
-def test_tiff_predictor():
-    """Decode Tiff Predictor 2 Images"""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf"
-    name = "tika-977609.pdf"
-    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
-    url_png = "https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png"
-    name_png = "tifimage.png"
-    refimg = Image.open(
-        BytesIO(get_pdf_from_url(url_png, name=name_png))
-    )  # not a pdf but it works
-    data = reader.pages[0].images[0]
-    img = Image.open(BytesIO(data.data))
-    assert ".png" in data.name
-    assert list(img.getdata()) == list(refimg.getdata())

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -6,13 +6,16 @@ and/or the actual image data with the expected value.
 """
 
 from io import BytesIO
+from math import sqrt
 from pathlib import Path
 
 import pytest
-from PIL import Image
+from PIL import Image, ImageChops
 
 from pypdf import PdfReader
 from pypdf._page import PageObject
+from pypdf.errors import PdfReadError
+from pypdf.generic import NameObject, NumberObject
 
 from . import get_pdf_from_url
 
@@ -27,7 +30,9 @@ def image_similarity(path1: Path, path2: Path) -> float:
     Check image similarity.
 
     A value of "0" means the images are different. A value of 1 means they are
-    identical. A value above 0.9 means they are almost the same
+    identical. A value above 0.9 means they are almost the same.
+
+    This can be used to ensure visual similarity.
     """
     # Open the images using Pillow
     image1 = Image.open(path1)
@@ -162,3 +167,88 @@ def test_image_extraction(src, page_index, image_key, expected):
         with open(f"page-{page_index}-{actual_image.name}", "wb") as fp:
             fp.write(actual_image.data)
     assert image_similarity(BytesIO(actual_image.data), expected) >= 0.99
+
+
+@pytest.mark.enable_socket()
+def test_pa_image_extraction():
+    """
+    PNG images with PA mode can be extracted.
+
+    This is a regression test for issue #1801
+    """
+    url = "https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf"
+    name = "issue-1801.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+
+    page0 = reader.pages[0]
+    images = page0.images
+    assert len(images) == 1
+    assert images[0].name == "Im1.png"
+
+    # Ensure visual appearence
+    data = get_pdf_from_url(
+        "https://user-images.githubusercontent.com/"
+        "1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png",
+        "issue-1801.png",
+    )
+    assert data == images[0].data
+
+
+@pytest.mark.enable_socket()
+def test_iss1787():
+    """Cf issue #1787"""
+    url = "https://github.com/py-pdf/pypdf/files/11219022/pdf_font_garbled.pdf"
+    name = "pdf_font_garbled.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    url_png = "https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png"
+    name_png = "watermark1.png"
+    refimg = Image.open(
+        BytesIO(get_pdf_from_url(url_png, name=name_png))
+    )  # not a pdf but it works
+    data = reader.pages[0].images[0]
+    img = Image.open(BytesIO(data.data))
+    assert ".png" in data.name
+    assert list(img.getdata()) == list(refimg.getdata())
+    obj = data.indirect_reference.get_object()
+    obj["/DecodeParms"][NameObject("/Columns")] = NumberObject(1000)
+    obj.decoded_self = None
+    with pytest.raises(PdfReadError) as exc:
+        reader.pages[0].images[0]
+    assert exc.value.args[0] == "Image data is not rectangular"
+
+
+@pytest.mark.enable_socket()
+def test_tiff_predictor():
+    """Decode Tiff Predictor 2 Images"""
+    url = "https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf"
+    name = "tika-977609.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    url_png = "https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png"
+    name_png = "tifimage.png"
+    refimg = Image.open(
+        BytesIO(get_pdf_from_url(url_png, name=name_png))
+    )  # not a pdf but it works
+    data = reader.pages[0].images[0]
+    img = Image.open(BytesIO(data.data))
+    assert ".png" in data.name
+    assert list(img.getdata()) == list(refimg.getdata())
+
+
+@pytest.mark.enable_socket()
+def test_rgba():
+    """Decode rgb with transparency"""
+    url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf"
+    name = "tika-972174.pdf"
+    reader = PdfReader(BytesIO(get_pdf_from_url(url, name=name)))
+    url_png = "https://user-images.githubusercontent.com/4083478/238288207-b77dd38c-34b4-4f4f-810a-bf9db7ca0414.png"
+    name_png = "tika-972174_p0-im0.png"
+    refimg = Image.open(
+        BytesIO(get_pdf_from_url(url_png, name=name_png))
+    )  # not a pdf but it works
+    data = reader.pages[0].images[0]
+    assert ".jp2" in data.name
+    diff = ImageChops.difference(data.image, refimg)
+    d = sqrt(
+        sum([(a * a + b * b + c * c + d * d) for a, b, c, d in diff.getdata()])
+    ) / (diff.size[0] * diff.size[1])
+    assert d < 0.01

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -47,16 +47,14 @@ def image_similarity(path1: Path, path2: Path) -> float:
         return 0
 
     # Convert images to pixel data arrays
-    pixels1 = list(image1.getdata())
-    pixels2 = list(image2.getdata())
+    diff = ImageChops.difference(image1, image2)
+    pixels = list(diff.getdata())
+
     # Calculate the Mean Squared Error (MSE)
-    if isinstance(pixels1[0], tuple):
-        mse = sum(
-            sum((c1 - c2) ** 2 for c1, c2 in zip(p1, p2))
-            for p1, p2 in zip(pixels1, pixels2)
-        ) / len(pixels1)
+    if isinstance(pixels[0], tuple):
+        mse = sum(sum(c**2 for c in p) / len(p) for p in pixels) / len(pixels)
     else:
-        mse = sum((p1 - p2) ** 2 for p1, p2 in zip(pixels1, pixels2)) / len(pixels1)
+        mse = sum(p**2 for p in pixels) / len(pixels)
 
     return 1 - mse
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -111,6 +111,12 @@ def test_image_new_property():
             SAMPLE_ROOT / "019-grayscale-image/page-0-X0.png",
         ),
     ],
+    ids=[
+        "009-pdflatex-geotopo/page-23-Im2.png",
+        "003-pdflatex-image/page-0-Im1.jpg",
+        "018-base64-image/page-0-QuickPDFImd32aa1ab.png",
+        "019-grayscale-image/page-0-X0.png",
+    ],
 )
 @pytest.mark.samples()
 def test_image_extraction(src, page_index, image_key, expected):


### PR DESCRIPTION
A function `image_similarity` was introduced which quantifies visual similarities of two images via Mean Squared Error (MSE). This way we can compare the extracted images with what we expect.

We cannot make a byte-wise comparison as updates to PIL can change the representation.

The new function helps us to ensure that updates to the pypdf code don't break image extraction.