### PR TITLE
DOC: Resolve build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,10 +14,10 @@ import os
 import shutil
 import sys
 
-import pypdf as py_pkg
-
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../"))
+
+import pypdf as py_pkg
 
 shutil.copyfile("../CHANGELOG.md", "meta/CHANGELOG.md")
 shutil.copyfile("../CONTRIBUTORS.md", "meta/CONTRIBUTORS.md")
@@ -57,8 +57,10 @@ extensions = [
     "myst_parser",
 ]
 
+python_version = ".".join(map(str, sys.version_info[:2]))
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": (f"https://docs.python.org/{python_version}", None),
+    "Pillow": ("https://pillow.readthedocs.io/en/latest/", None),
 }
 
 nitpick_ignore_regex = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import sys
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../"))
 
-import pypdf as py_pkg
+import pypdf as py_pkg  # noqa: E402
 
 shutil.copyfile("../CHANGELOG.md", "meta/CHANGELOG.md")
 shutil.copyfile("../CONTRIBUTORS.md", "meta/CONTRIBUTORS.md")

--- a/docs/dev/pypdf-parsing.md
+++ b/docs/dev/pypdf-parsing.md
@@ -20,9 +20,7 @@ structure of parsing:
    decodes these content streams by applying filters (e.g., `FlateDecode`,
    `LZWDecode`) specified in the stream's dictionary. This is only done when the
    object is requested via {py:meth}`PdfReader.get_object
-   <pypdf.PdfReader.get_object>` in the
-   {py:meth}`PdfReader._get_object_from_stream
-   <pypdf.PdfReader._get_object_from_stream>` method.
+   <pypdf.PdfReader.get_object>` in the `PdfReader._get_object_from_stream` method.
 
 ## References
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,9 @@ You can contribute to `pypdf on GitHub <https://github.com/py-pdf/pypdf>`_.
    modules/annotations
    modules/Fit
    modules/PaperSize
+   modules/constants
+   modules/errors
+   modules/generic
 
 .. toctree::
    :caption: Developer Guide

--- a/docs/modules/PageObject.rst
+++ b/docs/modules/PageObject.rst
@@ -5,3 +5,15 @@ The PageObject Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autoclass:: pypdf._utils.ImageFile
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :exclude-members: IndirectObject
+
+.. autoclass:: pypdf._utils.File
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :exclude-members: IndirectObject

--- a/docs/modules/PdfReader.rst
+++ b/docs/modules/PdfReader.rst
@@ -5,3 +5,8 @@ The PdfReader Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autoclass:: pypdf.PasswordType
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules/PdfWriter.rst
+++ b/docs/modules/PdfWriter.rst
@@ -5,3 +5,8 @@ The PdfWriter Class
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autoclass:: pypdf.ObjectDeletionFlag
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules/constants.rst
+++ b/docs/modules/constants.rst
@@ -1,0 +1,17 @@
+Constants
+---------
+
+.. autoclass:: pypdf.constants.AnnotationFlag
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pypdf.constants.ImageType
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: pypdf.constants.PageLabelStyle
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules/errors.rst
+++ b/docs/modules/errors.rst
@@ -1,0 +1,7 @@
+Errors
+------
+
+.. automodule:: pypdf.errors
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/modules/generic.rst
+++ b/docs/modules/generic.rst
@@ -1,0 +1,25 @@
+Generic PDF objects
+-------------------
+
+.. automodule:: pypdf.generic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :exclude-members: Destination, Field, Fit, RectangleObject
+
+.. autoclass:: pypdf._protocols.PdfObjectProtocol
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: pypdf._protocols.PdfReaderProtocol
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+.. autoclass:: pypdf._protocols.PdfWriterProtocol
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -303,8 +303,8 @@ class PageObject(DictionaryObject):
     """
     PageObject represents a single page within a PDF file.
 
-    Typically this object will be created by accessing the
-    :meth:`get_page()<pypdf.PdfReader.get_page>` method of the
+    Typically these objects will be created by accessing the
+    :attr:`pages<pypdf.PdfReader.pages>` property of the
     :class:`PdfReader<pypdf.PdfReader>` class, but it is
     also possible to create an empty page with the
     :meth:`create_blank_page()<pypdf._page.PageObject.create_blank_page>` static method.

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -298,6 +298,7 @@ class PdfReader:
     ) -> None:
         self.strict = strict
         self.flattened_pages: Optional[List[PageObject]] = None
+        #: Storage of parsed PDF objects.
         self.resolved_objects: Dict[Tuple[Any, Any], Optional[PdfObject]] = {}
         self.xref_index = 0
         self._page_id2num: Optional[
@@ -962,7 +963,7 @@ class PdfReader:
 
     @property
     def pages(self) -> List[PageObject]:
-        """Read-only property that emulates a list of :py:class:`Page<pypdf._page.Page>` objects."""
+        """Read-only property that emulates a list of :py:class:`PageObject<pypdf._page.PageObject>` objects."""
         return _VirtualList(self._get_num_pages, self._get_page)  # type: ignore
 
     @property

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -537,7 +537,7 @@ class ImageFile(File):
         Replace the Image with a new PIL image.
 
         Args:
-            new_image (Image.Image): The new PIL image to replace the existing image.
+            new_image (PIL.Image.Image): The new PIL image to replace the existing image.
             **kwargs: Additional keyword arguments to pass to `Image.Image.save()`.
 
         Raises:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1049,7 +1049,7 @@ class PdfWriter:
         When a file is first written, both identifiers shall be set to the same value.
         If both identifiers match when a file reference is resolved, it is very
         likely that the correct and unchanged file has been found. If only the first
-         identifier matches, a different version of the correct file has been found.
+        identifier matches, a different version of the correct file has been found.
         see 14.4 "File Identifiers".
         """
         if self._ID:
