### PR TITLE
Update _writer.py - Invalid Link Fix

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2129,9 +2129,12 @@ class PdfWriter:
         # destination
         if to_add.get("/Subtype") == "/Link" and "/Dest" in to_add:
             tmp = cast(Dict[Any, Any], to_add[NameObject("/Dest")])
+            # get target_page as an IndirectObject from target_page_index an integer
+            pages_obj = cast(Dict[str, Any], self.get_object(self._pages))
+            target_page = pages_obj[PA.KIDS][tmp["target_page_index"]]
             dest = Destination(
                 NameObject("/LinkName"),
-                tmp["target_page_index"],
+                target_page,
                 Fit(
                     fit_type=tmp["fit"], fit_args=dict(tmp)["fit_args"]
                 ),  # I have no clue why this dict-hack is necessary


### PR DESCRIPTION
passes an IndirectObject for the target page instead of an integer. passing an integer creates an invalid link.
resolves #2443 Issue