### PR TITLE
DOC: Fix docstring for RunLengthDecode.decode

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -322,7 +322,7 @@ class RunLengthDecode:
         **kwargs: Any,
     ) -> bytes:
         """
-        Decode an ASCII-Hex encoded data stream.
+        Decode a run length encoded data stream.
 
         Args:
           data: a bytes sequence of length/data


### PR DESCRIPTION
Fix a typo which seems to have been introduced by copying the docstring.