### PR TITLE
MAINT: Make ParseError inherit from PyPdfError

### DIFF
--- a/pypdf/errors.py
+++ b/pypdf/errors.py
@@ -36,7 +36,7 @@ class PdfStreamError(PdfReadError):
     """Raised when there is an issue reading the stream of data in a PDF file."""
 
 
-class ParseError(Exception):
+class ParseError(PyPdfError):
     """
     Raised when there is an issue parsing (analyzing and understanding the
     structure and meaning of) a PDF file.


### PR DESCRIPTION
It’s an exception raised by PyPdfError, I don’t see a reason to treat it
specially.