### PR TITLE
DEV: Stabilize Pillow test with Pillow missing

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -285,7 +285,9 @@ for page in reader.pages:
         "It can be installed via 'pip install pypdf[image]'"
     ), exc.value.args[0]
 """)
-    result = subprocess.run([shutil.which("python"), source_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run(  # noqa: S603, UP022
+        [shutil.which("python"), source_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     assert result.returncode == 0
     assert result.stdout == b""
     assert result.stderr == b"Superfluous whitespace found in object header b'4' b'0'\n"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -285,8 +285,8 @@ for page in reader.pages:
         "It can be installed via 'pip install pypdf[image]'"
     ), exc.value.args[0]
 """)
-    result = subprocess.run(  # noqa: S603, UP022
-        [shutil.which("python"), source_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    result = subprocess.run(  # noqa: UP022
+        [shutil.which("python"), source_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE  # noqa: S603
     )
     assert result.returncode == 0
     assert result.stdout == b""

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -269,7 +269,6 @@ def test_image_without_pillow(tmp_path):
     source_file = tmp_path / "script.py"
     source_file.write_text(f"""
 import sys
-from io import BytesIO
 from pypdf import PdfReader
 
 import pytest


### PR DESCRIPTION
There have been two issues with the existing test:

* The name was incorrect, as it never really checked ImageMagick stuff.
* Running `from pypdf import _xobj_image_helpers` beforehand, for example because of other tests, would lead to "strange" failures due to Python not re-importing modules which already have been imported.