### PR TITLE
BUG: Fix nested /DeviceN color space

### DIFF
--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -78,6 +78,8 @@ def _get_imagemode(
         color_space = color_space[2]
         if isinstance(color_space, IndirectObject):  # pragma: no cover
             color_space = color_space.get_object()
+        mode2, invert_color = _get_imagemode(color_space, color_components, prev_mode)
+        return mode2, invert_color
 
     mode_map = {
         "1bit": "1",  # pos [0] will be used for 1 bit

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -619,3 +619,12 @@ def test_convert_1_to_la():
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     for i in reader.pages[13].images:
         _ = i
+
+
+@pytest.mark.enable_socket()
+def test_nested_device_n_color_space():
+    """From #2240"""
+    url = "https://github.com/py-pdf/pypdf/files/12814018/out1.pdf"
+    name = "issue2240.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader.pages[0].images[0]


### PR DESCRIPTION
This adds handling for nested color spaces for the `/DeviceN` color space.

Fixes #2240