### PR TITLE
DOC: Change extract-text.md example codes from using cm to tm

### DIFF
--- a/docs/user/extract-text.md
+++ b/docs/user/extract-text.md
@@ -118,7 +118,7 @@ def visitor_svg_rect(op, args, cm, tm):
         dwg.add(dwg.rect((x, y), (w, h), stroke="red", fill_opacity=0.05))
 
 
-def visitor_svg_text(text, cm, tm, fontDict, fontSize):
+def visitor_svg_text(text, cm, tm, font_dict, font_size):
     (x, y) = (tm[4], tm[5])
     dwg.add(dwg.text(text, insert=(x, y), fill="blue"))
 

--- a/docs/user/extract-text.md
+++ b/docs/user/extract-text.md
@@ -84,7 +84,7 @@ parts = []
 
 
 def visitor_body(text, cm, tm, font_dict, font_size):
-    y = cm[5]
+    y = tm[5]
     if y > 50 and y < 720:
         parts.append(text)
 
@@ -119,7 +119,7 @@ def visitor_svg_rect(op, args, cm, tm):
 
 
 def visitor_svg_text(text, cm, tm, fontDict, fontSize):
-    (x, y) = (cm[4], cm[5])
+    (x, y) = (tm[4], tm[5])
     dwg.add(dwg.text(text, insert=(x, y), fill="blue"))
 
 


### PR DESCRIPTION
## TL;DR
Fixes [#2431](https://github.com/py-pdf/pypdf/issues/2431)
Changed `cm` (current_matrix) to `tm` (text matrix). 

## Problem

In the extract-text documentation [here](https://github.com/py-pdf/pypdf/blob/main/docs/user/extract-text.md#example-1-ignore-header-and-footer), the example codes that are used won't produce the correct output. 

For example, the first code snippet should output the text of table of contents, but it outputs nothing. The second code snippet is supposed to convert page 4 from the PDF to a SVG, including the text, but it only outputs empty fields.

## Reason

The coordination process should be using the text matrix instead of current matrix.

## Solution/update

Just changed the `cm` to `tm` in the code snippets.
