### PR TITLE
BUG: Handle indirect objects as parameters for CCITTFaxDecode

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -564,18 +564,18 @@ class CCITTFaxDecode:
         k = 0
         columns = 1728
         if parameters:
-            parameters = parameters.get_object()
-            if isinstance(parameters, ArrayObject):
-                for decode_parm in parameters:
+            parameters_unwrapped = cast(Union[ArrayObject, DictionaryObject], parameters.get_object())
+            if isinstance(parameters_unwrapped, ArrayObject):
+                for decode_parm in parameters_unwrapped:
                     if CCITT.COLUMNS in decode_parm:
                         columns = decode_parm[CCITT.COLUMNS]
                     if CCITT.K in decode_parm:
                         k = decode_parm[CCITT.K]
             else:
-                if CCITT.COLUMNS in parameters:
-                    columns = parameters[CCITT.COLUMNS]  # type: ignore
-                if CCITT.K in parameters:
-                    k = parameters[CCITT.K]  # type: ignore
+                if CCITT.COLUMNS in parameters_unwrapped:
+                    columns = parameters_unwrapped[CCITT.COLUMNS]  # type: ignore
+                if CCITT.K in parameters_unwrapped:
+                    k = parameters_unwrapped[CCITT.K]  # type: ignore
 
         return CCITParameters(k, columns, rows)
 

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -564,6 +564,8 @@ class CCITTFaxDecode:
         k = 0
         columns = 1728
         if parameters:
+            if isinstance(parameters, IndirectObject):
+                parameters = parameters.get_object()
             if isinstance(parameters, ArrayObject):
                 for decode_parm in parameters:
                     if CCITT.COLUMNS in decode_parm:

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -558,14 +558,13 @@ class CCITTFaxDecode:
 
     @staticmethod
     def _get_parameters(
-        parameters: Union[None, ArrayObject, DictionaryObject], rows: int
+        parameters: Union[None, ArrayObject, DictionaryObject, IndirectObject], rows: int
     ) -> CCITParameters:
         # TABLE 3.9 Optional parameters for the CCITTFaxDecode filter
         k = 0
         columns = 1728
         if parameters:
-            if isinstance(parameters, IndirectObject):
-                parameters = parameters.get_object()
+            parameters = parameters.get_object()
             if isinstance(parameters, ArrayObject):
                 for decode_parm in parameters:
                     if CCITT.COLUMNS in decode_parm:


### PR DESCRIPTION
While doing some error analysis, I stumbled upon the following error:

```
[...]
    if CCITT.COLUMNS in parameters:
TypeError: argument of type 'IndirectObject' is not iterable
```

This resolves the error. Unfortunately, I do not have any public test document at the moment which I could share here or privately.