@@ -2792,14 +2792,16 @@ class PdfWriter:
         Args:
             page_index_from: page index of the beginning of the range starting from 0
             page_index_to: page index of the beginning of the range starting from 0
-            style:  The numbering style to be used for the numeric portion of each page label:
-                        '/D' Decimal arabic numerals
-                        '/R' Uppercase roman numerals
-                        '/r' Lowercase roman numerals
-                        '/A' Uppercase letters (A to Z for the first 26 pages,
-                             AA to ZZ for the next 26, and so on)
-                        '/a' Lowercase letters (a to z for the first 26 pages,
-                             aa to zz for the next 26, and so on)
+            style: The numbering style to be used for the numeric portion of each page label:
+
+                       * ``/D`` Decimal arabic numerals
+                       * ``/R`` Uppercase roman numerals
+                       * ``/r`` Lowercase roman numerals
+                       * ``/A`` Uppercase letters (A to Z for the first 26 pages,
+                         AA to ZZ for the next 26, and so on)
+                       * ``/a`` Lowercase letters (a to z for the first 26 pages,
+                         aa to zz for the next 26, and so on)
+
             prefix: The label prefix for page labels in this range.
             start:  The value of the numeric portion for the first page label
                     in the range.

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -73,22 +73,21 @@ class PdfObject(PdfObjectProtocol):
         ignore_fields: Optional[Sequence[Union[str, int]]] = (),
     ) -> "PdfObject":
         """
-        clone object into pdf_dest (PdfWriterProtocol which is an interface for PdfWriter)
-        force_duplicate: in standard if the object has been already cloned and reference,
-            the copy is returned; when force_duplicate == True,
-            a new copy is always performed
-        ignore_fields : list/tuple of Fields names (for dictionaries that will
-            be ignored during cloning (apply also to childs duplication)
-            if fields are to be considered for a limited number of levels
-            you have to add it as integer:
-            eg  [1,"/B","/TOTO"] means "/B" will be ignored at first level only
-            but "/TOTO" on all levels
-        in standard, clone function call _reference_clone (see _reference)
+        Clone object into pdf_dest (PdfWriterProtocol which is an interface for PdfWriter).
+
+        By default, this method will call ``_reference_clone`` (see ``_reference``).
+
 
         Args:
-          pdf_dest:
-          force_duplicate:  (Default value = False)
-          ignore_fields:
+          pdf_dest: Target to clone to.
+          force_duplicate: By default, if the object has already been cloned and referenced,
+            the copy will be returned; when ``True``, a new copy will be created.
+            (Default value = ``False``)
+          ignore_fields: List/tuple of field names (for dictionaries) that will be ignored
+            during cloning (applies to children duplication as well). If fields are to be
+            considered for a limited number of levels, you have to add it as integer, for
+            example ``[1,"/B","/TOTO"]`` means that ``"/B"`` will be ignored at the first
+            level only but ``"/TOTO"`` on all levels.
 
         Returns:
           The cloned PdfObject


### PR DESCRIPTION
This fixes #1941 by cleaning up wrong references and adding new docs. Some notes about this:

* Building the docs now works without prior package installation.
* The intersphinx mapping will now always use the objects of the Python version used for the docs build.
* The intersphinx mapping for *Pillow* has been added.
* Links to private methods in the developer docs have been replaced by inline code as they are not part of the Sphinx docs.
* Some broken/outdated/strange docstrings have been fixed.
* New classes have been added to the docs. Module-specific classes have been added to the modules where they are being used directly, some generic classes/modules have been put into new files/pages.
* We have to exclude some members to avoid duplicate definitions.

Current output:

```
(venv) stefan@localhost:~/temp/pypdf> rm -rf build/ && LANG=C sphinx-build -n -T -b html docs build/sphinx/html
Running Sphinx v7.2.6
making output directory... done
loading intersphinx inventory from https://docs.python.org/3.9/objects.inv...
loading intersphinx inventory from https://pillow.readthedocs.io/en/latest/objects.inv...
[autosummary] generating autosummary for: dev/cmaps.md, dev/deprecations.md, dev/documentation.md, dev/intro.md, dev/pdf-format.md, dev/pypdf-parsing.md, dev/pypdf-writing.md, dev/releasing.md, dev/testing.md, index.rst, ..., user/metadata.md, user/migration-1-to-2.md, user/pdf-version-support.md, user/pdfa-compliance.md, user/post-processing-in-text-extraction.md, user/reading-pdf-annotations.md, user/robustness.md, user/streaming-data.md, user/suppress-warnings.md, user/viewer-preferences.md
myst v2.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=True, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 57 source files that are out of date
updating environment: [new config] 57 added, 0 changed, 0 removed
reading sources... [100%] user/viewer-preferences
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] user/viewer-preferences
/home/stefan/temp/pypdf/pypdf/xmp.py:docstring of pypdf.xmp.XmpInformation.rdfRoot:1: WARNING: py:class reference target not found: xml.dom.minidom.Element
generating indices... genindex py-modindex done
highlighting module code... [100%] pypdf.xmp
writing additional pages... search done
copying images... [100%] user/nup-dest2.png
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in build/sphinx/html.
```

The remaining issue is about https://github.com/py-pdf/pypdf/blob/a91e9f658f57cd2a5c7e90bf74a1bd9845755e83/pypdf/xmp.py#L228-L231 scheduled for removal in version 4.0.0 where I could not find a clean/nice solution for now.