### PR TITLE
BUG: clean_forms function cause infinite looping if elt["/Resources"] have circular relation

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -42,6 +42,7 @@ from typing import (
     Any,
     Callable,
     Deque,
+    Set,
     Dict,
     Iterable,
     List,
@@ -1766,12 +1767,15 @@ class PdfWriter:
             content.get_data()  # this ensures ._data is rebuilt from the .operations
 
         def clean_forms(
-            elt: DictionaryObject, stack: List[DictionaryObject]
+            elt: DictionaryObject, stack: List[DictionaryObject], visited_resouces: Set[Dict] = set()
         ) -> Tuple[List[str], List[str]]:
             nonlocal to_delete
             if elt in stack:
                 # to prevent infinite looping
                 return [], []  # pragma: no cover
+            if elt["/Resources"] in visited_resouces:
+                # to prevent infinite looping
+                return [], []
             try:
                 d = cast(
                     Dict[Any, Any],
@@ -1804,6 +1808,7 @@ class PdfWriter:
                                     if k1 not in ["/Length", "/Filter", "/DecodeParms"]
                                 }
                             )
+                        visited_resouces.add(elt["/Resources"])
                         clean_forms(content, stack + [elt])  # clean sub forms
                     if content is not None:
                         if isinstance(v, IndirectObject):

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1767,7 +1767,7 @@ class PdfWriter:
             content.get_data()  # this ensures ._data is rebuilt from the .operations
 
         def clean_forms(
-            elt: DictionaryObject, stack: List[DictionaryObject], visited_objects: Set[Dict] = set()
+            elt: DictionaryObject, stack: List[DictionaryObject], visited_objects: Set[Dict[Any, Any]] = set()
         ) -> Tuple[List[str], List[str]]:
             nonlocal to_delete
             if elt in stack:
@@ -1775,16 +1775,15 @@ class PdfWriter:
                 return [], []  # pragma: no cover
     
             try:
-                xobject = cast(DictionaryObject, elt["/Resources"])["/XObject"]
-                if xobject in visited_objects:
-                    # to prevent infinite looping
-                    return [], []
                 d = cast(
                     Dict[Any, Any],
                     cast(DictionaryObject, elt["/Resources"])["/XObject"],
                 )
+                if d in visited_objects:
+                    # to prevent infinite looping
+                    return [], []
+                visited_objects.add(d)
             except KeyError:
-                xobject = None
                 d = {}
             images = []
             forms = []
@@ -1811,8 +1810,6 @@ class PdfWriter:
                                     if k1 not in ["/Length", "/Filter", "/DecodeParms"]
                                 }
                             )
-                        if xobject:
-                            visited_objects.add(xobject)
                         clean_forms(content, stack + [elt])  # clean sub forms
                     if content is not None:
                         if isinstance(v, IndirectObject):

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1766,21 +1766,21 @@ class PdfWriter:
             content.get_data()  # this ensures ._data is rebuilt from the .operations
 
         def clean_forms(
-            elt: DictionaryObject, stack: List[DictionaryObject], visited_resources: List[Dict]
+            elt: DictionaryObject, stack: List[DictionaryObject], visited_objects: List[Dict[Any, Any]]
         ) -> Tuple[List[str], List[str]]:
             nonlocal to_delete
             if elt in stack:
                 # to prevent infinite looping
                 return [], []  # pragma: no cover
             try:
-                if elt["/Resources"] in visited_resources:
-                    # to prevent infinite looping
-                    return [], []
-                visited_resources.append(elt["/Resources"])
                 d = cast(
                     Dict[Any, Any],
                     cast(DictionaryObject, elt["/Resources"])["/XObject"],
                 )
+                if d in visited_objects:
+                    # to prevent infinite looping
+                    return [], []
+                visited_objects.append(d)
             except KeyError:
                 d = {}
             images = []
@@ -1808,7 +1808,7 @@ class PdfWriter:
                                     if k1 not in ["/Length", "/Filter", "/DecodeParms"]
                                 }
                             )
-                        clean_forms(content, stack + [elt], visited_resources)  # clean sub forms
+                        clean_forms(content, stack + [elt], visited_objects)  # clean sub forms
                     if content is not None:
                         if isinstance(v, IndirectObject):
                             self._objects[v.idnum - 1] = content

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -42,7 +42,6 @@ from typing import (
     Any,
     Callable,
     Deque,
-    Set,
     Dict,
     Iterable,
     List,
@@ -1773,13 +1772,11 @@ class PdfWriter:
             if elt in stack:
                 # to prevent infinite looping
                 return [], []  # pragma: no cover
-    
             try:
                 if elt["/Resources"] in visited_resources:
                     # to prevent infinite looping
                     return [], []
                 visited_resources.append(elt["/Resources"])
-                
                 d = cast(
                     Dict[Any, Any],
                     cast(DictionaryObject, elt["/Resources"])["/XObject"],


### PR DESCRIPTION
I have several PDF files from customers, and using `remove_text` can cause infinite looping. Upon investigation, I discovered a corner case where `elt["/Resources"]` has a circular relation, which can result in calling `clean_forms(content, stack + [elt])` infinitely.

I proposed keeping a memory variable `visited_resources` to keep track of which `elt["/Resources"]` has been processed and to avoid infinite looping.

The corner case files are private and cannot be shared, but I believe many people would encounter the same problem.

Closes #2474 