### PR TITLE
TST: Skip tests using fpdf2 if it's not installed

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1270,6 +1270,7 @@ def test_compression():
     """Test for issue #1897"""
 
     def create_stamp_pdf() -> BytesIO:
+        pytest.importorskip("fpdf")
         from fpdf import FPDF
 
         pdf = FPDF()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1951,6 +1951,7 @@ REFERENCES 76"""
 
 def test_merging_many_temporary_files():
     def create_number_pdf(n) -> BytesIO:
+        pytest.importorskip("fpdf")
         from fpdf import FPDF
 
         pdf = FPDF()


### PR DESCRIPTION
The Debian ecosystem installs only packages which are also present in the Debian ecosystem for testing. This includes pytest, but it does not include fpdf2.

Adding the line 'pytest.importorskip("fpdf")' within the test and before the import ensures that pytest skips the test in case fpdf is not installed.

Closes #2408