### PR TITLE
ROB: Initialize states array with an empty value

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -648,6 +648,7 @@ class PdfReader:
                 retval[key][NameObject("/_States_")].append(NameObject("/Off"))
         elif obj.get(FA.FT, "") == "/Btn" and obj.get(FA.Ff, 0) & FA.FfBits.Radio != 0:
             states = []
+            retval[key][NameObject("/_States_")] = ArrayObject(states)
             for k in obj.get(FA.Kids, {}):
                 k = k.get_object()
                 for s in list(k["/AP"]["/N"].keys()):

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -647,7 +647,7 @@ class PdfReader:
             if "/Off" not in retval[key]["/_States_"]:
                 retval[key][NameObject("/_States_")].append(NameObject("/Off"))
         elif obj.get(FA.FT, "") == "/Btn" and obj.get(FA.Ff, 0) & FA.FfBits.Radio != 0:
-            states = []
+            states: List[str] = []
             retval[key][NameObject("/_States_")] = ArrayObject(states)
             for k in obj.get(FA.Kids, {}):
                 k = k.get_object()


### PR DESCRIPTION
This is done to prevent dictionary key error below when states are not initialized