### PR TITLE
DEV: Write to temporary files instead of the working directory

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -6,6 +6,7 @@ Please keep in mind that the variance is high.
 """
 from io import BytesIO
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -98,27 +99,28 @@ def merge():
     writer.set_page_layout("/SinglePage")
     writer.page_mode = "/UseThumbs"
 
-    write_path = "dont_commit_merged.pdf"
-    writer.write(write_path)
-    writer.close()
+    with NamedTemporaryFile(suffix=".pdf") as target_file:
+        write_path = target_file.name
+        writer.write(write_path)
+        writer.close()
 
-    # Check if outline is correct
-    reader = PdfReader(write_path)
-    assert [
-        el.title for el in reader._get_outline() if isinstance(el, Destination)
-    ] == [
-        "Foo",
-        "Bar",
-        "Baz",
-        "Foo",
-        "Bar",
-        "Baz",
-        "Foo",
-        "Bar",
-        "Baz",
-        "True",
-        "An outline item",
-    ]
+        # Check if outline is correct
+        reader = PdfReader(write_path)
+        assert [
+            el.title for el in reader._get_outline() if isinstance(el, Destination)
+        ] == [
+            "Foo",
+            "Bar",
+            "Baz",
+            "Foo",
+            "Bar",
+            "Baz",
+            "Foo",
+            "Bar",
+            "Baz",
+            "True",
+            "An outline item",
+        ]
 
 
 def test_merge(benchmark):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -215,14 +215,19 @@ def writer_operate(writer: PdfWriter) -> None:
 
 
 @pytest.mark.parametrize(
-    ("write_data_here", "needs_cleanup"),
+    ("convert", "needs_cleanup"),
     [
-        (NamedTemporaryFile(suffix=".pdf", delete=False).name, True),
-        (Path(NamedTemporaryFile(suffix=".pdf", delete=False).name), True),
+        (str, True),
+        (Path, True),
         (BytesIO(), False),
     ],
 )
-def test_writer_operations_by_traditional_usage(write_data_here, needs_cleanup):
+def test_writer_operations_by_traditional_usage(convert, needs_cleanup):
+    if callable(convert):
+        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
+    else:
+        write_data_here = convert
+
     writer = PdfWriter()
 
     writer_operate(writer)
@@ -240,14 +245,19 @@ def test_writer_operations_by_traditional_usage(write_data_here, needs_cleanup):
 
 
 @pytest.mark.parametrize(
-    ("write_data_here", "needs_cleanup"),
+    ("convert", "needs_cleanup"),
     [
-        (NamedTemporaryFile(suffix=".pdf", delete=False).name, True),
-        (Path(NamedTemporaryFile(suffix=".pdf", delete=False).name), True),
+        (str, True),
+        (Path, True),
         (BytesIO(), False),
     ],
 )
-def test_writer_operations_by_semi_traditional_usage(write_data_here, needs_cleanup):
+def test_writer_operations_by_semi_traditional_usage(convert, needs_cleanup):
+    if callable(convert):
+        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
+    else:
+        write_data_here = convert
+
     with PdfWriter() as writer:
         writer_operate(writer)
 
@@ -264,16 +274,21 @@ def test_writer_operations_by_semi_traditional_usage(write_data_here, needs_clea
 
 
 @pytest.mark.parametrize(
-    ("write_data_here", "needs_cleanup"),
+    ("convert", "needs_cleanup"),
     [
-        (NamedTemporaryFile(suffix=".pdf", delete=False).name, True),
-        (Path(NamedTemporaryFile(suffix=".pdf", delete=False).name), True),
+        (str, True),
+        (Path, True),
         (BytesIO(), False),
     ],
 )
 def test_writer_operations_by_semi_new_traditional_usage(
-    write_data_here, needs_cleanup
+    convert, needs_cleanup
 ):
+    if callable(convert):
+        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
+    else:
+        write_data_here = convert
+
     with PdfWriter() as writer:
         writer_operate(writer)
 
@@ -285,14 +300,19 @@ def test_writer_operations_by_semi_new_traditional_usage(
 
 
 @pytest.mark.parametrize(
-    ("write_data_here", "needs_cleanup"),
+    ("convert", "needs_cleanup"),
     [
-        (NamedTemporaryFile(suffix=".pdf", delete=False).name, True),
-        (Path(NamedTemporaryFile(suffix=".pdf", delete=False).name), True),
+        (str, True),
+        (Path, True),
         (BytesIO(), False),
     ],
 )
-def test_writer_operation_by_new_usage(write_data_here, needs_cleanup):
+def test_writer_operation_by_new_usage(convert, needs_cleanup):
+    if callable(convert):
+        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
+    else:
+        write_data_here = convert
+
     # This includes write "output" to pypdf-output.pdf
     with PdfWriter(write_data_here) as writer:
         writer_operate(writer)


### PR DESCRIPTION
The tests tended to be unstable due to parallel access to the same file inside the working directory. This PR attempts to fix this by using temporary files instead.