### PR TITLE
MAINT: Explicitly provide Any for IO generic argument

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -70,7 +70,7 @@ CompressedTransformationMatrix: TypeAlias = Tuple[
     float, float, float, float, float, float
 ]
 
-StreamType = IO
+StreamType = IO[Any]
 StrByteType = Union[str, StreamType]
 
 DEPR_MSG_NO_REPLACEMENT = "{} is deprecated and will be removed in pypdf {}."


### PR DESCRIPTION
I'm using pypdf in a project configured with pyright and the [`reportUnknownMemberType`](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportUnknownMemberType) option enabled. Since `IO` is not annotated explicitly with `Any` the error is triggered when using the `append` method of `PdfWriter`. This should probably also be fixed in pyright, but I thought the change here would be less controversial.