### PR TITLE
DOC: Correct the example of adding highlight annotation

### DIFF
--- a/docs/user/adding-pdf-annotations.md
+++ b/docs/user/adding-pdf-annotations.md
@@ -331,9 +331,8 @@ quad_points = [rect[0], rect[1], rect[2], rect[1], rect[0], rect[3], rect[2], re
 
 # Add the highlight
 annotation = Highlight(
-    rect=rect
+    rect=rect,
     quad_points=ArrayObject([FloatObject(quad_point) for quad_point in quad_points]),
-
 )
 writer.add_annotation(page_number=0, annotation=annotation)
 

--- a/docs/user/adding-pdf-annotations.md
+++ b/docs/user/adding-pdf-annotations.md
@@ -317,8 +317,7 @@ you can use the {py:class}`Highlight <pypdf.annotations.Highlight>`:
 ```python
 from pypdf import PdfReader, PdfWriter
 from pypdf.annotations import Highlight
-from pypdf.generic import ArrayObject
-from pypdf.generic._base import FloatObject
+from pypdf.generic import ArrayObject, FloatObject
 
 pdf_path = os.path.join(RESOURCE_ROOT, "crazyones.pdf")
 reader = PdfReader(pdf_path)

--- a/docs/user/adding-pdf-annotations.md
+++ b/docs/user/adding-pdf-annotations.md
@@ -317,6 +317,8 @@ you can use the {py:class}`Highlight <pypdf.annotations.Highlight>`:
 ```python
 from pypdf import PdfReader, PdfWriter
 from pypdf.annotations import Highlight
+from pypdf.generic import ArrayObject
+from pypdf.generic._base import FloatObject
 
 pdf_path = os.path.join(RESOURCE_ROOT, "crazyones.pdf")
 reader = PdfReader(pdf_path)
@@ -324,9 +326,14 @@ page = reader.pages[0]
 writer = PdfWriter()
 writer.add_page(page)
 
+rect = (50, 550, 200, 650)
+quad_points = [rect[0], rect[1], rect[2], rect[1], rect[0], rect[3], rect[2], rect[3]]
+
 # Add the highlight
 annotation = Highlight(
-    vertices=[(50, 550), (200, 650), (70, 750), (50, 700)],
+    rect=rect
+    quad_points=ArrayObject([FloatObject(quad_point) for quad_point in quad_points]),
+
 )
 writer.add_annotation(page_number=0, annotation=annotation)
 


### PR DESCRIPTION
Fix example for Add the Highlight:
the `pypdf.annotations.Highlight` requires `rect` and `quad_points` as input parameters not `vertices`