### PR TITLE
TST: Correctly close temporary files

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -44,7 +44,7 @@ SAMPLE_ROOT = Path(PROJECT_ROOT) / "sample-files"
 GHOSTSCRIPT_BINARY = shutil.which("gs")
 
 
-def _get_write_target(convert):
+def _get_write_target(convert) -> Any:
     target = convert
     if callable(convert):
         with NamedTemporaryFile(suffix=".pdf", delete=False) as temporary:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -44,6 +44,14 @@ SAMPLE_ROOT = Path(PROJECT_ROOT) / "sample-files"
 GHOSTSCRIPT_BINARY = shutil.which("gs")
 
 
+def _get_write_target(convert):
+    target = convert
+    if callable(convert):
+        with NamedTemporaryFile(suffix=".pdf", delete=False) as temporary:
+            target = temporary.name
+    return target
+
+
 def test_writer_exception_non_binary(tmp_path, caplog):
     src = RESOURCE_ROOT / "pdflatex-outline.pdf"
 
@@ -223,13 +231,8 @@ def writer_operate(writer: PdfWriter) -> None:
     ],
 )
 def test_writer_operations_by_traditional_usage(convert, needs_cleanup):
-    if callable(convert):
-        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
-    else:
-        write_data_here = convert
-
+    write_data_here = _get_write_target(convert)
     writer = PdfWriter()
-
     writer_operate(writer)
 
     # finally, write "output" to pypdf-output.pdf
@@ -253,10 +256,7 @@ def test_writer_operations_by_traditional_usage(convert, needs_cleanup):
     ],
 )
 def test_writer_operations_by_semi_traditional_usage(convert, needs_cleanup):
-    if callable(convert):
-        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
-    else:
-        write_data_here = convert
+    write_data_here = _get_write_target(convert)
 
     with PdfWriter() as writer:
         writer_operate(writer)
@@ -284,10 +284,7 @@ def test_writer_operations_by_semi_traditional_usage(convert, needs_cleanup):
 def test_writer_operations_by_semi_new_traditional_usage(
     convert, needs_cleanup
 ):
-    if callable(convert):
-        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
-    else:
-        write_data_here = convert
+    write_data_here = _get_write_target(convert)
 
     with PdfWriter() as writer:
         writer_operate(writer)
@@ -308,10 +305,7 @@ def test_writer_operations_by_semi_new_traditional_usage(
     ],
 )
 def test_writer_operation_by_new_usage(convert, needs_cleanup):
-    if callable(convert):
-        write_data_here = convert(NamedTemporaryFile(suffix=".pdf", delete=False).name)
-    else:
-        write_data_here = convert
+    write_data_here = _get_write_target(convert)
 
     # This includes write "output" to pypdf-output.pdf
     with PdfWriter(write_data_here) as writer:


### PR DESCRIPTION
Improvement for #2379 to use a common method and appropriately close the temporary files. Fixes #2394.