### PR TITLE
BUG: Handle IndirectObject as image filter

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -779,11 +779,8 @@ def _xobj_to_image(x_object_obj: Dict[str, Any]) -> Tuple[Optional[str], bytes, 
         )
     extension = None
     alpha = None
-    filters = x_object_obj.get(SA.FILTER, [None])
+    filters = x_object_obj.get(SA.FILTER, NullObject()).get_object()
     lfilters = filters[-1] if isinstance(filters, list) else filters
-    if isinstance(lfilters, IndirectObject):
-        lfilters = lfilters.get_object()
-        lfilters = lfilters[-1] if isinstance(lfilters, list) else lfilters
     if lfilters in (FT.FLATE_DECODE, FT.RUN_LENGTH_DECODE):
         img, image_format, extension, _ = _handle_flate(
             size,

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -781,6 +781,9 @@ def _xobj_to_image(x_object_obj: Dict[str, Any]) -> Tuple[Optional[str], bytes, 
     alpha = None
     filters = x_object_obj.get(SA.FILTER, [None])
     lfilters = filters[-1] if isinstance(filters, list) else filters
+    if isinstance(lfilters, IndirectObject):
+        lfilters = lfilters.get_object()
+        lfilters = lfilters[-1] if isinstance(lfilters, list) else lfilters
     if lfilters in (FT.FLATE_DECODE, FT.RUN_LENGTH_DECODE):
         img, image_format, extension, _ = _handle_flate(
             size,


### PR DESCRIPTION
Previously, we might pass `"4bits"` as image mode to *Pillow*, leading to "unrecognized image mode". Example: `lfilters = IndirectObject(26, 0, 139771595681120)`, whose `get_object()` would yield `['/FlateDecode']` (going into the `else` branch of the filter handling until now).

While I have a corresponding document where I stumbled upon this error, I cannot disclose it due to privacy reasons.
