### PR TITLE
BUG: Add support for GBK2K cmaps

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -121,6 +121,8 @@ _predefined_cmap: Dict[str, str] = {
     "/GBpc-EUC-V": "gb2312",  # TBC
     "/GBK-EUC-H": "gbk",  # TBC
     "/GBK-EUC-V": "gbk",  # TBC
+    "/GBK2K-H": "gb18030",
+    "/GBK2K-V": "gb18030",
     # UCS2 in code
 }
 


### PR DESCRIPTION
This adds support for the GBK2K-H and GBK2K-V cmaps mentioned in #2356 where I stumbled upon directly.

I do not consider #2356 solved with this for now as it is not clear to me why we do not add the complete mapping once and how to get nice test data. For now, I unfortunately have private test data only.