### PR TITLE
DEV: Add workflow_dispatch to CI

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -14,6 +14,7 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.rst'
+  workflow_dispatch:
 
 jobs:
   tests:


### PR DESCRIPTION
This was originally added by stefan on #2130

This allows anyone to manually run the workflow on their fork if desired with any branch.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch