### PR TITLE
Enable `disallow_any_generics` and add missing generics.

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -12,7 +12,7 @@ from .generic import DecodedStreamObject, DictionaryObject, StreamObject
 # code freely inspired from @twiggy ; see #711
 def build_char_map(
     font_name: str, space_width: float, obj: DictionaryObject
-) -> Tuple[str, float, Union[str, Dict[int, str]], Dict, DictionaryObject]:
+) -> Tuple[str, float, Union[str, Dict[int, str]], Dict[Any, Any], DictionaryObject]:
     """
     Determine information about a font.
 
@@ -34,7 +34,7 @@ def build_char_map(
 
 def build_char_map_from_dict(
     space_width: float, ft: DictionaryObject
-) -> Tuple[str, float, Union[str, Dict[int, str]], Dict]:
+) -> Tuple[str, float, Union[str, Dict[int, str]], Dict[Any, Any]]:
     """
     Determine information about a font.
 

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -759,7 +759,7 @@ class PasswordType(IntEnum):
     OWNER_PASSWORD = 2
 
 
-class EncryptAlgorithm(tuple, Enum):  # noqa: SLOT001
+class EncryptAlgorithm(Tuple[Any,...], Enum):  # noqa: SLOT001
     # V, R, Length
     RC4_40 = (1, 2, 40)
     RC4_128 = (2, 3, 128)
@@ -1144,7 +1144,7 @@ class Encryption:
     def make(
         alg: EncryptAlgorithm, permissions: int, first_id_entry: bytes
     ) -> "Encryption":
-        alg_ver, alg_rev, key_bits = cast(tuple, alg)
+        alg_ver, alg_rev, key_bits = cast(Tuple[Any, ...], alg)
 
         stm_filter, str_filter, ef_filter = "/V2", "/V2", "/V2"
 

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -759,7 +759,7 @@ class PasswordType(IntEnum):
     OWNER_PASSWORD = 2
 
 
-class EncryptAlgorithm(Tuple[Any,...], Enum):  # noqa: SLOT001
+class EncryptAlgorithm(Tuple[Any, ...], Enum):  # noqa: SLOT001
     # V, R, Length
     RC4_40 = (1, 2, 40)
     RC4_128 = (2, 3, 128)
@@ -1144,7 +1144,7 @@ class Encryption:
     def make(
         alg: EncryptAlgorithm, permissions: int, first_id_entry: bytes
     ) -> "Encryption":
-        alg_ver, alg_rev, key_bits = cast(Tuple[Any, ...], alg)
+        alg_ver, alg_rev, key_bits = alg
 
         stm_filter, str_filter, ef_filter = "/V2", "/V2", "/V2"
 

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1232,10 +1232,10 @@ class PageObject(DictionaryObject):
                 if "/QuadPoints" in a:
                     q = cast(ArrayObject, a["/QuadPoints"])
                     aa[NameObject("/QuadPoints")] = ArrayObject(
-                        cast(tuple, trsf.apply_on((q[0], q[1]), True))
-                        + cast(tuple, trsf.apply_on((q[2], q[3]), True))
-                        + cast(tuple, trsf.apply_on((q[4], q[5]), True))
-                        + cast(tuple, trsf.apply_on((q[6], q[7]), True))
+                        cast(Tuple[Any,...], trsf.apply_on((q[0], q[1]), True))
+                        + cast(Tuple[Any, ...], trsf.apply_on((q[2], q[3]), True))
+                        + cast(Tuple[Any, ...], trsf.apply_on((q[4], q[5]), True))
+                        + cast(Tuple[Any, ...], trsf.apply_on((q[6], q[7]), True))
                     )
                 try:
                     aa["/Popup"][NameObject("/Parent")] = aa.indirect_reference
@@ -1941,7 +1941,7 @@ class PageObject(DictionaryObject):
         def current_spacewidth() -> float:
             return _space_width / 1000.0
 
-        def process_operation(operator: bytes, operands: List) -> None:
+        def process_operation(operator: bytes, operands: List[Any]) -> None:
             nonlocal cm_matrix, cm_stack, tm_matrix, cm_prev, tm_prev, memo_cm, memo_tm
             nonlocal char_scale, space_scale, _space_width, TL, font_size, cmap
             nonlocal orientations, rtl_dir, visitor_text, output, text
