### PR TITLE
BUG: Fix test_watermarking_reportlab_rendering()

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -893,8 +893,7 @@ class PageObject(DictionaryObject):
             stream = contents
         else:
             stream = ContentStream(contents, pdf)
-        stream.operations.insert(0, ([], "q"))
-        stream.operations.append(([], "Q"))
+        stream.isolate_graphics_state()
         return stream
 
     @staticmethod
@@ -1127,7 +1126,7 @@ class PageObject(DictionaryObject):
         new_content_array = ArrayObject()
         original_content = self.get_contents()
         if original_content is not None:
-            new_content_array.append(original_content)
+            new_content_array.append(PageObject._push_pop_gs(original_content, self.pdf, use_original=True))
 
         page2content = page2.get_contents()
         if page2content is not None:
@@ -1262,10 +1261,9 @@ class PageObject(DictionaryObject):
                     pass
 
         new_content_array = ArrayObject()
-
         original_content = self.get_contents()
         if original_content is not None:
-            new_content_array.append(original_content)
+            new_content_array.append(PageObject._push_pop_gs(original_content, self.pdf))
 
         page2content = page2.get_contents()
         if page2content is not None:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -328,11 +328,11 @@ B_CACHE: Dict[Union[str, bytes], bytes] = {}
 
 
 def b_(s: Union[str, bytes]) -> bytes:
+    if isinstance(s, bytes):
+        return s
     bc = B_CACHE
     if s in bc:
         return bc[s]
-    if isinstance(s, bytes):
-        return s
     try:
         r = s.encode("latin-1")
         if len(s) < 2:

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1229,6 +1229,13 @@ class ContentStream(DecodedStreamObject):
         self._operations = operations
         self._data = b""
 
+    def isolate_graphics_state(self) -> None:
+        if self._operations:
+            self._operations.insert(0, ([], "q"))
+            self._operations.append(([], "Q"))
+        elif self._data:
+            self._data = b"q\n" + b_(self._data) + b"Q\n"
+
     # This overrides the parent method:
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes] = None

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1619,7 +1619,6 @@ def test_watermark_rendering(tmp_path):
     assert image_similarity(png_path, target_png_path) >= 0.95
 
 
-@pytest.mark.xfail(reason="issue introduced with pypdf==3.15.4")
 def test_watermarking_reportlab_rendering(tmp_path):
     """
     This test shows that the merged page is rotated+mirrored.
@@ -1636,9 +1635,6 @@ def test_watermarking_reportlab_rendering(tmp_path):
     writer = PdfWriter()
     base_page.merge_page(watermark)
     writer.add_page(base_page)
-
-    for page in writer.pages:
-        page.compress_content_streams()
 
     target_png_path = RESOURCE_ROOT / "test_watermarking_reportlab_rendering.png"
     pdf_path = tmp_path / "out.pdf"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1621,7 +1621,7 @@ def test_watermark_rendering(tmp_path):
 
 def test_watermarking_reportlab_rendering(tmp_path):
     """
-    This test shows that the merged page is rotated+mirrored.
+    This test is showing a rotated+mirrored watermark in pypdf==3.15.4.
 
     Replacing the generate_base with e.g. the crazyones did not show the issue.
     """


### PR DESCRIPTION
This fixes the issue spotted in #2191

The solution was to re-introduce calls to `PageObject._push_pop_gs()`,
in `PageObject._merge_page` & `PageObject._merge_page_writer()`,
but to optimize `PageObject._push_pop_gs()` by introducing a `ContentsStream.isolate_graphics_state()` method.