### PR TITLE
Update _markup_annotations.py #2447

### DIFF
--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -325,9 +325,9 @@ class Link(MarkupAnnotation):
 
         border_arr: BorderArrayType
         if border is not None:
-            border_arr = [NameObject(n) for n in border[:3]]
+            border_arr = [NumberObject(n) for n in border[:3]]
             if len(border) == 4:
-                dash_pattern = ArrayObject([NameObject(n) for n in border[3]])
+                dash_pattern = ArrayObject([NumberObject(n) for n in border[3]])
                 border_arr.append(dash_pattern)
         else:
             border_arr = [NumberObject(0)] * 3


### PR DESCRIPTION
Change NameObject to NumberObject in lines 328 and 330 It will pass the array as a string and not an int if it is a NameObject and will cause a warning in the Class NameObject method renumber "Incorrect first char in NameObject:({self})" line 592 _base.py (pypdf.generic) resolves #2444 Issue