### PR TITLE
BUG: layout mode text extraction ZeroDivisionError

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2027,8 +2027,6 @@ class PageObject(DictionaryObject):
             layout_mode_strip_rotated (bool): layout mode does not support rotated text.
                 Set to False to include rotated text anyway. If rotated text is discovered,
                 layout will be degraded and a warning will result. Defaults to True.
-            layout_mode_strip_rotated: Removes text that is rotated w.r.t. to the page from
-                layout mode output. Defaults to True.
             layout_mode_debug_path (Path | None): if supplied, must target a directory.
                 creates the following files with debug information for layout mode
                 functions if supplied:

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -144,7 +144,7 @@ def recurs_to_target_op(
                     # applied to the first tj of a BTGroup in fixed_width_page().
                     excess_tx = round(_tj.tx - last_displaced_tx, 3) * (_idx != bt_idx)
                     # space_tx could be 0 if either Tz or font_size was 0 for this _tj.
-                    spaces = int(excess_tx // _tj.space_tx) if int(_tj.space_tx) else 0
+                    spaces = int(excess_tx // _tj.space_tx) if _tj.space_tx else 0
                     new_text = f'{" " * spaces}{_tj.txt}'
 
                     last_ty = _tj.ty

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -143,8 +143,9 @@ def recurs_to_target_op(
                     # multiply by bool (_idx != bt_idx) to ensure spaces aren't double
                     # applied to the first tj of a BTGroup in fixed_width_page().
                     excess_tx = round(_tj.tx - last_displaced_tx, 3) * (_idx != bt_idx)
-
-                    new_text = f'{" " * int(excess_tx // _tj.space_tx)}{_tj.txt}'
+                    # space_tx could be 0 if either Tz or font_size was 0 for this _tj.
+                    spaces = int(excess_tx // _tj.space_tx) if int(_tj.space_tx) else 0
+                    new_text = f'{" " * spaces}{_tj.txt}'
 
                     last_ty = _tj.ty
                     _text = f"{_text}{new_text}"


### PR DESCRIPTION
For fonts without an explicitly defined width for the " " character, it's still possible to generate a ZeroDivisionError when compiling TextStateParams objects in _fixed_width_page.recurs_to_target_op() if the font size or the Tz parameter has been set to 0. 

Discovered during processing of a "pre-OCR'd" image PDF having `{"/BaseFont": "/GlyphLessFont"}`.

Remove duplicate docstring for layout_mode_strip_rotated