### PR TITLE
TST: resolve file naming conflict in test_iss1767

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,5 @@
 """Test the pypdf._writer module."""
+
 import re
 import shutil
 import subprocess
@@ -1418,7 +1419,7 @@ def test_iss1767():
     # twice to define catalog and one as an XObject inducing a loop when
     # cloning
     url = "https://github.com/py-pdf/pypdf/files/11138472/test.pdf"
-    name = "iss1723.pdf"
+    name = "iss1767.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     PdfWriter(clone_from=reader)
 


### PR DESCRIPTION
The PDF filename used in test_iss1767() with conflicting with the filename in test_iss1723().

This fix might solve the unpredictable test error of the PR https://github.com/py-pdf/pypdf/pull/2440.