### PR TITLE
MAINT: Relax typing_extensions version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typing_extensions >= 3.10.0.0; python_version < '3.10'",
+    "typing_extensions >= 3.7.4.2; python_version < '3.10'",
     "dataclasses; python_version < '3.7'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "typing_extensions >= 3.7.4.2; python_version < '3.10'",
+    "typing_extensions >= 3.7.4.3; python_version < '3.10'",
     "dataclasses; python_version < '3.7'",
 ]
 


### PR DESCRIPTION
This relaxes the version of `typing_extensions` required by PyPDF as proposed in #1950.

Please note that this change is not reflected in CI due to the reasons outlined in https://github.com/py-pdf/pypdf/issues/1950#issuecomment-1627387294, but I have tested it locally and some time ago on my fork of the project.

Closes #1950.