### PR TITLE
DOC: Fix typo in example in extract-attachments.md

### DIFF
--- a/docs/user/extract-attachments.md
+++ b/docs/user/extract-attachments.md
@@ -11,7 +11,7 @@ from pypdf import PdfReader
 
 reader = PdfReader("example.pdf")
 
-for name, content_list in reader.attachments:
+for name, content_list in reader.attachments.items():
     for i, content in enumerate(content_list):
         with open(f"{name}-{i}", "wb") as fp:
             fp.write(content)


### PR DESCRIPTION
The example code in `extract-attachments.md` iterates over a dictionary but doesn't properly call `.items()`, so the code fails as written. This adds the `.items()` call so the example works if cut and pasted into python.