### PR TITLE
DOC: Replace references and redirects to PyPDF2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html>
 <head>
-   <title>Home page for the PyPDF2 project</title>
-   <meta http-equiv="Refresh" content="0; url=https://pypdf2.readthedocs.io/en/latest/" />
+   <title>Homepage for the pypdf project</title>
+   <meta http-equiv="Refresh" content="0; url=https://pypdf.readthedocs.io/en/latest/" />
 </head>
 <body>
-<h1>Home page for the PyPDF2 project</h1>
+<h1>Homepage for the pypdf project</h1>
 
-Please go to <a href="https://pypdf2.readthedocs.io/en/latest/">https://pypdf2.readthedocs.io/en/latest/</a>
+Please go to <a href="https://pypdf.readthedocs.io/en/latest/">https://pypdf.readthedocs.io/en/latest/</a>
 </html>


### PR DESCRIPTION
I stumbled upon the GitHub Pages site by accident, which was still referencing PyPDF2 and redirecting to its docs. This appears to be wrong and has been fixed.