### PR TITLE
ROB: Cope with damaged PDF

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -496,6 +496,8 @@ class DictionaryObject(dict, PdfObject):
                 assert pdf is not None  # hint for mypy
                 length = pdf.get_object(length)
                 stream.seek(t, 0)
+            if length is None:  # if the PDF is damaged
+                length = -1
             pstart = stream.tell()
             if length > 0:
                 data["__streamdata__"] = stream.read(length)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1238,7 +1238,9 @@ def test_iss1601():
     url = "https://github.com/py-pdf/pypdf/files/10579503/badges-38.pdf"
     name = "badge-38.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
-    original_cs_operations = ContentStream(reader.pages[0].get_contents(), reader).operations
+    original_cs_operations = ContentStream(
+        reader.pages[0].get_contents(), reader
+    ).operations
     writer = PdfWriter()
     page_1 = writer.add_blank_page(
         reader.pages[0].mediabox[2], reader.pages[0].mediabox[3]
@@ -1636,6 +1638,19 @@ def test_no_t_in_articles():
     """Cf #2078"""
     url = "https://github.com/py-pdf/pypdf/files/12311735/bad.pdf"
     name = "iss2078.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter()
+    writer.append(reader)
+
+
+@pytest.mark.enable_socket()
+def test_damaged_pdf_length_returning_none():
+    """
+    Cf #140
+    https://github.com/py-pdf/pypdf/issues/140#issuecomment-1685380549
+    """
+    url = "https://github.com/py-pdf/pypdf/files/12168578/bad_pdf_example.pdf"
+    name = "iss140_bad_pdf.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     writer = PdfWriter()
     writer.append(reader)


### PR DESCRIPTION
closes  #140  - late exchanges in the theads:
https://github.com/py-pdf/pypdf/issues/140#issuecomment-1685380549

the PDF is damaged.The length is an indirectobject that can not be found returning None.