### PR TITLE
Rename create_viewer_preference

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -54,6 +54,7 @@ history and [GitHubs 'Contributors' feature](https://github.com/py-pdf/pypdf/gra
 * [WevertonGomes](https://github.com/WevertonGomesCosta)
 * [Wilson, Huon](https://github.com/huonw)
 * ztravis
+* [Stober, Marc](https://github.com/marcstober)
 
 ## Adding a new contributor
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -384,7 +384,7 @@ class PdfWriter:
                 self._root_object[NameObject(CD.VIEWER_PREFERENCES)] = o
         return o
 
-    def create_viewer_preference(self) -> ViewerPreferences:
+    def create_viewer_preferences(self) -> ViewerPreferences:
         o = ViewerPreferences()
         self._root_object[NameObject(CD.VIEWER_PREFERENCES)] = self._add_object(o)
         return o

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1725,10 +1725,7 @@ def test_damaged_pdf_length_returning_none():
 
 @pytest.mark.enable_socket()
 def test_viewerpreferences():
-    """
-    Add Tests for ViewerPreferences
-    https://github.com/py-pdf/pypdf/issues/140#issuecomment-1685380549
-    """
+    """Add Tests for ViewerPreferences"""
     url = "https://github.com/py-pdf/pypdf/files/9175966/2015._pb_decode_pg0.pdf"
     name = "2015._pb_decode_pg0.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
@@ -1779,8 +1776,10 @@ def test_viewerpreferences():
     v.print_pagerange = ArrayObject()
     assert len(v.print_pagerange) == 0
 
-    writer.create_viewer_preference()
+    writer.create_viewer_preferences()
     assert len(writer._root_object["/ViewerPreferences"]) == 0
+    writer.viewer_preferences.direction = "/R2L"
+    assert len(writer._root_object["/ViewerPreferences"]) == 1
 
     del reader.trailer["/Root"]["/ViewerPreferences"]
     assert reader.viewer_preferences is None


### PR DESCRIPTION
Proposed change to not include `create_viewer_preference` in the public API. Also fix some docstring typos.

See #2144