### PR TITLE
DEV: Add pytest-timeout to the dev dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ crypto = [
     "PyCryptodome; python_version == '3.6'",
 ]
 image = ["Pillow>=8.0.0"]
-dev = ["black", "pip-tools", "pre-commit<2.18.0", "pytest-cov", "pytest-socket", "flit", "wheel"]
+dev = ["black", "pip-tools", "pre-commit<2.18.0", "pytest-cov", "pytest-socket", "pytest-timeout", "flit", "wheel"]
 docs = ["sphinx", "sphinx_rtd_theme", "myst_parser"]
 
 [tool.mutmut]


### PR DESCRIPTION
Trying to run the tests after `pip install -e '.[dev]'` results in:

ERROR tests/test_reader.py - pytest.PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this