### PR TITLE
ROB: Robustify stream object extraction

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1612,7 +1612,8 @@ class PdfReader:
                     # any existing key is already set correctly.
                     pass
                 else:
-                    self.xref[generation][num] = offset
+                    if entry_type_b == b"n":
+                        self.xref[generation][num] = offset
                     try:
                         self.xref_free_entry[generation][num] = entry_type_b == b"f"
                     except Exception:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2809,7 +2809,7 @@ class PdfWriter:
         if node is None:
             node = NullObject()
         node = node.get_object()
-        if isinstance(node, NullObject):
+        if node is None or isinstance(node, NullObject):
             node = DictionaryObject()
         if node.get("/Type", "") == "/Outlines" or "/Title" not in node:
             node = node.get("/First", None)

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -436,14 +436,14 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
         def get_next_obj_pos(
             p: int, p1: int, rem_gens: List[int], pdf: PdfReaderProtocol
         ) -> int:
-            loc = pdf.xref[rem_gens[0]]
-            for o in loc:
-                if p1 > loc[o] and p < loc[o]:
-                    p1 = loc[o]
-            if len(rem_gens) == 1:
-                return p1
-            else:
-                return get_next_obj_pos(p, p1, rem_gens[1:], pdf)
+            out = p1
+            for gen in rem_gens:
+                loc = pdf.xref[gen]
+                try:
+                    out = min(out, min([x for x in loc.values() if p < x <= p1]))
+                except ValueError:
+                    pass
+            return out
 
         def read_unsized_from_stream(
             stream: StreamType, pdf: PdfReaderProtocol


### PR DESCRIPTION
fixes #2523
situation met:
* length field is not correct
* xref may contains not ordered stream datas
* xref contains some free entries (i.e. not contains stream offset)