### PR TITLE
MAINT: Remove user assignment for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: Request a Feature
 about: What do you think is missing in pypdf?
 title: ''
 labels: Feature Request
-assignees: MartinThoma
+assignees: ''
 
 ---
 


### PR DESCRIPTION
Assigning @MartinThoma to new feature requests does not make much sense without any active monitoring. I currently consider it sufficient enough to just handle feature requests in the same triaging workflow as bug reports - no need to explicitly assign someone as this will not speed up or slow down any processing at the moment.