### PR TITLE
DEP: Remove deprecated code

### DIFF
--- a/pypdf/__init__.py
+++ b/pypdf/__init__.py
@@ -9,11 +9,11 @@ You can read the full docs at https://pypdf.readthedocs.io/.
 
 from ._crypt_providers import crypt_provider
 from ._encryption import PasswordType
-from ._merger import PdfFileMerger, PdfMerger
+from ._merger import PdfMerger
 from ._page import PageObject, Transformation, mult
-from ._reader import DocumentInformation, PdfFileReader, PdfReader
+from ._reader import DocumentInformation, PdfReader
 from ._version import __version__
-from ._writer import ObjectDeletionFlag, PdfFileWriter, PdfWriter
+from ._writer import ObjectDeletionFlag, PdfWriter
 from .constants import ImageType
 from .pagerange import PageRange, parse_filename_page_ranges
 from .papersizes import PaperSize
@@ -39,9 +39,6 @@ __all__ = [
     "DocumentInformation",
     "ObjectDeletionFlag",
     "parse_filename_page_ranges",
-    "PdfFileMerger",  # will be removed in pypdf==4.0.0; use PdfMerger instead
-    "PdfFileReader",  # will be removed in pypdf==4.0.0; use PdfReader instead
-    "PdfFileWriter",  # will be removed in pypdf==4.0.0; use PdfWriter instead
     "PdfMerger",
     "PdfReader",
     "PdfWriter",

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -48,7 +48,6 @@ from ._utils import (
     StrByteType,
     deprecate_with_replacement,
     deprecation_bookmark,
-    deprecation_with_replacement,
     str_,
 )
 from ._writer import PdfWriter
@@ -70,7 +69,7 @@ from .generic import (
     TreeObject,
 )
 from .pagerange import PageRange, PageRangeSpec
-from .types import FitType, LayoutType, OutlineType, PagemodeType, ZoomArgType
+from .types import LayoutType, OutlineType, PagemodeType
 
 ERR_CLOSED_WRITER = "close() was called and thus the writer cannot be used anymore"
 
@@ -360,24 +359,6 @@ class PdfMerger:
             raise RuntimeError(ERR_CLOSED_WRITER)
         self.output.add_metadata(infos)
 
-    def addMetadata(self, infos: Dict[str, Any]) -> None:  # deprecated
-        """
-        Use :meth:`add_metadata` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addMetadata", "add_metadata")
-        self.add_metadata(infos)
-
-    def setPageLayout(self, layout: LayoutType) -> None:  # deprecated
-        """
-        Use :meth:`set_page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("setPageLayout", "set_page_layout")
-        self.set_page_layout(layout)
-
     def set_page_layout(self, layout: LayoutType) -> None:
         """
         Set the page layout.
@@ -406,15 +387,6 @@ class PdfMerger:
         if self.output is None:
             raise RuntimeError(ERR_CLOSED_WRITER)
         self.output._set_page_layout(layout)
-
-    def setPageMode(self, mode: PagemodeType) -> None:  # deprecated
-        """
-        Use :meth:`set_page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("setPageMode", "set_page_mode", "3.0.0")
-        self.set_page_mode(mode)
 
     def set_page_mode(self, mode: PagemodeType) -> None:
         """
@@ -723,68 +695,6 @@ class PdfMerger:
             fit,
         )
 
-    def addBookmark(
-        self,
-        title: str,
-        pagenum: int,  # deprecated, but the whole method is deprecated
-        parent: Union[None, TreeObject, IndirectObject] = None,
-        color: Optional[Tuple[float, float, float]] = None,
-        bold: bool = False,
-        italic: bool = False,
-        fit: FitType = "/Fit",
-        *args: ZoomArgType,
-    ) -> IndirectObject:  # deprecated
-        """
-        .. deprecated:: 1.28.0
-            Use :meth:`add_outline_item` instead.
-        """
-        deprecation_with_replacement("addBookmark", "add_outline_item", "3.0.0")
-        return self.add_outline_item(
-            title,
-            pagenum,
-            parent,
-            color,
-            bold,
-            italic,
-            Fit(fit_type=fit, fit_args=args),
-        )
-
-    def add_bookmark(
-        self,
-        title: str,
-        pagenum: int,  # deprecated, but the whole method is deprecated already
-        parent: Union[None, TreeObject, IndirectObject] = None,
-        color: Optional[Tuple[float, float, float]] = None,
-        bold: bool = False,
-        italic: bool = False,
-        fit: FitType = "/Fit",
-        *args: ZoomArgType,
-    ) -> IndirectObject:  # deprecated
-        """
-        .. deprecated:: 2.9.0
-            Use :meth:`add_outline_item` instead.
-        """
-        deprecation_with_replacement("addBookmark", "add_outline_item", "3.0.0")
-        return self.add_outline_item(
-            title,
-            pagenum,
-            parent,
-            color,
-            bold,
-            italic,
-            Fit(fit_type=fit, fit_args=args),
-        )
-
-    def addNamedDestination(self, title: str, pagenum: int) -> None:  # deprecated
-        """
-        .. deprecated:: 1.28.0
-            Use :meth:`add_named_destination` instead.
-        """
-        deprecation_with_replacement(
-            "addNamedDestination", "add_named_destination", "3.0.0"
-        )
-        return self.add_named_destination(title, pagenum)
-
     def add_named_destination(
         self,
         title: str,
@@ -822,12 +732,3 @@ class PdfMerger:
             Fit.fit_horizontally(top=826),
         )
         self.named_dests.append(dest)
-
-
-class PdfFileMerger(PdfMerger):  # deprecated
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        deprecation_with_replacement("PdfFileMerger", "PdfMerger", "3.0.0")
-
-        if "strict" not in kwargs and len(args) < 1:
-            kwargs["strict"] = True  # maintain the default
-        super().__init__(*args, **kwargs)

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -377,6 +377,38 @@ class PdfMerger:
            * - /UseAttachments
              - Show attachments panel
         """
+        self.page_mode = mode
+
+    @property
+    def page_mode(self) -> Optional[PagemodeType]:
+        """
+        Set the page mode.
+
+        Args:
+            mode: The page mode to use.
+
+        .. list-table:: Valid ``mode`` arguments
+           :widths: 50 200
+
+           * - /UseNone
+             - Do not show outline or thumbnails panels
+           * - /UseOutlines
+             - Show outline (aka bookmarks) panel
+           * - /UseThumbs
+             - Show page thumbnails panel
+           * - /FullScreen
+             - Fullscreen view
+           * - /UseOC
+             - Show Optional Content Group (OCG) panel
+           * - /UseAttachments
+             - Show attachments panel
+        """
+        if self.output is None:
+            raise RuntimeError(ERR_CLOSED_WRITER)
+        return self.output.page_mode
+
+    @page_mode.setter
+    def page_mode(self, mode: PagemodeType) -> None:
         if self.output is None:
             raise RuntimeError(ERR_CLOSED_WRITER)
         self.output.page_mode = mode

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -46,7 +46,6 @@ from ._reader import PdfReader
 from ._utils import (
     StrByteType,
     deprecate_with_replacement,
-    deprecation_bookmark,
     str_,
 )
 from ._writer import PdfWriter
@@ -90,7 +89,6 @@ class PdfMerger:
     .. deprecated:: 5.0.0
     """
 
-    @deprecation_bookmark(bookmarks="outline")
     def __init__(
         self, strict: bool = False, fileobj: Union[Path, StrByteType] = ""
     ) -> None:
@@ -120,7 +118,6 @@ class PdfMerger:
             self.write(self.fileobj)
         self.close()
 
-    @deprecation_bookmark(bookmark="outline_item", import_bookmarks="import_outline")
     def merge(
         self,
         page_number: int,
@@ -244,7 +241,6 @@ class PdfMerger:
             )
         return stream, encryption_obj
 
-    @deprecation_bookmark(bookmark="outline_item", import_bookmarks="import_outline")
     def append(
         self,
         fileobj: Union[StrByteType, PdfReader, Path],
@@ -466,7 +462,6 @@ class PdfMerger:
             if page_index is not None:  # deprecated
                 self.output.add_named_destination_object(named_dest)
 
-    @deprecation_bookmark(bookmarks="outline")
     def _write_outline(
         self,
         outline: Optional[Iterable[OutlineItem]] = None,
@@ -494,7 +489,6 @@ class PdfMerger:
                 del outline_item["/Page"], outline_item["/Type"]
                 last_added = self.output.add_outline_item_dict(outline_item, parent)
 
-    @deprecation_bookmark(bookmark="outline_item")
     def _write_outline_item_on_page(
         self, outline_item: Union[OutlineItem, Destination], page: _MergedPage
     ) -> None:
@@ -547,7 +541,6 @@ class PdfMerger:
                 )
             named_dest[NameObject("/Page")] = NumberObject(page_index)
 
-    @deprecation_bookmark(bookmarks="outline")
     def _associate_outline_items_to_pages(
         self, pages: List[_MergedPage], outline: Optional[Iterable[OutlineItem]] = None
     ) -> None:
@@ -572,7 +565,6 @@ class PdfMerger:
             if page_index is not None:
                 outline_item[NameObject("/Page")] = NumberObject(page_index)
 
-    @deprecation_bookmark(bookmark="outline_item")
     def find_outline_item(
         self,
         outline_item: Dict[str, Any],
@@ -585,7 +577,7 @@ class PdfMerger:
             if isinstance(oi_enum, list):
                 # oi_enum is still an inner node
                 # (OutlineType, if recursive types were supported by mypy)
-                res = self.find_outline_item(outline_item, oi_enum)
+                res = self.find_outline_item(outline_item, oi_enum)  # type: ignore
                 if res:  # deprecated
                     return [i] + res
             elif (
@@ -597,7 +589,6 @@ class PdfMerger:
 
         return None
 
-    @deprecation_bookmark(bookmark="outline_item")
     def find_bookmark(
         self,
         outline_item: Dict[str, Any],

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -25,7 +25,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import warnings
 from io import BytesIO, FileIO, IOBase
 from pathlib import Path
 from types import TracebackType
@@ -124,12 +123,11 @@ class PdfMerger:
     @deprecation_bookmark(bookmark="outline_item", import_bookmarks="import_outline")
     def merge(
         self,
-        page_number: Optional[int] = None,
-        fileobj: Union[None, Path, StrByteType, PdfReader] = None,
+        page_number: int,
+        fileobj: Union[Path, StrByteType, PdfReader],
         outline_item: Optional[str] = None,
         pages: Optional[PageRangeSpec] = None,
         import_outline: bool = True,
-        position: Optional[int] = None,  # deprecated
     ) -> None:
         """
         Merge the pages from the given file into the output file at the
@@ -154,33 +152,6 @@ class PdfMerger:
                 outline (collection of outline items, previously referred to as
                 'bookmarks') from being imported by specifying this as ``False``.
         """
-        if position is not None:  # deprecated
-            if page_number is None:
-                page_number = position
-                old_term = "position"
-                new_term = "page_number"
-                warnings.warn(
-                    (
-                        f"{old_term} is deprecated as an argument and will be "
-                        f"removed in pypdf=4.0.0. Use {new_term} instead"
-                    ),
-                    DeprecationWarning,
-                )
-            else:
-                raise ValueError(
-                    "The argument position of merge is deprecated. "
-                    "Use page_number only."
-                )
-
-        if page_number is None:  # deprecated
-            # The parameter is only marked as Optional as long as
-            # position is not fully deprecated
-            raise ValueError("page_number may not be None")
-        if fileobj is None:  # deprecated
-            # The argument is only Optional due to the deprecated position
-            # argument
-            raise ValueError("fileobj may not be None")
-
         stream, encryption_obj = self._create_stream(fileobj)
 
         # Create a new PdfReader instance using the stream
@@ -641,13 +612,12 @@ class PdfMerger:
     def add_outline_item(
         self,
         title: str,
-        page_number: Optional[int] = None,
+        page_number: int,
         parent: Union[None, TreeObject, IndirectObject] = None,
         color: Optional[Tuple[float, float, float]] = None,
         bold: bool = False,
         italic: bool = False,
         fit: Fit = PAGE_FIT,
-        pagenum: Optional[int] = None,  # deprecated
     ) -> IndirectObject:
         """
         Add an outline item (commonly referred to as a "Bookmark") to this PDF file.
@@ -663,24 +633,6 @@ class PdfMerger:
             italic: Outline item font is italic
             fit: The fit of the destination page.
         """
-        if page_number is not None and pagenum is not None:
-            raise ValueError(
-                "The argument pagenum of add_outline_item is deprecated. "
-                "Use page_number only."
-            )
-        if pagenum is not None:  # deprecated
-            old_term = "pagenum"
-            new_term = "page_number"
-            warnings.warn(
-                (
-                    f"{old_term} is deprecated as an argument and will be "
-                    f"removed in pypdf==4.0.0. Use {new_term} instead"
-                ),
-                DeprecationWarning,
-            )
-            page_number = pagenum
-        if page_number is None:  # deprecated
-            raise ValueError("page_number may not be None")
         writer = self.output
         if writer is None:
             raise RuntimeError(ERR_CLOSED_WRITER)
@@ -698,8 +650,7 @@ class PdfMerger:
     def add_named_destination(
         self,
         title: str,
-        page_number: Optional[int] = None,
-        pagenum: Optional[int] = None,
+        page_number: int,
     ) -> None:
         """
         Add a destination to the output.
@@ -708,24 +659,6 @@ class PdfMerger:
             title: Title to use
             page_number: Page number this destination points at.
         """
-        if page_number is not None and pagenum is not None:
-            raise ValueError(
-                "The argument pagenum of add_named_destination is deprecated. "
-                "Use page_number only."
-            )
-        if pagenum is not None:  # deprecated
-            old_term = "pagenum"
-            new_term = "page_number"
-            warnings.warn(
-                (
-                    f"{old_term} is deprecated as an argument and will be "
-                    f"removed in pypdf==4.0.0. Use {new_term} instead"
-                ),
-                DeprecationWarning,
-            )
-            page_number = pagenum
-        if page_number is None:  # deprecated
-            raise ValueError("page_number may not be None")
         dest = Destination(
             TextStringObject(title),
             NumberObject(page_number),

--- a/pypdf/_merger.py
+++ b/pypdf/_merger.py
@@ -136,7 +136,6 @@ class PdfMerger:
             fileobj: A File Object or an object that supports the standard
                 read and seek methods similar to a File Object. Could also be a
                 string representing a path to a PDF file.
-                None as an argument is deprecated.
             outline_item: Optionally, you may specify an outline item
                 (previously referred to as a 'bookmark') to be applied at the
                 beginning of the included file by supplying the text of the outline item.
@@ -380,7 +379,7 @@ class PdfMerger:
         """
         if self.output is None:
             raise RuntimeError(ERR_CLOSED_WRITER)
-        self.output.set_page_mode(mode)
+        self.output.page_mode = mode
 
     def _trim_dests(
         self,
@@ -588,17 +587,6 @@ class PdfMerger:
                 return [i]
 
         return None
-
-    def find_bookmark(
-        self,
-        outline_item: Dict[str, Any],
-        root: Optional[OutlineType] = None,
-    ) -> Optional[List[int]]:  # deprecated
-        """
-        .. deprecated:: 2.9.0
-            Use :meth:`find_outline_item` instead.
-        """
-        return self.find_outline_item(outline_item, root)
 
     def add_outline_item(
         self,

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -322,40 +322,13 @@ class PageObject(DictionaryObject):
         self,
         pdf: Union[None, PdfReaderProtocol, PdfWriterProtocol] = None,
         indirect_reference: Optional[IndirectObject] = None,
-        indirect_ref: Optional[IndirectObject] = None,  # deprecated
     ) -> None:
         DictionaryObject.__init__(self)
         self.pdf: Union[None, PdfReaderProtocol, PdfWriterProtocol] = pdf
         self.inline_images: Optional[Dict[str, ImageFile]] = None
         # below Union for mypy but actually Optional[List[str]]
         self.inline_images_keys: Optional[List[Union[str, List[str]]]] = None
-        if indirect_ref is not None:  # deprecated
-            warnings.warn(
-                (
-                    "indirect_ref is deprecated and will be removed in "
-                    "pypdf 4.0.0. Use indirect_reference instead of indirect_ref."
-                ),
-                DeprecationWarning,
-            )
-            if indirect_reference is not None:
-                raise ValueError("Use indirect_reference instead of indirect_ref.")
-            indirect_reference = indirect_ref
         self.indirect_reference = indirect_reference
-
-    @property
-    def indirect_ref(self) -> Optional[IndirectObject]:  # deprecated
-        warnings.warn(
-            (
-                "indirect_ref is deprecated and will be removed in pypdf 4.0.0"
-                "Use indirect_reference instead of indirect_ref."
-            ),
-            DeprecationWarning,
-        )
-        return self.indirect_reference
-
-    @indirect_ref.setter
-    def indirect_ref(self, value: Optional[IndirectObject]) -> None:  # deprecated
-        self.indirect_reference = value
 
     def hash_value_data(self) -> bytes:
         data = super().hash_value_data()

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -29,7 +29,6 @@
 
 import math
 import re
-import warnings
 from decimal import Decimal
 from typing import (
     Any,
@@ -1872,8 +1871,6 @@ class PageObject(DictionaryObject):
     def extract_text(
         self,
         *args: Any,
-        Tj_sep: Optional[str] = None,
-        TJ_sep: Optional[str] = None,
         orientations: Union[int, Tuple[int, ...]] = (0, 90, 180, 270),
         space_width: float = 200.0,
         visitor_operand_before: Optional[Callable[[Any, Any, Any, Any], None]] = None,
@@ -1899,8 +1896,6 @@ class PageObject(DictionaryObject):
         For example in some PDF files this can be useful to parse tables.
 
         Args:
-            Tj_sep: Deprecated. Kept for compatibility until pypdf 4.0.0
-            TJ_sep: Deprecated. Kept for compatibility until pypdf 4.0.0
             orientations: list of orientations text_extraction will look for
                 default = (0, 90, 180, 270)
                 note: currently only 0(Up),90(turned Left), 180(upside Down),
@@ -1924,12 +1919,6 @@ class PageObject(DictionaryObject):
         """
         if len(args) >= 1:
             if isinstance(args[0], str):
-                Tj_sep = args[0]
-                if len(args) >= 2:
-                    if isinstance(args[1], str):
-                        TJ_sep = args[1]
-                    else:
-                        raise TypeError(f"Invalid positional parameter {args[1]}")
                 if len(args) >= 3:
                     if isinstance(args[2], (tuple, int)):
                         orientations = args[2]
@@ -1949,11 +1938,6 @@ class PageObject(DictionaryObject):
                         raise TypeError(f"Invalid positional parameter {args[1]}")
             else:
                 raise TypeError(f"Invalid positional parameter {args[0]}")
-        if Tj_sep is not None or TJ_sep is not None:
-            warnings.warn(
-                "parameters Tj_Sep, TJ_sep depreciated, and will be removed in pypdf 4.0.0.",
-                DeprecationWarning,
-            )
 
         if isinstance(orientations, int):
             orientations = (orientations,)

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -61,8 +61,6 @@ from ._utils import (
     File,
     ImageFile,
     TransformationMatrixType,
-    deprecation_no_replacement,
-    deprecation_with_replacement,
     logger_warning,
     matrix_multiply,
 )
@@ -105,31 +103,12 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
     return retval
 
 
-def getRectangle(
-    self: Any, name: str, defaults: Iterable[str]
-) -> RectangleObject:  # deprecated
-    deprecation_no_replacement("getRectangle", "3.0.0")
-    return _get_rectangle(self, name, defaults)
-
-
 def _set_rectangle(self: Any, name: str, value: Union[RectangleObject, float]) -> None:
     name = NameObject(name)
     self[name] = value
 
 
-def setRectangle(
-    self: Any, name: str, value: Union[RectangleObject, float]
-) -> None:  # deprecated
-    deprecation_no_replacement("setRectangle", "3.0.0")
-    _set_rectangle(self, name, value)
-
-
 def _delete_rectangle(self: Any, name: str) -> None:
-    del self[name]
-
-
-def deleteRectangle(self: Any, name: str) -> None:  # deprecated
-    deprecation_no_replacement("deleteRectangle", "3.0.0")
     del self[name]
 
 
@@ -139,13 +118,6 @@ def _create_rectangle_accessor(name: str, fallback: Iterable[str]) -> property:
         lambda self, value: _set_rectangle(self, name, value),
         lambda self: _delete_rectangle(self, name),
     )
-
-
-def createRectangleAccessor(
-    name: str, fallback: Iterable[str]
-) -> property:  # deprecated
-    deprecation_no_replacement("createRectangleAccessor", "3.0.0")
-    return _create_rectangle_accessor(name, fallback)
 
 
 class Transformation:
@@ -445,20 +417,6 @@ class PageObject(DictionaryObject):
         )
 
         return page
-
-    @staticmethod
-    def createBlankPage(
-        pdf: Optional[PdfReaderProtocol] = None,
-        width: Union[float, Decimal, None] = None,
-        height: Union[float, Decimal, None] = None,
-    ) -> "PageObject":  # deprecated
-        """
-        Use :meth:`create_blank_page` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("createBlankPage", "create_blank_page", "3.0.0")
-        return PageObject.create_blank_page(pdf, width, height)
 
     @property
     def _old_images(self) -> List[File]:  # deprecated
@@ -769,28 +727,6 @@ class PageObject(DictionaryObject):
         self[NameObject(PG.ROTATE)] = NumberObject(self.rotation + angle)
         return self
 
-    def rotate_clockwise(self, angle: int) -> "PageObject":  # deprecated
-        deprecation_with_replacement("rotate_clockwise", "rotate", "3.0.0")
-        return self.rotate(angle)
-
-    def rotateClockwise(self, angle: int) -> "PageObject":  # deprecated
-        """
-        Use :meth:`rotate_clockwise` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("rotateClockwise", "rotate", "3.0.0")
-        return self.rotate(angle)
-
-    def rotateCounterClockwise(self, angle: int) -> "PageObject":  # deprecated
-        """
-        Use :meth:`rotate_clockwise` with a negative argument instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("rotateCounterClockwise", "rotate", "3.0.0")
-        return self.rotate(-angle)
-
     def _merge_resources(
         self,
         res1: DictionaryObject,
@@ -956,15 +892,6 @@ class PageObject(DictionaryObject):
         else:
             return None
 
-    def getContents(self) -> Optional[ContentStream]:  # deprecated
-        """
-        Use :meth:`get_contents` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getContents", "get_contents", "3.0.0")
-        return self.get_contents()
-
     def replace_contents(
         self, content: Union[None, ContentStream, EncodedStreamObject, ArrayObject]
     ) -> None:
@@ -1042,15 +969,6 @@ class PageObject(DictionaryObject):
                 expanded to accommodate the dimensions of the page to be merged.
         """
         self._merge_page(page2, over=over, expand=expand)
-
-    def mergePage(self, page2: "PageObject") -> None:  # deprecated
-        """
-        Use :meth:`merge_page` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("mergePage", "merge_page", "3.0.0")
-        return self.merge_page(page2)
 
     def _merge_page(
         self,
@@ -1377,26 +1295,6 @@ class PageObject(DictionaryObject):
             expand,
         )
 
-    def mergeTransformedPage(
-        self,
-        page2: "PageObject",
-        ctm: Union[CompressedTransformationMatrix, Transformation],
-        expand: bool = False,
-    ) -> None:  # deprecated
-        """
-        deprecated
-
-        deprecated:: 1.28.0
-
-            Use :meth:`merge_transformed_page`  instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeTransformedPage(page2, ctm,expand)",
-            "page.merge_transformed_page(page2,ctm,expand)",
-            "3.0.0",
-        )
-        self.merge_transformed_page(page2, ctm, expand)
-
     def merge_scaled_page(
         self, page2: "PageObject", scale: float, over: bool = True, expand: bool = False
     ) -> None:
@@ -1413,23 +1311,6 @@ class PageObject(DictionaryObject):
         """
         op = Transformation().scale(scale, scale)
         self.merge_transformed_page(page2, op, over, expand)
-
-    def mergeScaledPage(
-        self, page2: "PageObject", scale: float, expand: bool = False
-    ) -> None:  # deprecated
-        """
-        deprecated
-
-        .. deprecated:: 1.28.0
-
-            Use :meth:`merge_scaled_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeScaledPage(page2, scale, expand)",
-            "page2.merge_scaled_page(page2, scale, expand)",
-            "3.0.0",
-        )
-        self.merge_scaled_page(page2, scale, expand)
 
     def merge_rotated_page(
         self,
@@ -1451,23 +1332,6 @@ class PageObject(DictionaryObject):
         """
         op = Transformation().rotate(rotation)
         self.merge_transformed_page(page2, op, over, expand)
-
-    def mergeRotatedPage(
-        self, page2: "PageObject", rotation: float, expand: bool = False
-    ) -> None:  # deprecated
-        """
-        deprecated
-
-        .. deprecated:: 1.28.0
-
-            Use :meth:`add_transformation` and :meth:`merge_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeRotatedPage(page2, rotation, expand)",
-            "page2.mergeotatedPage(page2, rotation, expand)",
-            "3.0.0",
-        )
-        self.merge_rotated_page(page2, rotation, expand)
 
     def merge_translated_page(
         self,
@@ -1491,131 +1355,6 @@ class PageObject(DictionaryObject):
         """
         op = Transformation().translate(tx, ty)
         self.merge_transformed_page(page2, op, over, expand)
-
-    def mergeTranslatedPage(
-        self, page2: "PageObject", tx: float, ty: float, expand: bool = False
-    ) -> None:  # deprecated
-        """
-        deprecated
-
-        .. deprecated:: 1.28.0
-
-            Use :meth:`merge_translated_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeTranslatedPage(page2, tx, ty, expand)",
-            "page2.add_transformation(Transformation().translate(tx, ty)); "
-            "page.merge_page(page2, expand)",
-            "3.0.0",
-        )
-        self.merge_translated_page(page2, tx, ty, expand)
-
-    def mergeRotatedTranslatedPage(
-        self,
-        page2: "PageObject",
-        rotation: float,
-        tx: float,
-        ty: float,
-        expand: bool = False,
-    ) -> None:  # deprecated
-        """
-        .. deprecated:: 1.28.0
-
-            Use :meth:`merge_transformed_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeRotatedTranslatedPage(page2, rotation, tx, ty, expand)",
-            "page.merge_transformed_page(page2, Transformation().rotate(rotation).translate(tx, ty), expand);",
-            "3.0.0",
-        )
-        op = Transformation().translate(-tx, -ty).rotate(rotation).translate(tx, ty)
-        return self.merge_transformed_page(page2, op, expand)
-
-    def mergeRotatedScaledPage(
-        self, page2: "PageObject", rotation: float, scale: float, expand: bool = False
-    ) -> None:  # deprecated
-        """
-        .. deprecated:: 1.28.0
-
-            Use :meth:`merge_transformed_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeRotatedScaledPage(page2, rotation, scale, expand)",
-            "page.merge_transformed_page(page2, Transformation()"
-            ".rotate(rotation).scale(scale)); page.merge_page(page2, expand)",
-            "3.0.0",
-        )
-        op = Transformation().rotate(rotation).scale(scale, scale)
-        self.mergeTransformedPage(page2, op, expand)
-
-    def mergeScaledTranslatedPage(
-        self,
-        page2: "PageObject",
-        scale: float,
-        tx: float,
-        ty: float,
-        expand: bool = False,
-    ) -> None:  # deprecated
-        """
-        mergeScaledTranslatedPage is similar to merge_page, but the stream to
-        be merged is translated and scaled by applying a transformation matrix.
-
-        :param PageObject page2: the page to be merged into this one. Should be
-            an instance of :class:`PageObject<PageObject>`.
-        :param float scale: The scaling factor
-        :param float tx: The translation on X axis
-        :param float ty: The translation on Y axis
-        :param bool expand: Whether the page should be expanded to fit the
-            dimensions of the page to be merged.
-
-        .. deprecated:: 1.28.0
-
-            Use :meth:`add_transformation` and :meth:`merge_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeScaledTranslatedPage(page2, scale, tx, ty, expand)",
-            "page2.add_transformation(Transformation().scale(scale).translate(tx, ty)); "
-            "page.merge_page(page2, expand)",
-            "3.0.0",
-        )
-        op = Transformation().scale(scale, scale).translate(tx, ty)
-        return self.mergeTransformedPage(page2, op, expand)
-
-    def mergeRotatedScaledTranslatedPage(
-        self,
-        page2: "PageObject",
-        rotation: float,
-        scale: float,
-        tx: float,
-        ty: float,
-        expand: bool = False,
-    ) -> None:  # deprecated
-        """
-        mergeRotatedScaledTranslatedPage is similar to merge_page, but the
-        stream to be merged is translated, rotated and scaled by applying a
-        transformation matrix.
-
-        :param PageObject page2: the page to be merged into this one. Should be
-            an instance of :class:`PageObject<PageObject>`.
-        :param float tx: The translation on X axis
-        :param float ty: The translation on Y axis
-        :param float rotation: The angle of the rotation, in degrees
-        :param float scale: The scaling factor
-        :param bool expand: Whether the page should be expanded to fit the
-            dimensions of the page to be merged.
-
-        .. deprecated:: 1.28.0
-
-            Use :meth:`add_transformation` and :meth:`merge_page` instead.
-        """
-        deprecation_with_replacement(
-            "page.mergeRotatedScaledTranslatedPage(page2, rotation, tx, ty, expand)",
-            "page2.add_transformation(Transformation().rotate(rotation).scale(scale)); "
-            "page.merge_page(page2, expand)",
-            "3.0.0",
-        )
-        op = Transformation().rotate(rotation).scale(scale, scale).translate(tx, ty)
-        self.mergeTransformedPage(page2, op, expand)
 
     def add_transformation(
         self,
@@ -1668,17 +1407,6 @@ class PageObject(DictionaryObject):
 
             self.mediabox.lower_left = lowerleft
             self.mediabox.upper_right = upperright
-
-    def addTransformation(
-        self, ctm: CompressedTransformationMatrix
-    ) -> None:  # deprecated
-        """
-        Use :meth:`add_transformation` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addTransformation", "add_transformation", "3.0.0")
-        self.add_transformation(ctm)
 
     def scale(self, sx: float, sy: float) -> None:
         """
@@ -1743,15 +1471,6 @@ class PageObject(DictionaryObject):
         """
         self.scale(factor, factor)
 
-    def scaleBy(self, factor: float) -> None:  # deprecated
-        """
-        Use :meth:`scale_by` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("scaleBy", "scale_by", "3.0.0")
-        self.scale(factor, factor)
-
     def scale_to(self, width: float, height: float) -> None:
         """
         Scale a page to the specified dimensions by applying a transformation
@@ -1764,15 +1483,6 @@ class PageObject(DictionaryObject):
         sx = width / float(self.mediabox.width)
         sy = height / float(self.mediabox.height)
         self.scale(sx, sy)
-
-    def scaleTo(self, width: float, height: float) -> None:  # deprecated
-        """
-        Use :meth:`scale_to` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("scaleTo", "scale_to", "3.0.0")
-        self.scale_to(width, height)
 
     def compress_content_streams(self, level: int = -1) -> None:
         """
@@ -1796,17 +1506,6 @@ class PageObject(DictionaryObject):
                     self.replace_contents(content_obj)
                 else:
                     raise ValueError("Page must be part of a PdfWriter")
-
-    def compressContentStreams(self) -> None:  # deprecated
-        """
-        Use :meth:`compress_content_streams` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "compressContentStreams", "compress_content_streams", "3.0.0"
-        )
-        self.compress_content_streams()
 
     @property
     def page_number(self) -> int:
@@ -2331,15 +2030,6 @@ class PageObject(DictionaryObject):
             visitor_text,
         )
 
-    def extractText(self, Tj_sep: str = "", TJ_sep: str = "") -> str:  # deprecated
-        """
-        Use :meth:`extract_text` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("extractText", "extract_text", "3.0.0")
-        return self.extract_text()
-
     def _get_fonts(self) -> Tuple[Set[str], Set[str]]:
         """
         Get the names of embedded fonts and unembedded fonts.
@@ -2360,26 +2050,6 @@ class PageObject(DictionaryObject):
     default user space units, defining the boundaries of the physical medium on
     which the page is intended to be displayed or printed."""
 
-    @property
-    def mediaBox(self) -> RectangleObject:  # deprecated
-        """
-        Use :py:attr:`mediabox` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("mediaBox", "mediabox", "3.0.0")
-        return self.mediabox
-
-    @mediaBox.setter
-    def mediaBox(self, value: RectangleObject) -> None:  # deprecated
-        """
-        Use :py:attr:`mediabox` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("mediaBox", "mediabox", "3.0.0")
-        self.mediabox = value
-
     cropbox = _create_rectangle_accessor("/CropBox", (PG.MEDIABOX,))
     """
     A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
@@ -2392,80 +2062,20 @@ class PageObject(DictionaryObject):
     :attr:`mediabox<mediabox>`.
     """
 
-    @property
-    def cropBox(self) -> RectangleObject:  # deprecated
-        """
-        Use :py:attr:`cropbox` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("cropBox", "cropbox", "3.0.0")
-        return self.cropbox
-
-    @cropBox.setter
-    def cropBox(self, value: RectangleObject) -> None:  # deprecated
-        deprecation_with_replacement("cropBox", "cropbox", "3.0.0")
-        self.cropbox = value
-
     bleedbox = _create_rectangle_accessor("/BleedBox", ("/CropBox", PG.MEDIABOX))
     """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the region to which the contents of the
     page should be clipped when output in a production environment."""
-
-    @property
-    def bleedBox(self) -> RectangleObject:  # deprecated
-        """
-        Use :py:attr:`bleedbox` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("bleedBox", "bleedbox", "3.0.0")
-        return self.bleedbox
-
-    @bleedBox.setter
-    def bleedBox(self, value: RectangleObject) -> None:  # deprecated
-        deprecation_with_replacement("bleedBox", "bleedbox", "3.0.0")
-        self.bleedbox = value
 
     trimbox = _create_rectangle_accessor("/TrimBox", ("/CropBox", PG.MEDIABOX))
     """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the intended dimensions of the finished
     page after trimming."""
 
-    @property
-    def trimBox(self) -> RectangleObject:  # deprecated
-        """
-        Use :py:attr:`trimbox` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("trimBox", "trimbox", "3.0.0")
-        return self.trimbox
-
-    @trimBox.setter
-    def trimBox(self, value: RectangleObject) -> None:  # deprecated
-        deprecation_with_replacement("trimBox", "trimbox", "3.0.0")
-        self.trimbox = value
-
     artbox = _create_rectangle_accessor("/ArtBox", ("/CropBox", PG.MEDIABOX))
     """A :class:`RectangleObject<pypdf.generic.RectangleObject>`, expressed in
     default user space units, defining the extent of the page's meaningful
     content as intended by the page's creator."""
-
-    @property
-    def artBox(self) -> RectangleObject:  # deprecated
-        """
-        Use :py:attr:`artbox` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("artBox", "artbox", "3.0.0")
-        return self.artbox
-
-    @artBox.setter
-    def artBox(self, value: RectangleObject) -> None:  # deprecated
-        deprecation_with_replacement("artBox", "artbox", "3.0.0")
-        self.artbox = value
 
     @property
     def annotations(self) -> Optional[ArrayObject]:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -56,8 +56,6 @@ from ._utils import (
     StreamType,
     b_,
     deprecate_no_replacement,
-    deprecation_no_replacement,
-    deprecation_with_replacement,
     logger_warning,
     parse_iso8824_date,
     read_non_whitespace,
@@ -118,11 +116,6 @@ def convert_to_int(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:
     return struct.unpack(">q", d)[0]
 
 
-def convertToInt(d: bytes, size: int) -> Union[int, Tuple[Any, ...]]:  # deprecated
-    deprecation_with_replacement("convertToInt", "convert_to_int")
-    return convert_to_int(d, size)
-
-
 class DocumentInformation(DictionaryObject):
     """
     A class representing the basic document metadata provided in a PDF File.
@@ -146,15 +139,6 @@ class DocumentInformation(DictionaryObject):
         if isinstance(retval, TextStringObject):
             return retval
         return None
-
-    def getText(self, key: str) -> Optional[str]:  # deprecated
-        """
-        Use the attributes (e.g. :py:attr:`title` / :py:attr:`author`).
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_no_replacement("getText", "3.0.0")
-        return self._get_text(key)
 
     @property
     def title(self) -> Optional[str]:
@@ -394,25 +378,6 @@ class PdfReader:
         retval.update(obj)  # type: ignore
         return retval
 
-    def getDocumentInfo(self) -> Optional[DocumentInformation]:  # deprecated
-        """
-        Use the attribute :py:attr:`metadata` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getDocumentInfo", "metadata", "3.0.0")
-        return self.metadata
-
-    @property
-    def documentInfo(self) -> Optional[DocumentInformation]:  # deprecated
-        """
-        Use the attribute :py:attr:`metadata` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("documentInfo", "metadata", "3.0.0")
-        return self.metadata
-
     @property
     def xmp_metadata(self) -> Optional[XmpInformation]:
         """XMP (Extensible Metadata Platform) data."""
@@ -421,25 +386,6 @@ class PdfReader:
             return self.trailer[TK.ROOT].xmp_metadata  # type: ignore
         finally:
             self._override_encryption = False
-
-    def getXmpMetadata(self) -> Optional[XmpInformation]:  # deprecated
-        """
-        Use the attribute :py:attr:`metadata` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getXmpMetadata", "xmp_metadata", "3.0.0")
-        return self.xmp_metadata
-
-    @property
-    def xmpMetadata(self) -> Optional[XmpInformation]:  # deprecated
-        """
-        Use the attribute :py:attr:`xmp_metadata` instead.
-
-        .. deprecated:: 1.28.0.
-        """
-        deprecation_with_replacement("xmpMetadata", "xmp_metadata", "3.0.0")
-        return self.xmp_metadata
 
     def _get_num_pages(self) -> int:
         """
@@ -462,36 +408,6 @@ class PdfReader:
                 self._flatten()
             return len(self.flattened_pages)  # type: ignore
 
-    def getNumPages(self) -> int:  # deprecated
-        """
-        Use :code:`len(reader.pages)` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("reader.getNumPages", "len(reader.pages)", "3.0.0")
-        return self._get_num_pages()
-
-    @property
-    def numPages(self) -> int:  # deprecated
-        """
-        Use :code:`len(reader.pages)` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("reader.numPages", "len(reader.pages)", "3.0.0")
-        return self._get_num_pages()
-
-    def getPage(self, pageNumber: int) -> PageObject:  # deprecated
-        """
-        Use :code:`reader.pages[page_number]` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "reader.getPage(pageNumber)", "reader.pages[page_number]", "3.0.0"
-        )
-        return self._get_page(pageNumber)
-
     def _get_page(self, page_number: int) -> PageObject:
         """
         Retrieve a page by number from this PDF file.
@@ -507,16 +423,6 @@ class PdfReader:
             self._flatten()
         assert self.flattened_pages is not None, "hint for mypy"
         return self.flattened_pages[page_number]
-
-    @property
-    def namedDestinations(self) -> Dict[str, Any]:  # deprecated
-        """
-        Use :py:attr:`named_destinations` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("namedDestinations", "named_destinations", "3.0.0")
-        return self.named_destinations
 
     @property
     def named_destinations(self) -> Dict[str, Any]:
@@ -578,20 +484,6 @@ class PdfReader:
                 self._build_field(field, retval, fileobj, field_attributes)
 
         return retval
-
-    def getFields(
-        self,
-        tree: Optional[TreeObject] = None,
-        retval: Optional[Dict[Any, Any]] = None,
-        fileobj: Optional[Any] = None,
-    ) -> Optional[Dict[str, Any]]:  # deprecated
-        """
-        Use :meth:`get_fields` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getFields", "get_fields", "3.0.0")
-        return self.get_fields(tree, retval, fileobj)
 
     def _get_qualified_field_name(self, parent: DictionaryObject) -> str:
         if "/TM" in parent:
@@ -744,17 +636,6 @@ class PdfReader:
                     ff[indexed_key(cast(str, value["/T"]), ff)] = value.get("/V")
         return ff
 
-    def getFormTextFields(self) -> Dict[str, Any]:  # deprecated
-        """
-        Use :meth:`get_form_text_fields` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "getFormTextFields", "get_form_text_fields", "3.0.0"
-        )
-        return self.get_form_text_fields()
-
     def _get_named_destinations(
         self,
         tree: Union[TreeObject, None] = None,
@@ -825,21 +706,6 @@ class PdfReader:
                     retval[k__] = dest
         return retval
 
-    def getNamedDestinations(
-        self,
-        tree: Union[TreeObject, None] = None,
-        retval: Optional[Any] = None,
-    ) -> Dict[str, Any]:  # deprecated
-        """
-        Use :py:attr:`named_destinations` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "getNamedDestinations", "named_destinations", "3.0.0"
-        )
-        return self._get_named_destinations(tree, retval)
-
     @property
     def outline(self) -> OutlineType:
         """
@@ -849,16 +715,6 @@ class PdfReader:
         'bookmarks')
         """
         return self._get_outline()
-
-    @property
-    def outlines(self) -> OutlineType:  # deprecated
-        """
-        Use :py:attr:`outline` instead.
-
-        .. deprecated:: 2.9.0
-        """
-        deprecation_with_replacement("outlines", "outline", "3.0.0")
-        return self.outline
 
     def _get_outline(
         self, node: Optional[DictionaryObject] = None, outline: Optional[Any] = None
@@ -900,17 +756,6 @@ class PdfReader:
             node = cast(DictionaryObject, node["/Next"])
 
         return outline
-
-    def getOutlines(
-        self, node: Optional[DictionaryObject] = None, outline: Optional[Any] = None
-    ) -> OutlineType:  # deprecated
-        """
-        Use :py:attr:`outline` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getOutlines", "outline", "3.0.0")
-        return self._get_outline(node, outline)
 
     @property
     def threads(self) -> Optional[ArrayObject]:
@@ -968,15 +813,6 @@ class PdfReader:
         """
         return self._get_page_number_by_indirect(page.indirect_reference)
 
-    def getPageNumber(self, page: PageObject) -> int:  # deprecated
-        """
-        Use :meth:`get_page_number` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getPageNumber", "get_page_number", "3.0.0")
-        return self.get_page_number(page)
-
     def get_destination_page_number(self, destination: Destination) -> int:
         """
         Retrieve page number of a given Destination object.
@@ -988,17 +824,6 @@ class PdfReader:
             The page number or -1 if page is not found
         """
         return self._get_page_number_by_indirect(destination.page)
-
-    def getDestinationPageNumber(self, destination: Destination) -> int:  # deprecated
-        """
-        Use :meth:`get_destination_page_number` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "getDestinationPageNumber", "get_destination_page_number", "3.0.0"
-        )
-        return self.get_destination_page_number(destination)
 
     def _build_destination(
         self,
@@ -1150,25 +975,6 @@ class PdfReader:
             return cast(NameObject, trailer[CD.PAGE_LAYOUT])
         return None
 
-    def getPageLayout(self) -> Optional[str]:  # deprecated
-        """
-        Use :py:attr:`page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getPageLayout", "page_layout", "3.0.0")
-        return self.page_layout
-
-    @property
-    def pageLayout(self) -> Optional[str]:  # deprecated
-        """
-        Use :py:attr:`page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("pageLayout", "page_layout", "3.0.0")
-        return self.page_layout
-
     @property
     def page_mode(self) -> Optional[PagemodeType]:
         """
@@ -1194,25 +1000,6 @@ class PdfReader:
             return self.trailer[TK.ROOT]["/PageMode"]  # type: ignore
         except KeyError:
             return None
-
-    def getPageMode(self) -> Optional[PagemodeType]:  # deprecated
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getPageMode", "page_mode", "3.0.0")
-        return self.page_mode
-
-    @property
-    def pageMode(self) -> Optional[PagemodeType]:  # deprecated
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("pageMode", "page_mode", "3.0.0")
-        return self.page_mode
 
     def _flatten(
         self,
@@ -1466,17 +1253,6 @@ class PdfReader:
         )
         return retval
 
-    def getObject(
-        self, indirectReference: IndirectObject
-    ) -> Optional[PdfObject]:  # deprecated
-        """
-        Use :meth:`get_object` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getObject", "get_object", "3.0.0")
-        return self.get_object(indirectReference)
-
     def read_object_header(self, stream: StreamType) -> Tuple[int, int]:
         # Should never be necessary to read out whitespace, since the
         # cross-reference table should put us in the right spot to read the
@@ -1505,32 +1281,10 @@ class PdfReader:
             )
         return int(idnum), int(generation)
 
-    def readObjectHeader(self, stream: StreamType) -> Tuple[int, int]:  # deprecated
-        """
-        Use :meth:`read_object_header` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("readObjectHeader", "read_object_header", "3.0.0")
-        return self.read_object_header(stream)
-
     def cache_get_indirect_object(
         self, generation: int, idnum: int
     ) -> Optional[PdfObject]:
         return self.resolved_objects.get((generation, idnum))
-
-    def cacheGetIndirectObject(
-        self, generation: int, idnum: int
-    ) -> Optional[PdfObject]:  # deprecated
-        """
-        Use :meth:`cache_get_indirect_object` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "cacheGetIndirectObject", "cache_get_indirect_object", "3.0.0"
-        )
-        return self.cache_get_indirect_object(generation, idnum)
 
     def cache_indirect_object(
         self, generation: int, idnum: int, obj: Optional[PdfObject]
@@ -1544,17 +1298,6 @@ class PdfReader:
         if obj is not None:
             obj.indirect_reference = IndirectObject(idnum, generation, self)
         return obj
-
-    def cacheIndirectObject(
-        self, generation: int, idnum: int, obj: Optional[PdfObject]
-    ) -> Optional[PdfObject]:  # deprecated
-        """
-        Use :meth:`cache_indirect_object` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("cacheIndirectObject", "cache_indirect_object")
-        return self.cache_indirect_object(generation, idnum, obj)
 
     def read(self, stream: StreamType) -> None:
         self._basic_validation(stream)
@@ -2045,13 +1788,6 @@ class PdfReader:
         line_parts.reverse()
         return b"".join(line_parts)
 
-    def readNextEndLine(
-        self, stream: StreamType, limit_offset: int = 0
-    ) -> bytes:  # deprecated
-        """.. deprecated:: 1.28.0"""
-        deprecation_no_replacement("readNextEndLine", "3.0.0")
-        return self.read_next_end_line(stream, limit_offset)
-
     def decrypt(self, password: Union[str, bytes]) -> PasswordType:
         """
         When using an encrypted / secured PDF file with the PDF Standard
@@ -2100,25 +1836,6 @@ class PdfReader:
         :meth:`decrypt()<pypdf.PdfReader.decrypt>` method is called.
         """
         return TK.ENCRYPT in self.trailer
-
-    def getIsEncrypted(self) -> bool:  # deprecated
-        """
-        Use :py:attr:`is_encrypted` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getIsEncrypted", "is_encrypted", "3.0.0")
-        return self.is_encrypted
-
-    @property
-    def isEncrypted(self) -> bool:  # deprecated
-        """
-        Use :py:attr:`is_encrypted` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("isEncrypted", "is_encrypted", "3.0.0")
-        return self.is_encrypted
 
     @property
     def xfa(self) -> Optional[Dict[str, Any]]:
@@ -2314,11 +2031,3 @@ class LazyDict(Mapping[Any, Any]):
 
     def __str__(self) -> str:
         return f"LazyDict(keys={list(self.keys())})"
-
-
-class PdfFileReader(PdfReader):  # deprecated
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        deprecation_with_replacement("PdfFileReader", "PdfReader", "3.0.0")
-        if "strict" not in kwargs and len(args) < 2:
-            kwargs["strict"] = True  # maintain the default
-        super().__init__(*args, **kwargs)

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -55,7 +55,6 @@ from ._utils import (
     StrByteType,
     StreamType,
     b_,
-    deprecate_no_replacement,
     logger_warning,
     parse_iso8824_date,
     read_non_whitespace,
@@ -1754,39 +1753,6 @@ class PdfReader:
             i += 2
             if (i + 1) >= len(array):
                 break
-
-    def read_next_end_line(
-        self, stream: StreamType, limit_offset: int = 0
-    ) -> bytes:  # deprecated
-        """.. deprecated:: 2.1.0"""
-        deprecate_no_replacement("read_next_end_line", removed_in="4.0.0")
-        line_parts = []
-        while True:
-            # Prevent infinite loops in malformed PDFs
-            if stream.tell() == 0 or stream.tell() == limit_offset:
-                raise PdfReadError("Could not read malformed PDF file")
-            x = stream.read(1)
-            if stream.tell() < 2:
-                raise PdfReadError("EOL marker not found")
-            stream.seek(-2, 1)
-            if x in (b"\n", b"\r"):  # \n = LF; \r = CR
-                crlf = False
-                while x in (b"\n", b"\r"):
-                    x = stream.read(1)
-                    if x in (b"\n", b"\r"):  # account for CR+LF
-                        stream.seek(-1, 1)
-                        crlf = True
-                    if stream.tell() < 2:
-                        raise PdfReadError("EOL marker not found")
-                    stream.seek(-2, 1)
-                stream.seek(
-                    2 if crlf else 1, 1
-                )  # if using CR+LF, go back 2 bytes, else 1
-                break
-            else:
-                line_parts.append(x)
-        line_parts.reverse()
-        return b"".join(line_parts)
 
     def decrypt(self, password: Union[str, bytes]) -> PasswordType:
         """

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -41,7 +41,6 @@ from os import SEEK_CUR
 from typing import (
     IO,
     Any,
-    Callable,
     Dict,
     List,
     Optional,
@@ -464,26 +463,6 @@ def logger_warning(msg: str, src: str) -> None:
       to strict=False mode.
     """
     logging.getLogger(src).warning(msg)
-
-
-def deprecation_bookmark(**aliases: str) -> Callable[..., Any]:
-    """
-    Decorator for deprecated term "bookmark".
-
-    To be used for methods and function arguments
-        outline_item = a bookmark
-        outline = a collection of outline items.
-    """
-
-    def decoration(func: Callable[..., Any]) -> Any:
-        @functools.wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            rename_kwargs(func.__name__, kwargs, aliases, fail=True)
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return decoration
 
 
 def rename_kwargs(

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -201,7 +201,7 @@ def check_if_whitespace_only(value: bytes) -> bool:
         True if the value only has whitespace characters, otherwise return False.
     """
     for index in range(len(value)):
-        current = value[index:index + 1]
+        current = value[index : index + 1]
         if current not in WHITESPACES:
             return False
     return True
@@ -427,26 +427,22 @@ def deprecation(msg: str) -> None:
     raise DeprecationError(msg)
 
 
-def deprecate_with_replacement(
-    old_name: str, new_name: str, removed_in: str = "3.0.0"
-) -> None:
+def deprecate_with_replacement(old_name: str, new_name: str, removed_in: str) -> None:
     """Raise an exception that a feature will be removed, but has a replacement."""
     deprecate(DEPR_MSG.format(old_name, removed_in, new_name), 4)
 
 
-def deprecation_with_replacement(
-    old_name: str, new_name: str, removed_in: str = "3.0.0"
-) -> None:
+def deprecation_with_replacement(old_name: str, new_name: str, removed_in: str) -> None:
     """Raise an exception that a feature was already removed, but has a replacement."""
     deprecation(DEPR_MSG_HAPPENED.format(old_name, removed_in, new_name))
 
 
-def deprecate_no_replacement(name: str, removed_in: str = "3.0.0") -> None:
+def deprecate_no_replacement(name: str, removed_in: str) -> None:
     """Raise an exception that a feature will be removed without replacement."""
     deprecate(DEPR_MSG_NO_REPLACEMENT.format(name, removed_in), 4)
 
 
-def deprecation_no_replacement(name: str, removed_in: str = "3.0.0") -> None:
+def deprecation_no_replacement(name: str, removed_in: str) -> None:
     """Raise an exception that a feature was already removed without replacement."""
     deprecation(DEPR_MSG_NO_REPLACEMENT_HAPPENED.format(name, removed_in))
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -286,15 +286,6 @@ class PdfWriter:
             raise ValueError("pdf must be self")
         return self._objects[indirect_reference.idnum - 1]
 
-    def getObject(self, ido: Union[int, IndirectObject]) -> PdfObject:  # deprecated
-        """
-        Use :meth:`get_object` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getObject", "get_object", "3.0.0")
-        return self.get_object(ido)
-
     def _replace_object(
         self,
         indirect_reference: Union[int, IndirectObject],
@@ -418,19 +409,6 @@ class PdfWriter:
         """
         return self._add_page(page, list.append, excluded_keys)
 
-    def addPage(
-        self,
-        page: PageObject,
-        excluded_keys: Iterable[str] = (),
-    ) -> PageObject:  # deprecated
-        """
-        Use :meth:`add_page` instead.
-
-        .. deprecated:: 1.28.0.
-        """
-        deprecation_with_replacement("addPage", "add_page", "3.0.0")
-        return self.add_page(page, excluded_keys)
-
     def insert_page(
         self,
         page: PageObject,
@@ -450,20 +428,6 @@ class PdfWriter:
             The added PageObject.
         """
         return self._add_page(page, lambda kids, p: kids.insert(index, p))
-
-    def insertPage(
-        self,
-        page: PageObject,
-        index: int = 0,
-        excluded_keys: Iterable[str] = (),
-    ) -> PageObject:  # deprecated
-        """
-        Use :meth:`insert_page` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("insertPage", "insert_page", "3.0.0")
-        return self.insert_page(page, index, excluded_keys)
 
     def get_page(
         self, page_number: Optional[int] = None, pageNumber: Optional[int] = None
@@ -491,27 +455,9 @@ class PdfWriter:
         # TODO: crude hack
         return cast(PageObject, pages[PA.KIDS][page_number].get_object())
 
-    def getPage(self, pageNumber: int) -> PageObject:  # deprecated
-        """
-        Use :code:`writer.pages[page_number]` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getPage", "writer.pages[page_number]", "3.0.0")
-        return self.get_page(pageNumber)
-
     def _get_num_pages(self) -> int:
         pages = cast(Dict[str, Any], self.get_object(self._pages))
         return int(pages[NameObject("/Count")])
-
-    def getNumPages(self) -> int:  # deprecated
-        """
-        Use :code:`len(writer.pages)` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getNumPages", "len(writer.pages)", "3.0.0")
-        return self._get_num_pages()
 
     @property
     def pages(self) -> List[PageObject]:
@@ -553,17 +499,6 @@ class PdfWriter:
         page = PageObject.create_blank_page(self, width, height)
         return self.add_page(page)
 
-    def addBlankPage(
-        self, width: Optional[float] = None, height: Optional[float] = None
-    ) -> PageObject:  # deprecated
-        """
-        Use :meth:`add_blank_page` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addBlankPage", "add_blank_page", "3.0.0")
-        return self.add_blank_page(width, height)
-
     def insert_blank_page(
         self,
         width: Optional[Union[float, decimal.Decimal]] = None,
@@ -596,20 +531,6 @@ class PdfWriter:
         page = PageObject.create_blank_page(self, width, height)
         self.insert_page(page, index)
         return page
-
-    def insertBlankPage(
-        self,
-        width: Optional[Union[float, decimal.Decimal]] = None,
-        height: Optional[Union[float, decimal.Decimal]] = None,
-        index: int = 0,
-    ) -> PageObject:  # deprecated
-        """
-        Use :meth:`insertBlankPage` instead.
-
-        .. deprecated:: 1.28.0.
-        """
-        deprecation_with_replacement("insertBlankPage", "insert_blank_page", "3.0.0")
-        return self.insert_blank_page(width, height, index)
 
     @property
     def open_destination(
@@ -693,15 +614,6 @@ class PdfWriter:
         # but it can be anything.
         js_list.append(create_string_object(str(uuid.uuid4())))
         js_list.append(self._add_object(js))
-
-    def addJS(self, javascript: str) -> None:  # deprecated
-        """
-        Use :meth:`add_js` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addJS", "add_js", "3.0.0")
-        return self.add_js(javascript)
 
     def add_attachment(self, filename: str, data: Union[str, bytes]) -> None:
         """
@@ -791,15 +703,6 @@ class PdfWriter:
             [create_string_object(filename), filespec]
         )
 
-    def addAttachment(self, fname: str, fdata: Union[str, bytes]) -> None:  # deprecated
-        """
-        Use :meth:`add_attachment` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addAttachment", "add_attachment", "3.0.0")
-        return self.add_attachment(fname, fdata)
-
     def append_pages_from_reader(
         self,
         reader: PdfReader,
@@ -831,21 +734,6 @@ class PdfWriter:
             # Trigger callback, pass writer page as parameter
             if callable(after_page_append):
                 after_page_append(writer_page)
-
-    def appendPagesFromReader(
-        self,
-        reader: PdfReader,
-        after_page_append: Optional[Callable[[PageObject], None]] = None,
-    ) -> None:  # deprecated
-        """
-        Use :meth:`append_pages_from_reader` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "appendPagesFromReader", "append_pages_from_reader", "3.0.0"
-        )
-        self.append_pages_from_reader(reader, after_page_append)
 
     def _get_qualified_field_name(self, parent: DictionaryObject) -> Optional[str]:
         if "/TM" in parent:
@@ -1079,22 +967,6 @@ class PdfWriter:
                             value if value in k[AA.AP]["/N"] else "/Off"
                         )
 
-    def updatePageFormFieldValues(
-        self,
-        page: PageObject,
-        fields: Dict[str, Any],
-        flags: FieldFlag = OPTIONAL_READ_WRITE_FIELD,
-    ) -> None:  # deprecated
-        """
-        Use :meth:`update_page_form_field_values` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "updatePageFormFieldValues", "update_page_form_field_values", "3.0.0"
-        )
-        return self.update_page_form_field_values(page, fields, flags)
-
     def clone_reader_document_root(self, reader: PdfReader) -> None:
         """
         Copy the reader document root to the writer and all sub elements,
@@ -1117,17 +989,6 @@ class PdfWriter:
             NameObject("/Kids")
         ] = self.flattened_pages
         del self.flattened_pages
-
-    def cloneReaderDocumentRoot(self, reader: PdfReader) -> None:  # deprecated
-        """
-        Use :meth:`clone_reader_document_root` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "cloneReaderDocumentRoot", "clone_reader_document_root", "3.0.0"
-        )
-        self.clone_reader_document_root(reader)
 
     def _flatten(
         self,
@@ -1207,21 +1068,6 @@ class PdfWriter:
                 ArrayObject, cast(DictionaryObject, self._pages.get_object())["/Kids"]
             ):
                 after_page_append(page.get_object())
-
-    def cloneDocumentFromReader(
-        self,
-        reader: PdfReader,
-        after_page_append: Optional[Callable[[PageObject], None]] = None,
-    ) -> None:  # deprecated
-        """
-        Use :meth:`clone_document_from_reader` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "cloneDocumentFromReader", "clone_document_from_reader", "3.0.0"
-        )
-        self.clone_document_from_reader(reader, after_page_append)
 
     def _compute_document_identifier(self) -> ByteStringObject:
         stream = BytesIO()
@@ -1457,15 +1303,6 @@ class PdfWriter:
             args[NameObject(key)] = create_string_object(str(value))
         cast(DictionaryObject, self._info.get_object()).update(args)
 
-    def addMetadata(self, infos: Dict[str, Any]) -> None:  # deprecated
-        """
-        Use :meth:`add_metadata` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addMetadata", "add_metadata", "3.0.0")
-        self.add_metadata(infos)
-
     def _sweep_indirect_references(
         self,
         root: Union[
@@ -1624,15 +1461,6 @@ class PdfWriter:
         assert ref.get_object() == obj
         return ref
 
-    def getReference(self, obj: PdfObject) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`get_reference` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getReference", "get_reference", "3.0.0")
-        return self.get_reference(obj)
-
     def get_outline_root(self) -> TreeObject:
         if CO.OUTLINES in self._root_object:
             # TABLE 3.25 Entries in the catalog dictionary
@@ -1681,15 +1509,6 @@ class PdfWriter:
         """
         return self.get_threads_root()
 
-    def getOutlineRoot(self) -> TreeObject:  # deprecated
-        """
-        Use :meth:`get_outline_root` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getOutlineRoot", "get_outline_root", "3.0.0")
-        return self.get_outline_root()
-
     def get_named_dest_root(self) -> ArrayObject:
         if CA.NAMES in self._root_object and isinstance(
             self._root_object[CA.NAMES], DictionaryObject
@@ -1724,15 +1543,6 @@ class PdfWriter:
             dests[NameObject(CA.NAMES)] = nd
 
         return nd
-
-    def getNamedDestRoot(self) -> ArrayObject:  # deprecated
-        """
-        Use :meth:`get_named_dest_root` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getNamedDestRoot", "get_named_dest_root", "3.0.0")
-        return self.get_named_dest_root()
 
     def add_outline_item_destination(
         self,
@@ -1793,34 +1603,6 @@ class PdfWriter:
 
         return page_destination_ref
 
-    def add_bookmark_destination(
-        self,
-        dest: Union[PageObject, TreeObject],
-        parent: Union[None, TreeObject, IndirectObject] = None,
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_outline_item_destination` instead.
-
-        .. deprecated:: 2.9.0
-        """
-        deprecation_with_replacement(
-            "add_bookmark_destination", "add_outline_item_destination", "3.0.0"
-        )
-        return self.add_outline_item_destination(dest, parent)
-
-    def addBookmarkDestination(
-        self, dest: PageObject, parent: Optional[TreeObject] = None
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_outline_item_destination` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "addBookmarkDestination", "add_outline_item_destination", "3.0.0"
-        )
-        return self.add_outline_item_destination(dest, parent)
-
     @deprecation_bookmark(bookmark="outline_item")
     def add_outline_item_dict(
         self,
@@ -1843,34 +1625,6 @@ class PdfWriter:
         return self.add_outline_item_destination(
             outline_item_object, parent, before, is_open
         )
-
-    @deprecation_bookmark(bookmark="outline_item")
-    def add_bookmark_dict(
-        self, outline_item: OutlineItemType, parent: Optional[TreeObject] = None
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_outline_item_dict` instead.
-
-        .. deprecated:: 2.9.0
-        """
-        deprecation_with_replacement(
-            "add_bookmark_dict", "add_outline_item_dict", "3.0.0"
-        )
-        return self.add_outline_item_dict(outline_item, parent)
-
-    @deprecation_bookmark(bookmark="outline_item")
-    def addBookmarkDict(
-        self, outline_item: OutlineItemType, parent: Optional[TreeObject] = None
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_outline_item_dict` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "addBookmarkDict", "add_outline_item_dict", "3.0.0"
-        )
-        return self.add_outline_item_dict(outline_item, parent)
 
     def add_outline_item(
         self,
@@ -1955,61 +1709,6 @@ class PdfWriter:
             parent = self.get_outline_root()
         return self.add_outline_item_destination(outline_item, parent, before, is_open)
 
-    def add_bookmark(
-        self,
-        title: str,
-        pagenum: int,  # deprecated, but the whole method is deprecated
-        parent: Union[None, TreeObject, IndirectObject] = None,
-        color: Optional[Tuple[float, float, float]] = None,
-        bold: bool = False,
-        italic: bool = False,
-        fit: FitType = "/Fit",
-        *args: ZoomArgType,
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_outline_item` instead.
-
-        .. deprecated:: 2.9.0
-        """
-        deprecation_with_replacement("add_bookmark", "add_outline_item", "3.0.0")
-        return self.add_outline_item(
-            title,
-            pagenum,
-            parent,
-            color,  # type: ignore
-            bold,  # type: ignore
-            italic,
-            Fit(fit_type=fit, fit_args=args),  # type: ignore
-        )
-
-    def addBookmark(
-        self,
-        title: str,
-        pagenum: int,
-        parent: Union[None, TreeObject, IndirectObject] = None,
-        color: Optional[Tuple[float, float, float]] = None,
-        bold: bool = False,
-        italic: bool = False,
-        fit: FitType = "/Fit",
-        *args: ZoomArgType,
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_outline_item` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addBookmark", "add_outline_item", "3.0.0")
-        return self.add_outline_item(
-            title,
-            pagenum,
-            parent,
-            None,
-            color,
-            bold,
-            italic,
-            Fit(fit_type=fit, fit_args=args),
-        )
-
     def add_outline(self) -> None:
         raise NotImplementedError(
             "This method is not yet implemented. Use :meth:`add_outline_item` instead."
@@ -2061,19 +1760,6 @@ class PdfWriter:
 
         return page_destination_ref
 
-    def addNamedDestinationObject(
-        self, dest: Destination
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_named_destination_object` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "addNamedDestinationObject", "add_named_destination_object", "3.0.0"
-        )
-        return self.add_named_destination_object(dest)
-
     def add_named_destination(
         self,
         title: str,
@@ -2116,32 +1802,10 @@ class PdfWriter:
         self.add_named_destination_array(title, dest_ref)
         return dest_ref
 
-    def addNamedDestination(
-        self, title: str, pagenum: int
-    ) -> IndirectObject:  # deprecated
-        """
-        Use :meth:`add_named_destination` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "addNamedDestination", "add_named_destination", "3.0.0"
-        )
-        return self.add_named_destination(title, pagenum)
-
     def remove_links(self) -> None:
         """Remove links and annotations from this output."""
         for page in self.pages:
             self.remove_objects_from_page(page, ObjectDeletionFlag.ALL_ANNOTATIONS)
-
-    def removeLinks(self) -> None:  # deprecated
-        """
-        Use :meth:`remove_links` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("removeLinks", "remove_links", "3.0.0")
-        return self.remove_links()
 
     def remove_annotations(
         self, subtypes: Optional[Union[AnnotationSubtype, Iterable[AnnotationSubtype]]]
@@ -2351,15 +2015,6 @@ class PdfWriter:
         for page in self.pages:
             self.remove_objects_from_page(page, i)
 
-    def removeImages(self, ignoreByteStringObject: bool = False) -> None:  # deprecated
-        """
-        Use :meth:`remove_images` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("removeImages", "remove_images", "3.0.0")
-        return self.remove_images()
-
     def remove_text(self, ignore_byte_string_object: Optional[bool] = None) -> None:
         """
         Remove text from this output.
@@ -2375,15 +2030,6 @@ class PdfWriter:
             )
         for page in self.pages:
             self.remove_objects_from_page(page, ObjectDeletionFlag.TEXT)
-
-    def removeText(self, ignoreByteStringObject: bool = False) -> None:  # deprecated
-        """
-        Use :meth:`remove_text` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("removeText", "remove_text", "3.0.0")
-        return self.remove_text(ignoreByteStringObject)
 
     def add_uri(
         self,
@@ -2461,21 +2107,6 @@ class PdfWriter:
         else:
             page_ref[NameObject(PG.ANNOTS)] = ArrayObject([lnk_ref])
 
-    def addURI(
-        self,
-        pagenum: int,  # deprecated, but method is deprecated already
-        uri: str,
-        rect: RectangleObject,
-        border: Optional[ArrayObject] = None,
-    ) -> None:  # deprecated
-        """
-        Use :meth:`add_uri` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("addURI", "add_uri", "3.0.0")
-        return self.add_uri(pagenum, uri, rect, border)
-
     def add_link(
         self,
         pagenum: int,  # deprecated, but method is deprecated already
@@ -2486,7 +2117,7 @@ class PdfWriter:
         *args: ZoomArgType,
     ) -> DictionaryObject:
         deprecation_with_replacement(
-            "add_link", "add_annotation(pypdf.annotations.Link(...))"
+            "add_link", "add_annotation(pypdf.annotations.Link(...))", "3.0.0"
         )
 
         if isinstance(rect, str):
@@ -2541,15 +2172,6 @@ class PdfWriter:
             return cast(LayoutType, self._root_object["/PageLayout"])
         except KeyError:
             return None
-
-    def getPageLayout(self) -> Optional[LayoutType]:  # deprecated
-        """
-        Use :py:attr:`page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getPageLayout", "page_layout", "3.0.0")
-        return self._get_page_layout()
 
     def _set_page_layout(self, layout: Union[NameObject, LayoutType]) -> None:
         """
@@ -2612,17 +2234,6 @@ class PdfWriter:
         """
         self._set_page_layout(layout)
 
-    def setPageLayout(self, layout: LayoutType) -> None:  # deprecated
-        """
-        Use :py:attr:`page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "writer.setPageLayout(val)", "writer.page_layout = val", "3.0.0"
-        )
-        return self._set_page_layout(layout)
-
     @property
     def page_layout(self) -> Optional[LayoutType]:
         """
@@ -2652,26 +2263,6 @@ class PdfWriter:
     def page_layout(self, layout: LayoutType) -> None:
         self._set_page_layout(layout)
 
-    @property
-    def pageLayout(self) -> Optional[LayoutType]:  # deprecated
-        """
-        Use :py:attr:`page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("pageLayout", "page_layout", "3.0.0")
-        return self.page_layout
-
-    @pageLayout.setter
-    def pageLayout(self, layout: LayoutType) -> None:  # deprecated
-        """
-        Use :py:attr:`page_layout` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("pageLayout", "page_layout", "3.0.0")
-        self.page_layout = layout
-
     _valid_modes = (
         "/UseNone",
         "/UseOutlines",
@@ -2686,15 +2277,6 @@ class PdfWriter:
             return cast(PagemodeType, self._root_object["/PageMode"])
         except KeyError:
             return None
-
-    def getPageMode(self) -> Optional[PagemodeType]:  # deprecated
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getPageMode", "page_mode", "3.0.0")
-        return self._get_page_mode()
 
     def set_page_mode(self, mode: PagemodeType) -> None:
         """
@@ -2711,17 +2293,6 @@ class PdfWriter:
                 )
             mode_name = NameObject(mode)
         self._root_object.update({NameObject("/PageMode"): mode_name})
-
-    def setPageMode(self, mode: PagemodeType) -> None:  # deprecated
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "writer.setPageMode(val)", "writer.page_mode = val", "3.0.0"
-        )
-        self.set_page_mode(mode)
 
     @property
     def page_mode(self) -> Optional[PagemodeType]:
@@ -2749,26 +2320,6 @@ class PdfWriter:
     @page_mode.setter
     def page_mode(self, mode: PagemodeType) -> None:
         self.set_page_mode(mode)
-
-    @property
-    def pageMode(self) -> Optional[PagemodeType]:  # deprecated
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("pageMode", "page_mode", "3.0.0")
-        return self.page_mode
-
-    @pageMode.setter
-    def pageMode(self, mode: PagemodeType) -> None:  # deprecated
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("pageMode", "page_mode", "3.0.0")
-        self.page_mode = mode
 
     def add_annotation(
         self,
@@ -3621,9 +3172,3 @@ def _create_outline_item(
             format_flag += 2
         outline_item.update({NameObject("/F"): NumberObject(format_flag)})
     return outline_item
-
-
-class PdfFileWriter(PdfWriter):  # deprecated
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        deprecation_with_replacement("PdfFileWriter", "PdfWriter", "3.0.0")
-        super().__init__(*args, **kwargs)

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -63,7 +63,6 @@ from ._utils import (
     StreamType,
     _get_max_pdf_version_header,
     b_,
-    deprecation_bookmark,
     logger_warning,
 )
 from .constants import AnnotationDictionaryAttributes as AA
@@ -1511,7 +1510,6 @@ class PdfWriter:
 
         return page_destination_ref
 
-    @deprecation_bookmark(bookmark="outline_item")
     def add_outline_item_dict(
         self,
         outline_item: OutlineItemType,
@@ -2292,7 +2290,6 @@ class PdfWriter:
                 excluded_fields,
             )
 
-    @deprecation_bookmark(bookmark="outline_item", import_bookmarks="import_outline")
     def merge(
         self,
         position: Optional[int],
@@ -2724,7 +2721,6 @@ class PdfWriter:
         """To match the functions from Merger."""
         return
 
-    # @deprecation_bookmark(bookmark="outline_item")
     def find_outline_item(
         self,
         outline_item: Dict[str, Any],
@@ -2754,7 +2750,6 @@ class PdfWriter:
             else:
                 return None
 
-    @deprecation_bookmark(bookmark="outline_item")
     def find_bookmark(
         self,
         outline_item: Dict[str, Any],

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1844,7 +1844,6 @@ class PdfWriter:
         Args:
             to_delete : The type of images to be deleted
                 (default = all images types)
-            ignore_byte_string_object: deprecated
         """
         if isinstance(to_delete, bool):
             to_delete = ImageType.ALL
@@ -1869,12 +1868,7 @@ class PdfWriter:
             self.remove_objects_from_page(page, i)
 
     def remove_text(self) -> None:
-        """
-        Remove text from this output.
-
-        Args:
-            ignore_byte_string_object: deprecated
-        """
+        """Remove text from this output."""
         for page in self.pages:
             self.remove_objects_from_page(page, ObjectDeletionFlag.TEXT)
 
@@ -2065,22 +2059,6 @@ class PdfWriter:
         except KeyError:
             return None
 
-    def set_page_mode(self, mode: PagemodeType) -> None:
-        """
-        Use :py:attr:`page_mode` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        if isinstance(mode, NameObject):
-            mode_name: NameObject = mode
-        else:
-            if mode not in self._valid_modes:
-                logger_warning(
-                    f"Mode should be one of: {', '.join(self._valid_modes)}", __name__
-                )
-            mode_name = NameObject(mode)
-        self._root_object.update({NameObject("/PageMode"): mode_name})
-
     @property
     def page_mode(self) -> Optional[PagemodeType]:
         """
@@ -2106,7 +2084,15 @@ class PdfWriter:
 
     @page_mode.setter
     def page_mode(self, mode: PagemodeType) -> None:
-        self.set_page_mode(mode)
+        if isinstance(mode, NameObject):
+            mode_name: NameObject = mode
+        else:
+            if mode not in self._valid_modes:
+                logger_warning(
+                    f"Mode should be one of: {', '.join(self._valid_modes)}", __name__
+                )
+            mode_name = NameObject(mode)
+        self._root_object.update({NameObject("/PageMode"): mode_name})
 
     def add_annotation(
         self,

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -63,12 +63,9 @@ from ._utils import (
     StreamType,
     _get_max_pdf_version_header,
     b_,
-    deprecate_with_replacement,
     deprecation_bookmark,
-    deprecation_with_replacement,
     logger_warning,
 )
-from .annotations import Link
 from .constants import AnnotationDictionaryAttributes as AA
 from .constants import CatalogAttributes as CA
 from .constants import (
@@ -119,12 +116,10 @@ from .pagerange import PageRange, PageRangeSpec
 from .types import (
     AnnotationSubtype,
     BorderArrayType,
-    FitType,
     LayoutType,
     OutlineItemType,
     OutlineType,
     PagemodeType,
-    ZoomArgType,
 )
 
 OPTIONAL_READ_WRITE_FIELD = FieldFlag(0)
@@ -1895,8 +1890,6 @@ class PdfWriter:
         """
         Add an URI from a rectangular area to the specified page.
 
-        This uses the basic structure of :meth:`add_link`
-
         Args:
             page_number: index of the page on which to place the URI action.
             uri: URI of resource to link to.
@@ -1952,56 +1945,6 @@ class PdfWriter:
             page_ref[PG.ANNOTS].append(lnk_ref)
         else:
             page_ref[NameObject(PG.ANNOTS)] = ArrayObject([lnk_ref])
-
-    def add_link(
-        self,
-        pagenum: int,  # deprecated, but method is deprecated already
-        page_destination: int,
-        rect: RectangleObject,
-        border: Optional[ArrayObject] = None,
-        fit: FitType = "/Fit",
-        *args: ZoomArgType,
-    ) -> DictionaryObject:
-        deprecation_with_replacement(
-            "add_link", "add_annotation(pypdf.annotations.Link(...))", "3.0.0"
-        )
-
-        if isinstance(rect, str):
-            rect = rect.strip()[1:-1]
-            rect = RectangleObject(
-                [float(num) for num in rect.split(" ") if len(num) > 0]
-            )
-        elif isinstance(rect, RectangleObject):
-            pass
-        else:
-            rect = RectangleObject(rect)
-
-        annotation = Link(
-            rect=rect,
-            border=border,
-            target_page_index=page_destination,
-            fit=Fit(fit_type=fit, fit_args=args),
-        )
-        return self.add_annotation(page_number=pagenum, annotation=annotation)
-
-    def addLink(
-        self,
-        pagenum: int,  # deprecated, but method is deprecated already
-        page_destination: int,
-        rect: RectangleObject,
-        border: Optional[ArrayObject] = None,
-        fit: FitType = "/Fit",
-        *args: ZoomArgType,
-    ) -> None:  # deprecated
-        """
-        Use :meth:`add_link` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecate_with_replacement(
-            "addLink", "add_annotation(pypdf.annotations.Link(...))", "4.0.0"
-        )
-        self.add_link(pagenum, page_destination, rect, border, fit, *args)
 
     _valid_layouts = (
         "/NoLayout",

--- a/pypdf/generic/__init__.py
+++ b/pypdf/generic/__init__.py
@@ -58,7 +58,7 @@ from ._data_structures import (
     read_object,
 )
 from ._fit import Fit
-from ._outline import Bookmark, OutlineItem
+from ._outline import OutlineItem
 from ._rectangle import RectangleObject
 from ._utils import (
     create_string_object,
@@ -449,7 +449,6 @@ __all__ = [
     # Outline
     "OutlineItem",
     "OutlineFontFlag",
-    "Bookmark",
     # Data structures core functions
     "read_object",
     # Utility functions

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -38,7 +38,6 @@ from .._utils import (
     StreamType,
     b_,
     deprecate_no_replacement,
-    deprecation_with_replacement,
     logger_warning,
     read_non_whitespace,
     read_until_regex,
@@ -147,10 +146,6 @@ class PdfObject(PdfObjectProtocol):
         """Resolve indirect references."""
         return self
 
-    def getObject(self) -> Optional["PdfObject"]:  # deprecated
-        deprecation_with_replacement("getObject", "get_object", "3.0.0")
-        return self.get_object()
-
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes] = None
     ) -> None:
@@ -185,19 +180,8 @@ class NullObject(PdfObject):
             raise PdfReadError("Could not read Null object")
         return NullObject()
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
     def __repr__(self) -> str:
         return "NullObject"
-
-    @staticmethod
-    def readFromStream(stream: StreamType) -> "NullObject":  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return NullObject.read_from_stream(stream)
 
 
 class BooleanObject(PdfObject):
@@ -239,12 +223,6 @@ class BooleanObject(PdfObject):
         else:
             stream.write(b"false")
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
     @staticmethod
     def read_from_stream(stream: StreamType) -> "BooleanObject":
         word = stream.read(4)
@@ -255,11 +233,6 @@ class BooleanObject(PdfObject):
             return BooleanObject(False)
         else:
             raise PdfReadError("Could not read Boolean object")
-
-    @staticmethod
-    def readFromStream(stream: StreamType) -> "BooleanObject":  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return BooleanObject.read_from_stream(stream)
 
 
 class IndirectObject(PdfObject):
@@ -338,12 +311,6 @@ class IndirectObject(PdfObject):
             )
         stream.write(f"{self.idnum} {self.generation} R".encode())
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
     @staticmethod
     def read_from_stream(stream: StreamType, pdf: Any) -> "IndirectObject":  # PdfReader
         idnum = b""
@@ -370,13 +337,6 @@ class IndirectObject(PdfObject):
                 f"Error reading indirect object reference at byte {hex(stream.tell())}"
             )
         return IndirectObject(int(idnum), int(generation), pdf)
-
-    @staticmethod
-    def readFromStream(
-        stream: StreamType, pdf: Any  # PdfReader
-    ) -> "IndirectObject":  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return IndirectObject.read_from_stream(stream, pdf)
 
 
 FLOAT_WRITE_PRECISION = 8  # shall be min 5 digits max, allow user adj
@@ -431,12 +391,6 @@ class FloatObject(float, PdfObject):
             )
         stream.write(self.myrepr().encode("utf8"))
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
 
 class NumberObject(int, PdfObject):
     NumberPattern = re.compile(b"[^+-.0-9]")
@@ -472,25 +426,12 @@ class NumberObject(int, PdfObject):
             )
         stream.write(repr(self).encode("utf8"))
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
     @staticmethod
     def read_from_stream(stream: StreamType) -> Union["NumberObject", "FloatObject"]:
         num = read_until_regex(stream, NumberObject.NumberPattern)
         if num.find(b".") != -1:
             return FloatObject(num)
         return NumberObject(num)
-
-    @staticmethod
-    def readFromStream(
-        stream: StreamType,
-    ) -> Union["NumberObject", "FloatObject"]:  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return NumberObject.read_from_stream(stream)
 
 
 class ByteStringObject(bytes, PdfObject):
@@ -531,12 +472,6 @@ class ByteStringObject(bytes, PdfObject):
         stream.write(b"<")
         stream.write(binascii.hexlify(self))
         stream.write(b">")
-
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
 
 
 class TextStringObject(str, PdfObject):  # noqa: SLOT000
@@ -618,12 +553,6 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
                 stream.write(b_(chr(c)))
         stream.write(b")")
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
 
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
@@ -657,12 +586,6 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
                 "the encryption_key parameter of write_to_stream", "5.0.0"
             )
         stream.write(self.renumber())
-
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
 
     def renumber(self) -> bytes:
         out = self[0].encode("utf-8")
@@ -717,13 +640,6 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
                 raise PdfReadError(
                     f"Illegal character in Name Object ({name!r})"
                 ) from e
-
-    @staticmethod
-    def readFromStream(
-        stream: StreamType, pdf: Any  # PdfReader
-    ) -> "NameObject":  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return NameObject.read_from_stream(stream, pdf)
 
 
 def encode_pdfdocencoding(unicode_string: str) -> bytes:

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -53,7 +53,6 @@ from .._utils import (
     b_,
     deprecate_no_replacement,
     deprecate_with_replacement,
-    deprecation_with_replacement,
     logger_warning,
     read_non_whitespace,
     read_until_regex,
@@ -135,12 +134,6 @@ class ArrayObject(List[Any], PdfObject):
             data.write_to_stream(stream)
         stream.write(b" ]")
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
     @staticmethod
     def read_from_stream(
         stream: StreamType,
@@ -165,13 +158,6 @@ class ArrayObject(List[Any], PdfObject):
             # read and append obj
             arr.append(read_object(stream, pdf, forced_encoding))
         return arr
-
-    @staticmethod
-    def readFromStream(
-        stream: StreamType, pdf: PdfReaderProtocol
-    ) -> "ArrayObject":  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return ArrayObject.read_from_stream(stream, pdf)
 
 
 class DictionaryObject(Dict[Any, Any], PdfObject):
@@ -358,27 +344,6 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
             self[NameObject("/Metadata")] = metadata
         return metadata
 
-    def getXmpMetadata(
-        self,
-    ) -> Optional[PdfObject]:  # deprecated
-        """
-        Use :meth:`xmp_metadata` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("getXmpMetadata", "xmp_metadata", "3.0.0")
-        return self.xmp_metadata
-
-    @property
-    def xmpMetadata(self) -> Optional[PdfObject]:  # deprecated
-        """
-        Use :meth:`xmp_metadata` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("xmpMetadata", "xmp_metadata", "3.0.0")
-        return self.xmp_metadata
-
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes] = None
     ) -> None:
@@ -395,12 +360,6 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
             value.write_to_stream(stream)
             stream.write(b"\n")
         stream.write(b">>")
-
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
 
     @staticmethod
     def read_from_stream(
@@ -552,13 +511,6 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
             retval.update(data)
             return retval
 
-    @staticmethod
-    def readFromStream(
-        stream: StreamType, pdf: PdfReaderProtocol
-    ) -> "DictionaryObject":  # deprecated
-        deprecation_with_replacement("readFromStream", "read_from_stream", "3.0.0")
-        return DictionaryObject.read_from_stream(stream, pdf)
-
 
 class TreeObject(DictionaryObject):
     def __init__(self, dct: Optional[DictionaryObject] = None) -> None:
@@ -590,10 +542,6 @@ class TreeObject(DictionaryObject):
             if child_ref is None:
                 return
             child = child_ref.get_object()
-
-    def addChild(self, child: Any, pdf: Any) -> None:  # deprecated
-        deprecation_with_replacement("addChild", "add_child", "3.0.0")
-        self.add_child(child, pdf)
 
     def add_child(self, child: Any, pdf: PdfWriterProtocol) -> None:
         self.insert_child(child, None, pdf)
@@ -676,10 +624,6 @@ class TreeObject(DictionaryObject):
         child_obj[NameObject("/Parent")] = self.indirect_reference
         inc_parent_counter(self, child_obj.get("/Count", 1))
         return child
-
-    def removeChild(self, child: Any) -> None:  # deprecated
-        deprecation_with_replacement("removeChild", "remove_child", "3.0.0")
-        self.remove_child(child)
 
     def _remove_node_from_tree(
         self, prev: Any, prev_ref: Any, cur: Any, last: Any
@@ -842,28 +786,10 @@ class StreamObject(DictionaryObject):
     def set_data(self, data: bytes) -> None:
         self._data = data
 
-    def getData(self) -> Any:  # deprecated
-        deprecation_with_replacement("getData", "get_data", "3.0.0")
-        return self._data
-
-    def setData(self, data: Any) -> None:  # deprecated
-        deprecation_with_replacement("setData", "set_data", "3.0.0")
-        self.set_data(data)
-
     def hash_value_data(self) -> bytes:
         data = super().hash_value_data()
         data += b_(self._data)
         return data
-
-    @property
-    def decodedSelf(self) -> Optional["DecodedStreamObject"]:  # deprecated
-        deprecation_with_replacement("decodedSelf", "decoded_self", "3.0.0")
-        return self.decoded_self
-
-    @decodedSelf.setter
-    def decodedSelf(self, value: "DecodedStreamObject") -> None:  # deprecated
-        deprecation_with_replacement("decodedSelf", "decoded_self", "3.0.0")
-        self.decoded_self = value
 
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes] = None
@@ -899,10 +825,6 @@ class StreamObject(DictionaryObject):
         del data[SA.LENGTH]
         retval.update(data)
         return retval
-
-    def flateEncode(self) -> "EncodedStreamObject":  # deprecated
-        deprecation_with_replacement("flateEncode", "flate_encode", "3.0.0")
-        return self.flate_encode()
 
     def flate_encode(self, level: int = -1) -> "EncodedStreamObject":
         from ..filters import FlateDecode
@@ -944,16 +866,6 @@ class DecodedStreamObject(StreamObject):
 class EncodedStreamObject(StreamObject):
     def __init__(self) -> None:
         self.decoded_self: Optional[DecodedStreamObject] = None
-
-    @property
-    def decodedSelf(self) -> Optional["DecodedStreamObject"]:  # deprecated
-        deprecation_with_replacement("decodedSelf", "decoded_self", "3.0.0")
-        return self.decoded_self
-
-    @decodedSelf.setter
-    def decodedSelf(self, value: DecodedStreamObject) -> None:  # deprecated
-        deprecation_with_replacement("decodedSelf", "decoded_self", "3.0.0")
-        self.decoded_self = value
 
     # This overrides the parent method:
     def get_data(self) -> Union[bytes, str]:
@@ -1355,16 +1267,6 @@ class Field(TreeObject):
         return self.get(FieldDictionaryAttributes.FT)
 
     @property
-    def fieldType(self) -> Optional[NameObject]:  # deprecated
-        """
-        Use :py:attr:`field_type` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("fieldType", "field_type", "3.0.0")
-        return self.field_type
-
-    @property
     def parent(self) -> Optional[DictionaryObject]:
         """Read-only property accessing the parent of this field."""
         return self.get(FieldDictionaryAttributes.Parent)
@@ -1385,16 +1287,6 @@ class Field(TreeObject):
         return self.get(FieldDictionaryAttributes.TU)
 
     @property
-    def altName(self) -> Optional[str]:  # deprecated
-        """
-        Use :py:attr:`alternate_name` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("altName", "alternate_name", "3.0.0")
-        return self.alternate_name
-
-    @property
     def mapping_name(self) -> Optional[str]:
         """
         Read-only property accessing the mapping name of this field.
@@ -1403,16 +1295,6 @@ class Field(TreeObject):
         :meth:`get_fields()<pypdf.PdfReader.get_fields>`
         """
         return self.get(FieldDictionaryAttributes.TM)
-
-    @property
-    def mappingName(self) -> Optional[str]:  # deprecated
-        """
-        Use :py:attr:`mapping_name` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("mappingName", "mapping_name", "3.0.0")
-        return self.mapping_name
 
     @property
     def flags(self) -> Optional[int]:
@@ -1437,16 +1319,6 @@ class Field(TreeObject):
         return self.get(FieldDictionaryAttributes.DV)
 
     @property
-    def defaultValue(self) -> Optional[Any]:  # deprecated
-        """
-        Use :py:attr:`default_value` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("defaultValue", "default_value", "3.0.0")
-        return self.default_value
-
-    @property
     def additional_actions(self) -> Optional[DictionaryObject]:
         """
         Read-only property accessing the additional actions dictionary.
@@ -1455,16 +1327,6 @@ class Field(TreeObject):
         events. See Section 8.5.2 of the PDF 1.7 reference.
         """
         return self.get(FieldDictionaryAttributes.AA)
-
-    @property
-    def additionalActions(self) -> Optional[DictionaryObject]:  # deprecated
-        """
-        Use :py:attr:`additional_actions` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("additionalActions", "additional_actions", "3.0.0")
-        return self.additional_actions
 
 
 class Destination(TreeObject):
@@ -1551,15 +1413,6 @@ class Destination(TreeObject):
                 if x in self
             ]
         )
-
-    def getDestArray(self) -> "ArrayObject":  # deprecated
-        """
-        Use :py:attr:`dest_array` instead.
-
-        .. deprecated:: 1.28.3
-        """
-        deprecation_with_replacement("getDestArray", "dest_array", "3.0.0")
-        return self.dest_array
 
     def write_to_stream(
         self, stream: StreamType, encryption_key: Union[None, str, bytes] = None

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -806,7 +806,7 @@ class StreamObject(DictionaryObject):
         stream.write(b"\nendstream")
 
     @staticmethod
-    def initializeFromDictionary(
+    def initializeFromDictionary(  # TODO: mention when to deprecate
         data: Dict[str, Any]
     ) -> Union["EncodedStreamObject", "DecodedStreamObject"]:  # deprecated
         return StreamObject.initialize_from_dictionary(data)

--- a/pypdf/generic/_outline.py
+++ b/pypdf/generic/_outline.py
@@ -1,6 +1,6 @@
-from typing import Any, Union
+from typing import Union
 
-from .._utils import StreamType, deprecate_no_replacement, deprecation_with_replacement
+from .._utils import StreamType, deprecate_no_replacement
 from ._base import NameObject
 from ._data_structures import Destination
 
@@ -31,9 +31,3 @@ class OutlineItem(Destination):
         value.write_to_stream(stream)
         stream.write(b"\n")
         stream.write(b">>")
-
-
-class Bookmark(OutlineItem):  # deprecated
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        deprecation_with_replacement("Bookmark", "OutlineItem", "3.0.0")
-        super().__init__(*args, **kwargs)

--- a/pypdf/generic/_rectangle.py
+++ b/pypdf/generic/_rectangle.py
@@ -1,6 +1,5 @@
 from typing import Any, Tuple, Union
 
-from .._utils import deprecation_no_replacement, deprecation_with_replacement
 from ._base import FloatObject, NumberObject
 from ._data_structures import ArrayObject
 
@@ -41,12 +40,6 @@ class RectangleObject(ArrayObject):
             )
         )
 
-    def ensureIsNumber(
-        self, value: Any
-    ) -> Union[FloatObject, NumberObject]:  # deprecated
-        deprecation_no_replacement("ensureIsNumber", "3.0.0")
-        return self._ensure_is_number(value)
-
     def __repr__(self) -> str:
         return f"RectangleObject({list(self)!r})"
 
@@ -81,38 +74,6 @@ class RectangleObject(ArrayObject):
     @top.setter
     def top(self, f: float) -> None:
         self[3] = FloatObject(f)
-
-    def getLowerLeft_x(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getLowerLeft_x", "left", "3.0.0")
-        return self.left
-
-    def getLowerLeft_y(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getLowerLeft_y", "bottom", "3.0.0")
-        return self.bottom
-
-    def getUpperRight_x(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getUpperRight_x", "right", "3.0.0")
-        return self.right
-
-    def getUpperRight_y(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getUpperRight_y", "top", "3.0.0")
-        return self.top
-
-    def getUpperLeft_x(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getUpperLeft_x", "left", "3.0.0")
-        return self.left
-
-    def getUpperLeft_y(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getUpperLeft_y", "top", "3.0.0")
-        return self.top
-
-    def getLowerRight_x(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getLowerRight_x", "right", "3.0.0")
-        return self.right
-
-    def getLowerRight_y(self) -> FloatObject:  # deprecated
-        deprecation_with_replacement("getLowerRight_y", "bottom", "3.0.0")
-        return self.bottom
 
     @property
     def lower_left(self) -> Tuple[float, float]:
@@ -162,98 +123,10 @@ class RectangleObject(ArrayObject):
     def upper_right(self, value: Tuple[float, float]) -> None:
         self[2], self[3] = (self._ensure_is_number(x) for x in value)
 
-    def getLowerLeft(
-        self,
-    ) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("getLowerLeft", "lower_left", "3.0.0")
-        return self.lower_left
-
-    def getLowerRight(
-        self,
-    ) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("getLowerRight", "lower_right", "3.0.0")
-        return self.lower_right
-
-    def getUpperLeft(
-        self,
-    ) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("getUpperLeft", "upper_left", "3.0.0")
-        return self.upper_left
-
-    def getUpperRight(
-        self,
-    ) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("getUpperRight", "upper_right", "3.0.0")
-        return self.upper_right
-
-    def setLowerLeft(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("setLowerLeft", "lower_left", "3.0.0")
-        self.lower_left = value
-
-    def setLowerRight(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("setLowerRight", "lower_right", "3.0.0")
-        self[2], self[1] = (self._ensure_is_number(x) for x in value)
-
-    def setUpperLeft(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("setUpperLeft", "upper_left", "3.0.0")
-        self[0], self[3] = (self._ensure_is_number(x) for x in value)
-
-    def setUpperRight(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("setUpperRight", "upper_right", "3.0.0")
-        self[2], self[3] = (self._ensure_is_number(x) for x in value)
-
     @property
     def width(self) -> float:
         return self.right - self.left
 
-    def getWidth(self) -> float:  # deprecated
-        deprecation_with_replacement("getWidth", "width", "3.0.0")
-        return self.width
-
     @property
     def height(self) -> float:
         return self.top - self.bottom
-
-    def getHeight(self) -> float:  # deprecated
-        deprecation_with_replacement("getHeight", "height", "3.0.0")
-        return self.height
-
-    @property
-    def lowerLeft(self) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("lowerLeft", "lower_left", "3.0.0")
-        return self.lower_left
-
-    @lowerLeft.setter
-    def lowerLeft(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("lowerLeft", "lower_left", "3.0.0")
-        self.lower_left = value
-
-    @property
-    def lowerRight(self) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("lowerRight", "lower_right", "3.0.0")
-        return self.lower_right
-
-    @lowerRight.setter
-    def lowerRight(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("lowerRight", "lower_right", "3.0.0")
-        self.lower_right = value
-
-    @property
-    def upperLeft(self) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("upperLeft", "upper_left", "3.0.0")
-        return self.upper_left
-
-    @upperLeft.setter
-    def upperLeft(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("upperLeft", "upper_left", "3.0.0")
-        self.upper_left = value
-
-    @property
-    def upperRight(self) -> Tuple[float, float]:  # deprecated
-        deprecation_with_replacement("upperRight", "upper_right", "3.0.0")
-        return self.upper_right
-
-    @upperRight.setter
-    def upperRight(self, value: Tuple[float, float]) -> None:  # deprecated
-        deprecation_with_replacement("upperRight", "upper_right", "3.0.0")
-        self.upper_right = value

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -16,7 +16,6 @@ from typing import (
     Optional,
     TypeVar,
     Union,
-    cast,
 )
 from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement
@@ -26,7 +25,6 @@ from ._utils import (
     StreamType,
     deprecate_no_replacement,
     deprecate_with_replacement,
-    deprecation_with_replacement,
 )
 from .errors import PdfReadError
 from .generic import ContentStream, PdfObject
@@ -241,17 +239,6 @@ class XmpInformation(PdfObject):
             )
         self.stream.write_to_stream(stream)
 
-    def writeToStream(
-        self, stream: StreamType, encryption_key: Union[None, str, bytes]
-    ) -> None:  # deprecated
-        """
-        Use :meth:`write_to_stream` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("writeToStream", "write_to_stream", "3.0.0")
-        self.write_to_stream(stream)
-
     def get_element(self, about_uri: str, namespace: str, name: str) -> Iterator[Any]:
         for desc in self.rdf_root.getElementsByTagNameNS(RDF_NAMESPACE, "Description"):
             if desc.getAttributeNS(RDF_NAMESPACE, "about") == about_uri:
@@ -259,17 +246,6 @@ class XmpInformation(PdfObject):
                 if attr is not None:
                     yield attr
                 yield from desc.getElementsByTagNameNS(namespace, name)
-
-    def getElement(
-        self, aboutUri: str, namespace: str, name: str
-    ) -> Iterator[Any]:  # deprecated
-        """
-        Use :meth:`get_element` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement("getElement", "get_element", "3.0.0")
-        return self.get_element(aboutUri, namespace, name)
 
     def get_nodes_in_namespace(self, about_uri: str, namespace: str) -> Iterator[Any]:
         for desc in self.rdf_root.getElementsByTagNameNS(RDF_NAMESPACE, "Description"):
@@ -281,19 +257,6 @@ class XmpInformation(PdfObject):
                 for child in desc.childNodes:
                     if child.namespaceURI == namespace:
                         yield child
-
-    def getNodesInNamespace(
-        self, aboutUri: str, namespace: str
-    ) -> Iterator[Any]:  # deprecated
-        """
-        Use :meth:`get_nodes_in_namespace` instead.
-
-        .. deprecated:: 1.28.0
-        """
-        deprecation_with_replacement(
-            "getNodesInNamespace", "get_nodes_in_namespace", "3.0.0"
-        )
-        return self.get_nodes_in_namespace(aboutUri, namespace)
 
     def _get_text(self, element: XmlElement) -> str:
         text = ""
@@ -430,42 +393,12 @@ class XmpInformation(PdfObject):
     xmp_creator_tool = property(_getter_single(XMP_NAMESPACE, "CreatorTool"))
     """The name of the first known tool used to create the resource."""
 
-    @property
-    def xmp_creatorTool(self) -> str:  # deprecated
-        deprecation_with_replacement("xmp_creatorTool", "xmp_creator_tool", "3.0.0")
-        return self.xmp_creator_tool
-
-    @xmp_creatorTool.setter
-    def xmp_creatorTool(self, value: str) -> None:  # deprecated
-        deprecation_with_replacement("xmp_creatorTool", "xmp_creator_tool", "3.0.0")
-        self.xmp_creator_tool = value
-
     xmpmm_document_id = property(_getter_single(XMPMM_NAMESPACE, "DocumentID"))
     """The common identifier for all versions and renditions of this resource."""
-
-    @property
-    def xmpmm_documentId(self) -> str:  # deprecated
-        deprecation_with_replacement("xmpmm_documentId", "xmpmm_document_id", "3.0.0")
-        return self.xmpmm_document_id
-
-    @xmpmm_documentId.setter
-    def xmpmm_documentId(self, value: str) -> None:  # deprecated
-        deprecation_with_replacement("xmpmm_documentId", "xmpmm_document_id", "3.0.0")
-        self.xmpmm_document_id = value
 
     xmpmm_instance_id = property(_getter_single(XMPMM_NAMESPACE, "InstanceID"))
     """An identifier for a specific incarnation of a document, updated each
     time a file is saved."""
-
-    @property
-    def xmpmm_instanceId(self) -> str:  # deprecated
-        deprecation_with_replacement("xmpmm_instanceId", "xmpmm_instance_id", "3.0.0")
-        return cast(str, self.xmpmm_instance_id)
-
-    @xmpmm_instanceId.setter
-    def xmpmm_instanceId(self, value: str) -> None:  # deprecated
-        deprecation_with_replacement("xmpmm_instanceId", "xmpmm_instance_id", "3.0.0")
-        self.xmpmm_instance_id = value
 
     @property
     def custom_properties(self) -> Dict[Any, Any]:

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -96,7 +96,7 @@ def merge():
     writer.add_metadata({"author": "Martin Thoma"})
     writer.add_named_destination("title", 0)
     writer.set_page_layout("/SinglePage")
-    writer.set_page_mode("/UseThumbs")
+    writer.page_mode = "/UseThumbs"
 
     write_path = "dont_commit_merged.pdf"
     writer.write(write_path)

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -7,7 +7,6 @@ import pytest
 
 import pypdf
 from pypdf import PdfMerger, PdfReader, PdfWriter
-from pypdf.errors import DeprecationError
 from pypdf.generic import Destination, Fit
 
 from . import get_data_from_url
@@ -599,48 +598,6 @@ def test_iss1145_with_writer():
     merger = PdfWriter()
     merger.append(PdfReader(BytesIO(get_data_from_url(url, name=name))))
     merger.close()
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_deprecation_bookmark_decorator_deprecationexcp():
-    reader = PdfReader(RESOURCE_ROOT / "outlines-with-invalid-destinations.pdf")
-    merger = PdfMerger()
-    with pytest.raises(
-        DeprecationError,
-        match=(
-            "import_bookmarks is deprecated as an argument. "
-            "Use import_outline instead"
-        ),
-    ):
-        merger.merge(0, reader, import_bookmarks=True)
-
-
-def test_deprecation_bookmark_decorator_deprecationexcp_with_writer():
-    reader = PdfReader(RESOURCE_ROOT / "outlines-with-invalid-destinations.pdf")
-    merger = PdfWriter()
-    with pytest.raises(
-        DeprecationError,
-        match=(
-            "import_bookmarks is deprecated as an argument. "
-            "Use import_outline instead"
-        ),
-    ):
-        merger.merge(0, reader, import_bookmarks=True)
-
-
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_deprecation_bookmark_decorator_output():
-    reader = PdfReader(RESOURCE_ROOT / "outlines-with-invalid-destinations.pdf")
-    merger = PdfMerger()
-    with pytest.raises(DeprecationError):
-        merger.merge(0, reader, import_bookmarks=True)
-
-
-def test_deprecation_bookmark_decorator_output_with_writer():
-    reader = PdfReader(RESOURCE_ROOT / "outlines-with-invalid-destinations.pdf")
-    merger = PdfWriter()
-    with pytest.raises(DeprecationError):
-        merger.merge(0, reader, import_bookmarks=True)
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -130,7 +130,7 @@ def merger_operate(merger):
     merger.add_metadata({"/Author": "Martin Thoma"})
     merger.add_named_destination("/Title", 0)
     merger.set_page_layout("/SinglePage")
-    merger.set_page_mode("/UseThumbs")
+    merger.page_mode = "/UseThumbs"
 
 
 def check_outline(tmp_path):
@@ -288,7 +288,7 @@ def test_merge_write_closed_fh():
     assert exc.value.args[0] == err_closed
 
     with pytest.raises(RuntimeError) as exc:
-        merger.set_page_mode("/UseNone")
+        merger.page_mode = "/UseNone"
     assert exc.value.args[0] == err_closed
 
     with pytest.raises(RuntimeError) as exc:
@@ -313,7 +313,7 @@ def test_merge_write_closed_fh_with_writer(pdf_file_path):
     merger.write(pdf_file_path)
     merger.add_metadata({"author": "Martin Thoma"})
     merger.set_page_layout("/SinglePage")
-    merger.set_page_mode("/UseNone")
+    merger.page_mode = "/UseNone"
     merger.add_outline_item("An outline item", 0)
 
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -12,7 +12,7 @@ import pytest
 from pypdf import PdfReader, PdfWriter, Transformation
 from pypdf._page import PageObject
 from pypdf.constants import PageAttributes as PG
-from pypdf.errors import DeprecationError, PdfReadError, PdfReadWarning
+from pypdf.errors import PdfReadError, PdfReadWarning
 from pypdf.generic import (
     ArrayObject,
     ContentStream,
@@ -173,8 +173,7 @@ def test_transformation_equivalence():
     # Option 2: The old way
     page_box2 = deepcopy(page_box)
     page_base2 = deepcopy(page_base)
-    with pytest.raises(DeprecationError):
-        page_base2.mergeTransformedPage(page_box2, op, expand=False)
+    page_base2.merge_transformed_page(page_box2, op, expand=False)
     page_box2.add_transformation(op)
     page_base2.merge_page(page_box2)
 
@@ -260,22 +259,23 @@ def test_page_transformations():
     reader = PdfReader(pdf_path)
 
     page: PageObject = reader.pages[0]
-    with pytest.raises(DeprecationError):
-        page.mergeRotatedPage(page, 90, expand=True)
-    with pytest.raises(DeprecationError):
-        page.mergeRotatedScaledPage(page, 90, 1, expand=True)
-    with pytest.raises(DeprecationError):
-        page.mergeRotatedScaledTranslatedPage(
-            page, 90, scale=1, tx=1, ty=1, expand=True
-        )
-    with pytest.raises(DeprecationError):
-        page.mergeRotatedTranslatedPage(page, 90, 100, 100, expand=False)
-    with pytest.raises(DeprecationError):
-        page.mergeScaledPage(page, 2, expand=False)
-    with pytest.raises(DeprecationError):
-        page.mergeScaledTranslatedPage(page, 1, 1, 1)
-    with pytest.raises(DeprecationError):
-        page.mergeTranslatedPage(page, 100, 100, expand=False)
+    page.merge_rotated_page(page, 90, expand=True)
+
+    op = Transformation().rotate(90).scale(1, 1)
+    page.merge_transformed_page(page, op, expand=True)
+
+    op = Transformation().rotate(90).scale(1, 1).translate(1, 1)
+    page.merge_transformed_page(page, op, expand=True)
+
+    op = Transformation().translate(-100, -100).rotate(90).translate(100, 100)
+    page.merge_transformed_page(page, op, expand=False)
+
+    page.merge_scaled_page(page, 2, expand=False)
+
+    op = Transformation().scale(1, 1).translate(1, 1)
+    page.merge_transformed_page(page, op)
+
+    page.merge_translated_page(page, 100, 100, expand=False)
     page.add_transformation((1, 0, 0, 0, 0, 0))
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -8,11 +8,10 @@ import pytest
 
 from pypdf import PdfReader
 from pypdf._crypt_providers import crypt_provider
-from pypdf._reader import convert_to_int, convertToInt
+from pypdf._reader import convert_to_int
 from pypdf.constants import ImageAttributes as IA
 from pypdf.constants import PageAttributes as PG
 from pypdf.errors import (
-    DeprecationError,
     EmptyFileError,
     FileNotDecryptedError,
     PdfReadError,
@@ -758,18 +757,6 @@ def test_convert_to_int_error():
     with pytest.raises(PdfReadError) as exc:
         convert_to_int(b"256", 16)
     assert exc.value.args[0] == "invalid size in convert_to_int"
-
-
-def test_converttoint_deprecated():
-    msg = (
-        "convertToInt is deprecated and was removed in pypdf 3.0.0. "
-        "Use convert_to_int instead."
-    )
-    with pytest.raises(
-        DeprecationError,
-        match=msg,
-    ):
-        assert convertToInt(b"\x01", 8) == 1
 
 
 @pytest.mark.enable_socket()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,7 +127,7 @@ def test_b(input_str: str, expected: str):
 
 def test_deprecate_no_replacement():
     with pytest.warns(DeprecationWarning) as warn:
-        pypdf._utils.deprecate_no_replacement("foo")
+        pypdf._utils.deprecate_no_replacement("foo", removed_in="3.0.0")
     error_msg = "foo is deprecated and will be removed in pypdf 3.0.0."
     assert warn[0].message.args[0] == error_msg
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,6 @@ from pypdf._utils import (
     _human_readable_bytes,
     check_if_whitespace_only,
     deprecate_with_replacement,
-    deprecation_bookmark,
     deprecation_no_replacement,
     mark_location,
     matrix_multiply,
@@ -243,17 +242,6 @@ def test_read_block_backwards_exception():
     with pytest.raises(PdfReadError) as exc:
         read_block_backwards(stream, 7)
     assert exc.value.args[0] == "Could not read malformed PDF file"
-
-
-def test_deprecation_bookmark():
-    @deprecation_bookmark(old_param="new_param")
-    def foo(old_param: int = 1, baz: int = 2) -> None:
-        pass
-
-    with pytest.raises(DeprecationError) as exc:
-        foo(old_param=12, new_param=13)
-    expected_msg = "old_param is deprecated as an argument. Use new_param instead"
-    assert exc.value.args[0] == expected_msg
 
 
 def test_deprecate_with_replacement():

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -268,20 +268,14 @@ def test_extract_textbench(enable, url, pages, print_result=False):
 @pytest.mark.slow()
 def test_orientations():
     p = PdfReader(RESOURCE_ROOT / "test Orient.pdf").pages[0]
-    with pytest.warns(DeprecationWarning):
-        p.extract_text("", "")
-    with pytest.warns(DeprecationWarning):
-        p.extract_text("", "", 0)
-    with pytest.warns(DeprecationWarning):
-        p.extract_text("", "", 0, 200)
-
-    with pytest.warns(DeprecationWarning):
-        p.extract_text(Tj_sep="", TJ_sep="")
+    p.extract_text("", "")
+    p.extract_text("", "", 0)
+    p.extract_text("", "", 0, 200)
+    p.extract_text()
     assert findall("\\((.)\\)", p.extract_text()) == ["T", "B", "L", "R"]
     with pytest.raises(Exception):
         p.extract_text(None)
-    with pytest.raises(Exception):
-        p.extract_text("", 0)
+    p.extract_text("", 0)
     with pytest.raises(Exception):
         p.extract_text("", "", None)
     with pytest.raises(Exception):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -179,12 +179,7 @@ def writer_operate(writer: PdfWriter) -> None:
     )
     writer.add_blank_page()
     writer.add_uri(2, "https://example.com", RectangleObject([0, 0, 100, 100]))
-    with pytest.warns(
-        DeprecationWarning, match="'pagenum' argument of add_uri is deprecated"
-    ):
-        writer.add_uri(
-            2, "https://example.com", RectangleObject([0, 0, 100, 100]), pagenum=2
-        )
+    writer.add_uri(2, "https://example.com", RectangleObject([0, 0, 100, 100]))
     with pytest.raises(DeprecationError):
         writer.add_link(2, 1, RectangleObject([0, 0, 100, 100]))
     assert writer._get_page_layout() is None
@@ -522,20 +517,11 @@ def test_encrypt(use_128bit, user_password, owner_password, pdf_file_path):
 
     writer.add_page(page)
 
-    with pytest.raises(ValueError, match="owner_pwd of encrypt is deprecated."):
-        writer.encrypt(
-            owner_pwd=user_password,
-            owner_password=owner_password,
-            user_password=user_password,
-            use_128bit=use_128bit,
-        )
-    with pytest.raises(ValueError, match="'user_pwd' argument is deprecated"):
-        writer.encrypt(
-            owner_password=owner_password,
-            user_password=user_password,
-            user_pwd=user_password,
-            use_128bit=use_128bit,
-        )
+    writer.encrypt(
+        owner_password=owner_password,
+        user_password=user_password,
+        use_128bit=use_128bit,
+    )
     writer.encrypt(
         user_password=user_password,
         owner_password=owner_password,
@@ -641,14 +627,8 @@ def test_add_named_destination(pdf_file_path):
 
     writer.add_named_destination(TextStringObject("A named dest"), 2)
     writer.add_named_destination(TextStringObject("A named dest2"), 2)
-
-    with pytest.warns(DeprecationWarning, match="pagenum is deprecated as an argument"):
-        writer.add_named_destination(TextStringObject("A named dest3"), pagenum=2)
-
-    with pytest.raises(ValueError):
-        writer.add_named_destination(
-            TextStringObject("A named dest3"), pagenum=2, page_number=2
-        )
+    writer.add_named_destination(TextStringObject("A named dest3"), page_number=2)
+    writer.add_named_destination(TextStringObject("A named dest3"), page_number=2)
 
     root = writer.get_named_dest_root()
     assert root[0] == "A named dest"
@@ -1872,8 +1852,7 @@ def test_remove_image_per_type():
         for x in (b"BI", b"ID", b"EI")
     )
 
-    with pytest.raises(DeprecationWarning):
-        writer.remove_images(True)
+    writer.remove_images()
 
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "GeoBase_NHNC1_Data_Model_UML_EN.pdf")
     writer.remove_images(ImageType.DRAWING_IMAGES)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -18,7 +18,7 @@ from pypdf import (
     Transformation,
 )
 from pypdf.annotations import Link
-from pypdf.errors import DeprecationError, PageSizeNotDefinedError, PyPdfError
+from pypdf.errors import PageSizeNotDefinedError, PyPdfError
 from pypdf.generic import (
     ArrayObject,
     ContentStream,
@@ -945,19 +945,6 @@ def test_add_single_annotation(pdf_file_path):
     # Inspect manually by adding 'assert False' and viewing the PDF
     with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
-
-
-def test_deprecation_bookmark_decorator():
-    reader = PdfReader(RESOURCE_ROOT / "outlines-with-invalid-destinations.pdf")
-    page = reader.pages[0]
-    outline_item = reader.outline[0]
-    writer = PdfWriter()
-    writer.add_page(page)
-    with pytest.raises(
-        DeprecationError,
-        match="bookmark is deprecated as an argument. Use outline_item instead",
-    ):
-        writer.add_outline_item_dict(bookmark=outline_item)
 
 
 @pytest.mark.samples()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -191,9 +191,9 @@ def writer_operate(writer: PdfWriter) -> None:
     writer.page_layout = NameObject("/SinglePage")
     assert writer._get_page_layout() == "/SinglePage"
     assert writer._get_page_mode() is None
-    writer.set_page_mode("/UseNone")
+    writer.page_mode = "/UseNone"
     assert writer._get_page_mode() == "/UseNone"
-    writer.set_page_mode(NameObject("/UseOC"))
+    writer.page_mode = NameObject("/UseOC")
     assert writer._get_page_mode() == "/UseOC"
     writer.insert_blank_page(width=100, height=100)
     writer.insert_blank_page()  # without parameters


### PR DESCRIPTION
Also don't use a default for the deprecation functions. If the version is mentioned explicitly with every call, we can more easily search for it.

* Bookmarks: `Consistent terminology for outline items` (#1156, pypdf==2.9.0) introduced it. Meaning in pypdf==4.0.0 we can remove them :tada: 