### PR TITLE
BUG: Invalid Link

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2141,7 +2141,7 @@ class PdfWriter:
                 ),  # I have no clue why this dict-hack is necessary
             )
             to_add[NameObject("/Dest")] = dest.dest_array
-  
+
         page.annotations.append(self._add_object(to_add))
 
         if to_add.get("/Subtype") == "/Popup" and NameObject("/Parent") in to_add:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2129,17 +2129,18 @@ class PdfWriter:
         # destination
         if to_add.get("/Subtype") == "/Link" and "/Dest" in to_add:
             tmp = cast(Dict[Any, Any], to_add[NameObject("/Dest")])
+            # Changes target_page_index a integer to target_page an IndirectObject
+            page.annotations.append(self._add_object(to_add))
+            target_page = pages_obj[PA.KIDS][tmp["target_page_index"]]
+            pages_obj = cast(Dict[str, Any], self.get_object(self._pages))
             dest = Destination(
                 NameObject("/LinkName"),
-                tmp["target_page_index"],
+                target_page,
                 Fit(
                     fit_type=tmp["fit"], fit_args=dict(tmp)["fit_args"]
                 ),  # I have no clue why this dict-hack is necessary
             )
             to_add[NameObject("/Dest")] = dest.dest_array
-
-        page.annotations.append(self._add_object(to_add))
-
         if to_add.get("/Subtype") == "/Popup" and NameObject("/Parent") in to_add:
             cast(DictionaryObject, to_add["/Parent"].get_object())[
                 NameObject("/Popup")

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2141,6 +2141,9 @@ class PdfWriter:
                 ),  # I have no clue why this dict-hack is necessary
             )
             to_add[NameObject("/Dest")] = dest.dest_array
+            
+        page.annotations.append(self._add_object(to_add))
+        
         if to_add.get("/Subtype") == "/Popup" and NameObject("/Parent") in to_add:
             cast(DictionaryObject, to_add["/Parent"].get_object())[
                 NameObject("/Popup")

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2129,7 +2129,7 @@ class PdfWriter:
         # destination
         if to_add.get("/Subtype") == "/Link" and "/Dest" in to_add:
             tmp = cast(Dict[Any, Any], to_add[NameObject("/Dest")])
-            # Changes target_page_index a integer to target_page an IndirectObject
+            # Changes target_page_index an integer to target_page an IndirectObject
             page.annotations.append(self._add_object(to_add))
             target_page = pages_obj[PA.KIDS][tmp["target_page_index"]]
             pages_obj = cast(Dict[str, Any], self.get_object(self._pages))

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2141,9 +2141,9 @@ class PdfWriter:
                 ),  # I have no clue why this dict-hack is necessary
             )
             to_add[NameObject("/Dest")] = dest.dest_array
-            
+  
         page.annotations.append(self._add_object(to_add))
-        
+
         if to_add.get("/Subtype") == "/Popup" and NameObject("/Parent") in to_add:
             cast(DictionaryObject, to_add["/Parent"].get_object())[
                 NameObject("/Popup")

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2130,9 +2130,8 @@ class PdfWriter:
         if to_add.get("/Subtype") == "/Link" and "/Dest" in to_add:
             tmp = cast(Dict[Any, Any], to_add[NameObject("/Dest")])
             # Changes target_page_index an integer to target_page an IndirectObject
-            page.annotations.append(self._add_object(to_add))
-            target_page = pages_obj[PA.KIDS][tmp["target_page_index"]]
             pages_obj = cast(Dict[str, Any], self.get_object(self._pages))
+            target_page = pages_obj[PA.KIDS][tmp["target_page_index"]]
             dest = Destination(
                 NameObject("/LinkName"),
                 target_page,


### PR DESCRIPTION
passes an IndirectObject for the target page instead of an integer. passing an integer creates an invalid link.

Fixes #2443