### PR TITLE
MAINT: Remove reference to old 2.0.0 branch

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -5,12 +5,14 @@ name: CI
 
 on:
   push:
-    branches: [ main, 2.0.0-dev ]
+    branches:
+      - main
     paths-ignore:
       - '**/*.md'
       - '**/*.rst'
   pull_request:
-    branches: [ main, 2.0.0-dev ]
+    branches:
+      - main
     paths-ignore:
       - '**/*.md'
       - '**/*.rst'


### PR DESCRIPTION
Version 2.0.0 has been released on 2022-06-01, thus the corresponding branch is useless as a CI target.