### PR TITLE
SEC: Infinite recursion caused by IndirectObject clone

### DIFF
--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -281,8 +281,13 @@ class IndirectObject(PdfObject):
         if id(self.pdf) not in pdf_dest._id_translated:
             pdf_dest._id_translated[id(self.pdf)] = {}
 
-        if not force_duplicate and self.idnum in pdf_dest._id_translated[id(self.pdf)]:
+        if self.idnum in pdf_dest._id_translated[id(self.pdf)]:
             dup = pdf_dest.get_object(pdf_dest._id_translated[id(self.pdf)][self.idnum])
+            if force_duplicate:
+                assert dup is not None
+                assert dup.indirect_reference is not None
+                idref = dup.indirect_reference
+                return IndirectObject(idref.idnum, idref.generation, idref.pdf)
         else:
             obj = self.get_object()
             # case observed : a pointed object can not be found

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1783,3 +1783,15 @@ def test_viewerpreferences():
     assert reader.viewer_preferences is None
     writer = PdfWriter(clone_from=reader)
     assert writer.viewer_preferences is None
+
+
+@pytest.mark.enable_socket()
+def test_object_contains_indirect_reference_to_self():
+    url = "https://github.com/py-pdf/pypdf/files/12389243/testbook.pdf"
+    name = "iss2102.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter()
+    width, height = 595, 841
+    outpage = writer.add_blank_page(width, height)
+    outpage.merge_page(reader.pages[6])
+    writer.append(reader)


### PR DESCRIPTION
if a object contains a indirect_reference, which points to the object it self, cloning it will cause infinite recursion.
for example: a page contains a link to self.

this will fix #2102