### PR TITLE
PI: Use bytearray instead of bytes in ContentStream init

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1002,7 +1002,7 @@ class ContentStream(DecodedStreamObject):
         if stream is not None:
             stream = stream.get_object()
             if isinstance(stream, ArrayObject):
-                data = b""
+                data = bytearray()
                 for s in stream:
                     data += b_(s.get_object().get_data())
                     if len(data) == 0 or data[-1] != b"\n":


### PR DESCRIPTION
bytearray is mutable in contrast to bytes

See https://stackoverflow.com/a/62903378/562769

Running https://github.com/py-pdf/benchmarks:

* Text extraction speed: 2.3s ➔ 2.4s
* Image extraction speed: 2.8s - 2.9 ➔ 2.9s
* Watermarking speed: 10.3 - 10.4 ➔ 10.7s
  - For https://arxiv.org/pdf/2201.00214.pdf: 81.1s - 82.5s ➔ 82.9s