### PR TITLE
DEV: Add upper limits for complexity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         additional_dependencies: [black==22.1.0]
         exclude: "docs/user/robustness.md"
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.285'
+    rev: v0.0.285
     hooks:
     -   id: ruff
         args: ['--fix']

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -243,17 +243,17 @@ def handle_tj(
                 if (
                     # cases where the current inserting order is kept
                     (xx <= 0x2F)                        # punctuations but...
-                    or (0x3A <= xx and xx <= 0x40)      # numbers (x30-39)
-                    or (0x2000 <= xx and xx <= 0x206F)  # upper punctuations..
-                    or (0x20A0 <= xx and xx <= 0x21FF)  # but (numbers) indices/exponents
+                    or (xx >= 0x3A and xx <= 0x40)      # numbers (x30-39)
+                    or (xx >= 0x2000 and xx <= 0x206F)  # upper punctuations..
+                    or (xx >= 0x20A0 and xx <= 0x21FF)  # but (numbers) indices/exponents
                     or xx in CUSTOM_RTL_SPECIAL_CHARS   # customized....
                 ):
                     text = x + text if rtl_dir else text + x
                 elif (  # right-to-left characters set
-                    (0x0590 <= xx and xx <= 0x08FF)
-                    or (0xFB1D <= xx and xx <= 0xFDFF)
-                    or (0xFE70 <= xx and xx <= 0xFEFF)
-                    or (CUSTOM_RTL_MIN <= xx and xx <= CUSTOM_RTL_MAX)
+                    (xx >= 0x0590 and xx <= 0x08FF)
+                    or (xx >= 0xFB1D and xx <= 0xFDFF)
+                    or (xx >= 0xFE70 and xx <= 0xFEFF)
+                    or (xx >= CUSTOM_RTL_MIN and xx <= CUSTOM_RTL_MAX)
                 ):
                     if not rtl_dir:
                         rtl_dir = True

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -243,17 +243,17 @@ def handle_tj(
                 if (
                     # cases where the current inserting order is kept
                     (xx <= 0x2F)                        # punctuations but...
-                    or (xx >= 0x3A and xx <= 0x40)      # numbers (x30-39)
-                    or (xx >= 0x2000 and xx <= 0x206F)  # upper punctuations..
-                    or (xx >= 0x20A0 and xx <= 0x21FF)  # but (numbers) indices/exponents
+                    or 0x3A <= xx <= 0x40               # numbers (x30-39)
+                    or 0x2000 <= xx <= 0x206F           # upper punctuations..
+                    or 0x20A0 <= xx <= 0x21FF           # but (numbers) indices/exponents
                     or xx in CUSTOM_RTL_SPECIAL_CHARS   # customized....
                 ):
                     text = x + text if rtl_dir else text + x
                 elif (  # right-to-left characters set
-                    (xx >= 0x0590 and xx <= 0x08FF)
-                    or (xx >= 0xFB1D and xx <= 0xFDFF)
-                    or (xx >= 0xFE70 and xx <= 0xFEFF)
-                    or (xx >= CUSTOM_RTL_MIN and xx <= CUSTOM_RTL_MAX)
+                    0x0590 <= xx <= 0x08FF
+                    or 0xFB1D <= xx <= 0xFDFF
+                    or 0xFE70 <= xx <= 0xFEFF
+                    or CUSTOM_RTL_MIN <= xx <= CUSTOM_RTL_MAX
                 ):
                     if not rtl_dir:
                         rtl_dir = True

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -79,7 +79,7 @@ def read_string_from_stream(
             try:
                 tok = escape_dict[tok]
             except KeyError:
-                if tok >= b"0" and tok <= b"7":
+                if b"0" <= tok <= b"7":
                     # "The number ddd may consist of one, two, or three
                     # octal digits; high-order overflow shall be ignored.
                     # Three octal digits shall be used, with leading zeros
@@ -87,7 +87,7 @@ def read_string_from_stream(
                     # a digit." (PDF reference 7.3.4.2, p 16)
                     for _ in range(2):
                         ntok = stream.read(1)
-                        if ntok >= b"0" and ntok <= b"7":
+                        if b"0" <= ntok <= b"7":
                             tok += ntok
                         else:
                             stream.seek(-1, 1)  # ntok has to be analyzed

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -79,7 +79,7 @@ def read_string_from_stream(
             try:
                 tok = escape_dict[tok]
             except KeyError:
-                if b"0" <= tok and tok <= b"7":
+                if tok >= b"0" and tok <= b"7":
                     # "The number ddd may consist of one, two, or three
                     # octal digits; high-order overflow shall be ignored.
                     # Three octal digits shall be used, with leading zeros
@@ -87,7 +87,7 @@ def read_string_from_stream(
                     # a digit." (PDF reference 7.3.4.2, p 16)
                     for _ in range(2):
                         ntok = stream.read(1)
-                        if b"0" <= ntok and ntok <= b"7":
+                        if ntok >= b"0" and ntok <= b"7":
                             tok += ntok
                         else:
                             stream.seek(-1, 1)  # ntok has to be analyzed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ ignore = [
     "S110", # `try`-`except`-`pass` detected, consider logging the exception
     "SIM105",  # contextlib.suppress
     "SIM108",  # don't enforce ternary operators
-    "SIM300",  # yoda conditions
     "TID252",  # we want relative imports
     "TRY", # I don't know what this is about
     # As long as we are not on Python 3.9+
@@ -171,7 +170,6 @@ ignore = [
     "B028",  # No explicit `stacklevel` keyword argument found
     "B904", # Within an `except` clause, raise exceptions with
     "B905",  # `zip()` without an explicit `strict=` parameter
-    "C901",
     "D101",  # Missing docstring in public class
     "D102", # Missing docstring in public method
     "D417",  # Missing argument descriptions in the docstring
@@ -180,11 +178,6 @@ ignore = [
     "FBT003", # Boolean positional value in function call
     "PGH", # Use specific error messages
     "PLE",  # too many arguments for logging
-    "PLR0911",  # Too many return statements
-    "PLR0912", # Too many branches
-    "PLR0913",  # Too many arguments to function call
-    "PLR0915", # Too many statements
-    "PLR2004", # Magic value
     "PLW",  # global variables
     "PT011", # `pytest.raises(ValueError)` is too broad, set the `match`
     "PT012",  # `pytest.raises()` block should contain a single simple statement
@@ -199,18 +192,27 @@ ignore = [
     "PT014",  # Duplicate of test case at index 1 in `@pytest_mark.parametrize`
 ]
 
+[tool.ruff.mccabe]
+max-complexity = 54  # Recommended: 10
+
 [tool.ruff.per-file-ignores]
-"tests/*" = ["S101", "ANN001", "ANN201","D104", "S105", "S106", "D103", "B018", "B017"]
-"sample-files/*" = ["D100", "INP001"]
-"_encryption.py" = ["S324", "S311"]
 "_cryptography.py" = ["S304", "S305"]  # Use of insecure cipher / modes, aka RC4 and AES-ECB
+"_encryption.py" = ["S324", "S311"]
 "_writer.py" = ["S324"]
-"make_changelog.py" = ["T201", "S603", "S607"]
-"json_consistency.py" = ["T201"]
-"tests/test_workflows.py" =  ["T201"]
 "docs/conf.py" = ["PTH", "INP001"]
-# We first need to deprecate old stuff:
-"pypdf/*" = ["N802", "N803"]
+"json_consistency.py" = ["T201"]
+"make_changelog.py" = ["T201", "S603", "S607"]
+"pypdf/*" = ["N802", "N803"]  # We first need to deprecate old stuff:
+"sample-files/*" = ["D100", "INP001"]
+"tests/*" = ["S101", "ANN001", "ANN201","D104", "S105", "S106", "D103", "B018", "B017"]
+"tests/test_workflows.py" =  ["T201"]
+
+[tool.ruff.pylint]
+allow-magic-value-types = ["bytes", "float", "int", "str"]
+max-args = 12  # Recommended: 5
+max-branches = 36  # Recommended: 12
+max-returns = 11  # Recommended: 6
+max-statements = 176  # Recommended: 50
 
 [tool.docformatter]
 pre-summary-newline = true

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -205,7 +205,7 @@ def test_ccitparameters():
 )
 def test_ccitt_get_parameters(parameters, expected_k):
     parmeters = CCITTFaxDecode._get_parameters(parameters=parameters, rows=0)
-    assert expected_k == parmeters.K
+    assert parmeters.K == expected_k  # noqa: SIM300
 
 
 def test_ccitt_fax_decode():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -205,7 +205,7 @@ def test_ccitparameters():
 )
 def test_ccitt_get_parameters(parameters, expected_k):
     parmeters = CCITTFaxDecode._get_parameters(parameters=parameters, rows=0)
-    assert parmeters.K == expected_k
+    assert expected_k == parmeters.K
 
 
 def test_ccitt_fax_decode():


### PR DESCRIPTION
If we set upper limits then if someone wants to contribute more complex code then they need to justify in their pull request why they _need_ messier code than is already in the codebase.
```toml
[tool.ruff.mccabe]
max-complexity = 54  # Recommended: 10

[tool.ruff.pylint]
allow-magic-value-types = ["bytes", "float", "int", "str"]
max-args = 12  # Recommended: 5
max-branches = 36  # Recommended: 12
max-returns = 11  # Recommended: 6
max-statements = 176  # Recommended: 50
```