### PR TITLE
DOC: Mention pdfly on frontpage of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and
 [metadata](https://pypdf.readthedocs.io/en/stable/user/metadata.html)
 from PDFs as well.
 
+See [pdfly](https://github.com/py-pdf/pdfly) for a CLI application that uses pypdf to interact with PDFs.
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,8 @@ merging, cropping, and transforming the pages of PDF files. It can also add
 custom data, viewing options, and passwords to PDF files.
 pypdf can retrieve text and metadata from PDFs as well.
 
+See `pdfly <https://github.com/py-pdf/pdfly>`_ for a CLI application that uses pypdf to interact with PDFs.
+
 You can contribute to `pypdf on GitHub <https://github.com/py-pdf/pypdf>`_.
 
 .. toctree::


### PR DESCRIPTION
Based on https://github.com/py-pdf/pypdf/discussions/2171, feels like pdfly has a bit of a discovery problem. Adding a link at the front of pypdf's docs should hopefully help there.