@@ -2484,7 +2484,7 @@ class PageObject(DictionaryObject):
             self[NameObject("/Annots")] = value
 
 
-class _VirtualList(Sequence):
+class _VirtualList(Sequence[Any]):
     def __init__(
         self,
         length_function: Callable[[], int],
@@ -2669,7 +2669,7 @@ def _get_fonts_walk(
     return fnt, emb  # return the sets for each page
 
 
-class _VirtualListImages(Sequence):
+class _VirtualListImages(Sequence[Any]):
     def __init__(
         self,
         ids_function: Callable[[], List[Union[str, List[str]]]],

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -296,6 +296,16 @@ class Transformation:
     def __repr__(self) -> str:
         return f"Transformation(ctm={self.ctm})"
 
+    @overload
+    def apply_on(self, pt: List[float], as_object: bool = False) -> List[float]:
+        ...
+
+    @overload
+    def apply_on(
+        self, pt: Tuple[float, float], as_object: bool = False
+    ) -> Tuple[float, float]:
+        ...
+
     def apply_on(
         self,
         pt: Union[Tuple[float, float], List[float]],
@@ -1232,10 +1242,10 @@ class PageObject(DictionaryObject):
                 if "/QuadPoints" in a:
                     q = cast(ArrayObject, a["/QuadPoints"])
                     aa[NameObject("/QuadPoints")] = ArrayObject(
-                        cast(Tuple[Any,...], trsf.apply_on((q[0], q[1]), True))
-                        + cast(Tuple[Any, ...], trsf.apply_on((q[2], q[3]), True))
-                        + cast(Tuple[Any, ...], trsf.apply_on((q[4], q[5]), True))
-                        + cast(Tuple[Any, ...], trsf.apply_on((q[6], q[7]), True))
+                        trsf.apply_on((q[0], q[1]), True)
+                        + trsf.apply_on((q[2], q[3]), True)
+                        + trsf.apply_on((q[4], q[5]), True)
+                        + trsf.apply_on((q[6], q[7]), True)
                     )
                 try:
                     aa["/Popup"][NameObject("/Parent")] = aa.indirect_reference
@@ -2484,7 +2494,7 @@ class PageObject(DictionaryObject):
             self[NameObject("/Annots")] = value
 
 
-class _VirtualList(Sequence[Any]):
+class _VirtualList(Sequence[PageObject]):
     def __init__(
         self,
         length_function: Callable[[], int],
@@ -2669,7 +2679,7 @@ def _get_fonts_walk(
     return fnt, emb  # return the sets for each page
 
 
-class _VirtualListImages(Sequence[Any]):
+class _VirtualListImages(Sequence[ImageFile]):
     def __init__(
         self,
         ids_function: Callable[[], List[Union[str, List[str]]]],

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -70,7 +70,7 @@ class PdfWriterProtocol(Protocol):  # deprecated
     def get_object(self, indirect_reference: Any) -> Optional[PdfObjectProtocol]:
         ...
 
-    def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO]:
+    def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO[Any]]:
         ...
 
     def _add_object(self, obj: Any) -> Any:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -720,7 +720,7 @@ class PdfReader:
             second and following will get the suffix .2, .3, ...
         """
 
-        def indexed_key(k: str, fields: dict) -> str:
+        def indexed_key(k: str, fields: Dict[Any, Any]) -> str:
             if k not in fields:
                 return k
             else:
@@ -2291,7 +2291,7 @@ class PdfReader:
         return attachments
 
 
-class LazyDict(Mapping):
+class LazyDict(Mapping[Any, Any]):
     def __init__(self, *args: Any, **kw: Any) -> None:
         self._raw_dict = dict(*args, **kw)
 

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -453,7 +453,7 @@ def logger_warning(msg: str, src: str) -> None:
     logging.getLogger(src).warning(msg)
 
 
-def deprecation_bookmark(**aliases: str) -> Callable:
+def deprecation_bookmark(**aliases: str) -> Callable[..., Any]:
     """
     Decorator for deprecated term "bookmark".
 
@@ -462,7 +462,7 @@ def deprecation_bookmark(**aliases: str) -> Callable:
         outline = a collection of outline items.
     """
 
-    def decoration(func: Callable) -> Any:
+    def decoration(func: Callable[..., Any]) -> Any:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             rename_kwargs(func.__name__, kwargs, aliases, fail=True)

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -885,7 +885,7 @@ class PdfWriter:
         if font_name not in dr:
             # ...or AcroForm dictionary
             dr = cast(
-                dict,
+                Dict[Any, Any],
                 cast(DictionaryObject, self._root_object["/AcroForm"]).get("/DR", {}),
             )
             if isinstance(dr, IndirectObject):  # pragma: no cover
@@ -1353,7 +1353,7 @@ class PdfWriter:
         xref_location = self._write_xref_table(stream, object_positions)
         self._write_trailer(stream, xref_location)
 
-    def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO]:
+    def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO[Any]]:
         """
         Write the collection of pages added to this object out as a PDF file.
 
@@ -2240,7 +2240,7 @@ class PdfWriter:
                 # to prevent infinite looping
                 return [], []  # pragma: no cover
             try:
-                d = cast(dict, cast(DictionaryObject, elt["/Resources"])["/XObject"])
+                d = cast(Dict[Any, Any], cast(DictionaryObject, elt["/Resources"])["/XObject"])
             except KeyError:
                 d = {}
             images = []
@@ -2793,7 +2793,7 @@ class PdfWriter:
         # Internal link annotations need the correct object type for the
         # destination
         if to_add.get("/Subtype") == "/Link" and "/Dest" in to_add:
-            tmp = cast(dict, to_add[NameObject("/Dest")])
+            tmp = cast(Dict[Any, Any], to_add[NameObject("/Dest")])
             dest = Destination(
                 NameObject("/LinkName"),
                 tmp["target_page_index"],
@@ -3029,7 +3029,7 @@ class PdfWriter:
         for dest in reader._namedDests.values():
             arr = dest.dest_array
             if "/Names" in self._root_object and dest["/Title"] in cast(
-                list,
+                List[Any],
                 cast(
                     DictionaryObject,
                     cast(DictionaryObject, self._root_object["/Names"])["/Dests"],
@@ -3188,7 +3188,7 @@ class PdfWriter:
 
     def add_filtered_articles(
         self,
-        fltr: Union[Pattern, str],  # thread entry from the reader's array of threads
+        fltr: Union[Pattern[Any], str],  # thread entry from the reader's array of threads
         pages: Dict[int, PageObject],
         reader: PdfReader,
     ) -> None:
@@ -3245,7 +3245,7 @@ class PdfWriter:
     ) -> List[Destination]:
         outlist = ArrayObject()
         if isinstance(annots, IndirectObject):
-            annots = cast("List", annots.get_object())
+            annots = cast("List[Any]", annots.get_object())
         for an in annots:
             ano = cast("DictionaryObject", an.get_object())
             if (

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -87,7 +87,7 @@ NumberSigns = b"+-"
 IndirectPattern = re.compile(rb"[+-]?(\d+)\s+(\d+)\s+R[^a-zA-Z]")
 
 
-class ArrayObject(list, PdfObject):
+class ArrayObject(List[Any], PdfObject):
     def clone(
         self,
         pdf_dest: PdfWriterProtocol,
@@ -174,7 +174,7 @@ class ArrayObject(list, PdfObject):
         return ArrayObject.read_from_stream(stream, pdf)
 
 
-class DictionaryObject(dict, PdfObject):
+class DictionaryObject(Dict[Any, Any], PdfObject):
     def clone(
         self,
         pdf_dest: PdfWriterProtocol,
@@ -631,7 +631,7 @@ class TreeObject(DictionaryObject):
         child: Any,
         before: Any,
         pdf: PdfWriterProtocol,
-        inc_parent_counter: Optional[Callable] = None,
+        inc_parent_counter: Optional[Callable[..., Any]] = None,
     ) -> IndirectObject:
         if inc_parent_counter is None:
             inc_parent_counter = self.inc_parent_counter_default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,6 +225,7 @@ wrap-descriptions = 0
 show_error_codes = true
 ignore_missing_imports = true
 check_untyped_defs = true
+disallow_any_generics = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 warn_redundant_casts = true


### PR DESCRIPTION
Follow up on https://github.com/py-pdf/pypdf/pull/2272

Enable the `disallow_any_generics` option and add missing generics. Also, add some overloaded versions of `apply_on` to avoid some casts.

I think I could have made `EncryptAlgorithm` a  subtype of `Tuple[int, int, int]` instead of `Tuple[Any,...]`, but I don't know if that's a breaking change.