### PR TITLE
BUG: PdfWriter.add_uri was setting the wrong type

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1922,7 +1922,7 @@ class PdfWriter:
         lnk = DictionaryObject()
         lnk.update(
             {
-                NameObject(AA.Type): NameObject(PG.ANNOTS),
+                NameObject(AA.Type): NameObject("/Annot"),
                 NameObject(AA.Subtype): NameObject("/Link"),
                 NameObject(AA.P): page_link,
                 NameObject(AA.Rect): rect,


### PR DESCRIPTION
BUG:  /TYPE for a link should be "/Annot" not "/Annots"   This change makes add_uri work;  previously, it did not.  

```python
writer = pypdf.PdfWriter()
writer.add_blank_page(width=500, height=500)
writer.add_uri(0, 'https://cnn.com', [0, 0, 499, 499])
print ('writing demo.pdf')
writer.write('demo.pdf')
```