### PR TITLE
BUG: Handle IndirectObject in media boxes

### DIFF
--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -348,7 +348,7 @@ class FloatObject(float, PdfObject):
         try:
             value = float(str_(value))
             return float.__new__(cls, value)
-        except Exception as e:
+        except ValueError as e:
             # If this isn't a valid decimal (happens in malformed PDFs)
             # fallback to 0
             logger_warning(

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -47,6 +47,7 @@ from ..errors import STREAM_TRUNCATED_PREMATURELY, PdfReadError, PdfStreamError
 
 __author__ = "Mathieu Fenniak"
 __author_email__ = "biziqe@mathieu.fenniak.net"
+MAX_INDIRECT_OBJECT_NESTING_DEPTH = 10
 
 
 class PdfObject(PdfObjectProtocol):
@@ -292,8 +293,15 @@ class IndirectObject(PdfObject):
         Given a PdfObject that may be an IndirectObject, recursively unwrap that IndirectObject until a None or
         PdfObject that is not an IndirectObject is returned.
         """
-        if isinstance(obj, IndirectObject):
-            return IndirectObject.fully_unwrap(obj.get_object())
+        depth = 0
+        while isinstance(obj, IndirectObject):
+            if depth > MAX_INDIRECT_OBJECT_NESTING_DEPTH:
+                raise PdfReadError(
+                    "IndirectObject nested too deep. "
+                    "If required, consider increasing MAX_INDIRECT_OBJECT_NESTING_DEPTH."
+                )
+            depth += 1
+            obj = obj.get_object()
         return obj
 
     def __repr__(self) -> str:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -286,6 +286,16 @@ class IndirectObject(PdfObject):
             return None
         return obj.get_object()
 
+    @staticmethod
+    def fully_unwrap(obj: Optional["PdfObject"]) -> Optional["PdfObject"]:
+        """
+        Given a PdfObject that may be an IndirectObject, recursively unwrap that IndirectObject until a None or
+        PdfObject that is not an IndirectObject is returned.
+        """
+        if isinstance(obj, IndirectObject):
+            return IndirectObject.fully_unwrap(obj.get_object())
+        return obj
+
     def __repr__(self) -> str:
         return f"IndirectObject({self.idnum!r}, {self.generation!r}, {id(self.pdf)})"
 

--- a/pypdf/generic/_rectangle.py
+++ b/pypdf/generic/_rectangle.py
@@ -1,6 +1,6 @@
 from typing import Any, Tuple, Union
 
-from ._base import FloatObject, NumberObject
+from ._base import FloatObject, NumberObject, IndirectObject
 from ._data_structures import ArrayObject
 
 
@@ -26,6 +26,7 @@ class RectangleObject(ArrayObject):
         ArrayObject.__init__(self, [self._ensure_is_number(x) for x in arr])  # type: ignore
 
     def _ensure_is_number(self, value: Any) -> Union[FloatObject, NumberObject]:
+        value = IndirectObject.fully_unwrap(value)
         if not isinstance(value, (NumberObject, FloatObject)):
             value = FloatObject(value)
         return value

--- a/pypdf/generic/_rectangle.py
+++ b/pypdf/generic/_rectangle.py
@@ -1,6 +1,6 @@
 from typing import Any, Tuple, Union
 
-from ._base import FloatObject, NumberObject, IndirectObject
+from ._base import FloatObject, IndirectObject, NumberObject
 from ._data_structures import ArrayObject
 
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -47,14 +47,24 @@ class ChildDummy(DictionaryObject):
         return self
 
 
-def test_float_object_exception(caplog):
+def test_float_object_invalid_format_warning(caplog):
     assert FloatObject("abc") == 0
     assert caplog.text != ""
 
 
-def test_number_object_exception(caplog):
+def test_number_object_invalid_format_warning(caplog):
     assert NumberObject("0,0") == 0
     assert caplog.text != ""
+
+
+def test_float_object_indirect_object_exception(caplog):
+    with pytest.raises(TypeError):
+        FloatObject(IndirectObject(0, 0, None))
+
+
+def test_number_object_indirect_object_exception(caplog):
+    with pytest.raises(TypeError):
+        NumberObject(IndirectObject(0, 0, None))
 
 
 def test_number_object_no_exception():

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1048,6 +1048,16 @@ def test_name_object_invalid_decode():
     NameObject.read_from_stream(stream, ReaderDummy(strict=False))
 
 
+@pytest.mark.enable_socket()
+def test_indirect_object_page_dimensions():
+    url = "https://github.com/py-pdf/pypdf/files/13302338/Zymeworks_Corporate.Presentation_FINAL1101.pdf.pdf"
+    name = "issue2287.pdf"
+    data = BytesIO(get_data_from_url(url, name=name))
+    reader = PdfReader(data, strict=False)
+    mediabox = reader.pages[0].mediabox
+    assert mediabox == RectangleObject((0, 0, 792, 612))
+
+
 def test_indirect_object_invalid_read():
     stream = BytesIO(b"0 1 s")
     with pytest.raises(PdfReadError) as exc:


### PR DESCRIPTION
Fixes the bug where passing an `IndirectObject` to the constructor of `FloatObject` emitted a warning and resulting in a value of `0.0`, rather than an exception being thrown.

When an `IndirectObject` is passed to the constructor of `RectangleObject`, unwrap that `IndirectObject` so the number it contains is used; this allows for PDFs with page dimensions that include `IndirectObject`s.

Fixes https://github.com/py-pdf/pypdf/issues/2287