### PR TITLE
MAINT: Update Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 
 
 build:
-  os: ubuntu-lts-latest
+  os: ubuntu-22.04
   tools:
     python: "3.12"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,11 +3,11 @@ version: 2
 
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.11"
+    python: "3.12"
 
-# Build documentation in the docs/ directory with Sphinx
+# Build documentation in the "docs/" directory with Sphinx
 sphinx:
    configuration: docs/conf.py
 


### PR DESCRIPTION
Using ubuntu-lts-latest may break your builds unexpectedly if your project isn’t compatible with the newest Ubuntu LTS version when it’s updated by Read the Docs. [https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os]. For us this may be a feature since compatibility with the latest Ubuntu LTS is desirable and is in effect an extra test.