### PR TITLE
DOC: Fix testing prerequisites

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -3,7 +3,7 @@
 pypdf uses [`pytest`](https://docs.pytest.org/en/7.1.x/) for testing.
 
 To run the tests you need to install the CI (Continuous Integration) requirements by running `pip install -r requirements/ci.txt` or
-`pip install -r requirements/ci-3.11.txt` if running python 3.11.
+`pip install -r requirements/ci-3.11.txt` if running Python ≥ 3.11.
 
 ## De-selecting groups of tests
 
@@ -12,6 +12,7 @@ pypdf makes use of the following pytest markers:
 * `slow`: Tests that require more than 5 seconds
 * `samples`: Tests that require the [the `sample-files` git submodule](https://github.com/py-pdf/sample-files) to be initialized. As of October 2022, this is about 25 MB.
 * `enable_socket`: Tests that download PDF documents. They are stored locally and thus only need to be downloaded once. As of October 2022, this is about 200 MB.
+  * To successfully run the tests, please download most of the documents beforehand: `python -c "from tests import download_test_pdfs; download_test_pdfs()"`
 
 You can disable them by `pytest -m "not enable_socket"` or `pytest -m "not samples"`.
 You can even disable all of them: `pytest -m "not enable_socket" -m "not samples" -m "not slow"`.


### PR DESCRIPTION
When doing some tests today, *pypdf* would fail in lots of cases due to missing example files. Document that the developer is currently expected to download the test files beforehand.