### PR TITLE
handling name without leading /

### DIFF
--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -588,10 +588,13 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
         stream.write(self.renumber())
 
     def renumber(self) -> bytes:
-        out = self[0].encode("utf-8")
-        if out != b"/":
+        out = self.surfix
+        val = self[:]
+        if val[0].encode("utf-8") != self.surfix:
             logger_warning(f"Incorrect first char in NameObject:({self})", __name__)
-        for c in self[1:]:
+        else:
+            val = val[1:]
+        for c in val:
             if c > "~":
                 for x in c.encode("utf-8"):
                     out += f"#{x:02X}".encode()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -219,7 +219,7 @@ def test_name_object(caplog):
     caplog.clear()
     b = BytesIO()
     NameObject("hello").write_to_stream(b)
-    assert bytes(b.getbuffer()) == b"hello"
+    assert bytes(b.getbuffer()) == b"/hello"
     assert "Incorrect first char" in caplog.text
 
     caplog.clear()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -229,9 +229,13 @@ def test_name_object(caplog):
     assert caplog.text == ""
 
     b = BytesIO()
+    NameObject("#42").write_to_stream(b)
+    assert bytes(b.getbuffer()) == b"/#2342"
+
+    b = BytesIO()
     NameObject("/你好世界 (%)").write_to_stream(b)
-    assert bytes(b.getbuffer()) == b"/#E4#BD#A0#E5#A5#BD#E4#B8#96#E7#95#8C#20#28#25#29"
-    assert caplog.text == ""
+    assert bytes(b.getbuffer()) == b"/#E4#BD#A0#E5#A5#BD#E4#B8#96#E7#95#8C#20(%)"
+    assert "UnicodeEncodeError" in caplog.text
 
 
 def test_destination_fit_r():


### PR DESCRIPTION
Leading slash is not part of the Name value, but only required in binary representation, so it should not be needed for Name object creation.

From spec:
```
When writing a name in a PDF file, a SOLIDUS (2Fh) (/) shall be used to introduce a name. The SOLIDUS is not part of the name but is a prefix indicating that what follows is a sequence of characters representing the name in the PDF file and shall follow these rules:
```