### PR TITLE
DEV: Add easy way to see all relevant versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -17,7 +17,7 @@ Which environment were you using when you encountered the problem?
 $ python -m platform
 # TODO: Your output goes here
 
-$ python -c "import pypdf;print(pypdf.__version__)"
+$ python -c "import pypdf;print(pypdf._debug_versions)"
 # TODO: Your output goes here
 ```
 
@@ -36,4 +36,6 @@ better. Let us know if we may add them to our tests!
 
 This is the complete Traceback I see:
 
-TODO
+```
+# TODO: Your Traceback goes here (if applicable)
+```

--- a/pypdf/__init__.py
+++ b/pypdf/__init__.py
@@ -7,6 +7,7 @@ text and metadata from PDFs as well.
 You can read the full docs at https://pypdf.readthedocs.io/.
 """
 
+from ._crypt_providers import crypt_provider
 from ._encryption import PasswordType
 from ._merger import PdfFileMerger, PdfMerger
 from ._page import PageObject, Transformation
@@ -16,8 +17,20 @@ from ._writer import ObjectDeletionFlag, PdfFileWriter, PdfWriter
 from .pagerange import PageRange, parse_filename_page_ranges
 from .papersizes import PaperSize
 
+try:
+    import PIL
+
+    pil_version = PIL.__version__
+except ImportError:
+    pil_version = "none"
+
+_debug_versions = (
+    f"pypdf=={__version__}, crypt_provider={crypt_provider}, PIL={pil_version}"
+)
+
 __all__ = [
     "__version__",
+    "_debug_versions",
     "PageRange",
     "PaperSize",
     "DocumentInformation",

--- a/pypdf/_crypt_providers/__init__.py
+++ b/pypdf/_crypt_providers/__init__.py
@@ -35,6 +35,7 @@ try:
         aes_cbc_encrypt,
         aes_ecb_decrypt,
         aes_ecb_encrypt,
+        crypt_provider,
         rc4_decrypt,
         rc4_encrypt,
     )
@@ -47,6 +48,7 @@ except ImportError:
             aes_cbc_encrypt,
             aes_ecb_decrypt,
             aes_ecb_encrypt,
+            crypt_provider,
             rc4_decrypt,
             rc4_encrypt,
         )
@@ -58,11 +60,13 @@ except ImportError:
             aes_cbc_encrypt,
             aes_ecb_decrypt,
             aes_ecb_encrypt,
+            crypt_provider,
             rc4_decrypt,
             rc4_encrypt,
         )
 
 __all__ = [
+    "crypt_provider",
     "CryptBase",
     "CryptIdentity",
     "CryptRC4",

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -27,7 +27,6 @@
 
 import secrets
 
-from cryptography import __version__  # type: ignore
 from cryptography.hazmat.primitives import padding  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.base import Cipher  # type: ignore[import]
@@ -35,7 +34,7 @@ from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB  # type: ignor
 
 from pypdf._crypt_providers._base import CryptBase
 
-crypt_provider = ("cryptography", __version__)
+crypt_provider = ("cryptography", "__version__")
 
 
 class CryptRC4(CryptBase):

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -27,7 +27,7 @@
 
 import secrets
 
-from cryptography import __version__  # type: ignore[import]
+from cryptography import __version__  # type: ignore
 from cryptography.hazmat.primitives import padding  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.base import Cipher  # type: ignore[import]

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -27,6 +27,7 @@
 
 import secrets
 
+from cryptography import __version__  # type: ignore[import]
 from cryptography.hazmat.primitives import padding  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.base import Cipher  # type: ignore[import]
@@ -34,7 +35,7 @@ from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB  # type: ignor
 
 from pypdf._crypt_providers._base import CryptBase
 
-crypt_provider = ("cryptography", "__version__")
+crypt_provider = ("cryptography", __version__)
 
 
 class CryptRC4(CryptBase):

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -27,12 +27,15 @@
 
 import secrets
 
+from cryptography import __version__
 from cryptography.hazmat.primitives import padding  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.base import Cipher  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB  # type: ignore[import]
 
 from pypdf._crypt_providers._base import CryptBase
+
+crypt_provider = ("cryptography", __version__)
 
 
 class CryptRC4(CryptBase):

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -27,7 +27,7 @@
 
 import secrets
 
-from cryptography import __version__
+from cryptography import __version__  # type: ignore[import]
 from cryptography.hazmat.primitives import padding  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4  # type: ignore[import]
 from cryptography.hazmat.primitives.ciphers.base import Cipher  # type: ignore[import]

--- a/pypdf/_crypt_providers/_fallback.py
+++ b/pypdf/_crypt_providers/_fallback.py
@@ -31,6 +31,9 @@ from pypdf.errors import DependencyError
 _DEPENDENCY_ERROR_STR = "PyCryptodome is required for AES algorithm"
 
 
+crypt_provider = ("local_crypt_fallback", "0.0.0")
+
+
 class CryptRC4(CryptBase):  # type: ignore
     def __init__(self, key: bytes) -> None:
         self.S = bytearray(range(256))

--- a/pypdf/_crypt_providers/_pycryptodome.py
+++ b/pypdf/_crypt_providers/_pycryptodome.py
@@ -27,10 +27,13 @@
 
 import secrets
 
+from Crypto import __version__
 from Crypto.Cipher import AES, ARC4  # type: ignore[import]
 from Crypto.Util.Padding import pad  # type: ignore[import]
 
 from pypdf._crypt_providers._base import CryptBase
+
+crypt_provider = ("pycryptodome", __version__)
 
 
 class CryptRC4(CryptBase):

--- a/pypdf/_crypt_providers/_pycryptodome.py
+++ b/pypdf/_crypt_providers/_pycryptodome.py
@@ -27,7 +27,7 @@
 
 import secrets
 
-from Crypto import __version__
+from Crypto import __version__  # type: ignore[import]
 from Crypto.Cipher import AES, ARC4  # type: ignore[import]
 from Crypto.Util.Padding import pad  # type: ignore[import]
 


### PR DESCRIPTION
We often need a couple of package versions to investigate issues. This command gives us a one-liner to get that data.

See #2107