### PR TITLE
DEV: setup-python for Python 3.12 allow-prerelease: true in Github Actions

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -18,7 +18,6 @@ on:
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
@@ -31,6 +30,7 @@ jobs:
             use-crypto-lib: ""
           - python-version: "3.12"
             os: "ubuntu-22.04"
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-beta.4"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         use-crypto-lib: ["pycryptodome"]
         include:
           - python-version: "3.9"
@@ -44,11 +44,12 @@ jobs:
       if: matrix.python-version == '3.6' || matrix.python-version == '3.7' || matrix.python-version == '3.8' || matrix.python-version == '3.9' || matrix.python-version == '3.10'
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: '**/requirements/ci.txt'
     - name: Setup Python (3.11+)
       uses: actions/setup-python@v4
-      if: matrix.python-version == '3.11' || matrix.python-version == '3.12.0-beta.4'
+      if: matrix.python-version == '3.11' || matrix.python-version == '3.12'
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -63,7 +64,7 @@ jobs:
     - name: Install requirements (Python 3.11+)
       run: |
         pip install -r requirements/ci-3.11.txt
-      if: matrix.python-version == '3.11' || matrix.python-version == '3.12.0-beta.4'
+      if: matrix.python-version == '3.11' || matrix.python-version == '3.12'
     - name: Remove pycryptodome
       run: |
         pip uninstall pycryptodome -y

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -18,9 +18,9 @@ on:
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        os-version: ["ubuntu-20.04"]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         use-crypto-lib: ["pycryptodome"]
         include:
@@ -28,7 +28,6 @@ jobs:
             use-crypto-lib: "cryptography"
           - python-version: "3.10"
             use-crypto-lib: ""
-    runs-on: ${{ matrix.os-version }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -18,16 +18,19 @@ on:
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
-    runs-on: ubuntu-20.04
+    runs-on: matrix.os-version
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os-version: ["ubuntu-20.04"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         use-crypto-lib: ["pycryptodome"]
         include:
           - python-version: "3.9"
             use-crypto-lib: "cryptography"
           - python-version: "3.10"
             use-crypto-lib: ""
+          - python-version: "3.12"
+            os-version: "ubuntu-22.04"
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -18,10 +18,10 @@ on:
 jobs:
   tests:
     name: pytest on ${{ matrix.python-version }}
-    runs-on: matrix.os-version
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os-version: ["ubuntu-20.04"]
+        os: ["ubuntu-20.04"]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         use-crypto-lib: ["pycryptodome"]
         include:
@@ -30,7 +30,7 @@ jobs:
           - python-version: "3.10"
             use-crypto-lib: ""
           - python-version: "3.12"
-            os-version: "ubuntu-22.04"
+            os: "ubuntu-22.04"
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -20,7 +20,7 @@ jobs:
     name: pytest on ${{ matrix.python-version }}
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
+        os-version: ["ubuntu-20.04"]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         use-crypto-lib: ["pycryptodome"]
         include:
@@ -29,8 +29,9 @@ jobs:
           - python-version: "3.10"
             use-crypto-lib: ""
           - python-version: "3.12"
-            os: "ubuntu-22.04"
-    runs-on: ${{ matrix.os }}
+            use-crypto-lib: "pycryptodome"
+            os-version: "ubuntu-22.04"
+    runs-on: ${{ matrix.os-version }}
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -21,16 +21,13 @@ jobs:
     strategy:
       matrix:
         os-version: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         use-crypto-lib: ["pycryptodome"]
         include:
           - python-version: "3.9"
             use-crypto-lib: "cryptography"
           - python-version: "3.10"
             use-crypto-lib: ""
-          - python-version: "3.12"
-            use-crypto-lib: "pycryptodome"
-            os-version: "ubuntu-22.04"
     runs-on: ${{ matrix.os-version }}
     steps:
     - name: Checkout Code
@@ -48,7 +45,6 @@ jobs:
       if: matrix.python-version == '3.6' || matrix.python-version == '3.7' || matrix.python-version == '3.8' || matrix.python-version == '3.9' || matrix.python-version == '3.10'
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: '**/requirements/ci.txt'
     - name: Setup Python (3.11+)
@@ -56,6 +52,7 @@ jobs:
       if: matrix.python-version == '3.11' || matrix.python-version == '3.12'
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
         cache: 'pip'
         cache-dependency-path: '**/requirements/ci-3.11.txt'
     - name: Upgrade pip


### PR DESCRIPTION
Use the current version of Python 3.12 whether it is a pre-release or a production release as discussed at: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases

This should run tests on [Python 3.12 rc1](https://www.python.org/download/pre-releases/) instead of hard coding __beta 4__.