### PR TITLE
MAINT: Update upload-artifact and download-artifact actions from v3 to v4

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -128,9 +128,9 @@ jobs:
     - name: Rename coverage data file
       run: mv .coverage ".coverage.$RANDOM"
     - name: Upload coverage data
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: coverage-data
+        name: coverage-data.${{ matrix.python-version }}-${{ matrix.use-crypto-lib }}
         path: .coverage.*
         if-no-files-found: ignore
 
@@ -201,9 +201,10 @@ jobs:
 
       - run: python -m pip install --upgrade coverage[toml]
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          pattern: coverage-data*
+          merge-multiple: true
 
       - name: Check Number of Downloaded Files
         run: |


### PR DESCRIPTION
This is a general fix which covers #2344, #2345 and #2350, including some incompatible changes as detailed in https://github.com/py-pdf/pypdf/pull/2344#issuecomment-1859671837.

The key point is that both actions have to be updated at the same time to avoid conflicts. Additionally, artifacts of the same name are not supported anymore, thus I decided to go the recommended route from https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact to include the matrix parameters inside the artifact names.