### PR TITLE
BUG: Ambiguous translated references

### DIFF
--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -79,7 +79,7 @@ class PdfReaderProtocol(PdfCommonDocProtocol, Protocol):
 
 class PdfWriterProtocol(PdfCommonDocProtocol, Protocol):
     _objects: List[Any]
-    _id_translated: WeakKeyDictionary["PdfReaderProtocol", Dict[int, int]]
+    _id_translated: "WeakKeyDictionary[PdfReaderProtocol, Dict[int, int]]"
 
     @abstractmethod
     def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO[Any]]:

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod
 from pathlib import Path
 from typing import IO, Any, Dict, List, Optional, Tuple, Union
+from weakref import WeakKeyDictionary
 
 try:
     # Python 3.8+: https://peps.python.org/pep-0586
@@ -78,7 +79,7 @@ class PdfReaderProtocol(PdfCommonDocProtocol, Protocol):
 
 class PdfWriterProtocol(PdfCommonDocProtocol, Protocol):
     _objects: List[Any]
-    _id_translated: Dict[int, Dict[int, int]]
+    _id_translated: WeakKeyDictionary["PdfReaderProtocol", Dict[int, int]]
 
     @abstractmethod
     def write(self, stream: Union[Path, StrByteType]) -> Tuple[bool, IO[Any]]:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -180,7 +180,7 @@ class PdfWriter(PdfDocCommon):
         self._idnum_hash: Dict[bytes, IndirectObject] = {}
         """Maps hash values of indirect objects to their IndirectObject instances."""
 
-        self._id_translated: WeakKeyDictionary[PdfReaderProtocol, dict[int, int]] = WeakKeyDictionary()
+        self._id_translated: "WeakKeyDictionary[PdfReaderProtocol, dict[int, int]]" = WeakKeyDictionary()
 
         # The root of our page tree node.
         pages = DictionaryObject()

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -126,7 +126,6 @@ class PdfObject(PdfObjectProtocol):
         if ind is not None:
             if ind.pdf not in pdf_dest._id_translated:
                 pdf_dest._id_translated[ind.pdf] = {}
-                pdf_dest._id_translated[ind.pdf]["PreventGC"] = ind.pdf  # type: ignore
             if (
                 not force_duplicate
                 and ind.idnum in pdf_dest._id_translated[ind.pdf]

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -124,19 +124,19 @@ class PdfObject(PdfObjectProtocol):
             return clone
         i = len(pdf_dest._objects) + 1
         if ind is not None:
-            if id(ind.pdf) not in pdf_dest._id_translated:
-                pdf_dest._id_translated[id(ind.pdf)] = {}
-                pdf_dest._id_translated[id(ind.pdf)]["PreventGC"] = ind.pdf  # type: ignore
+            if ind.pdf not in pdf_dest._id_translated:
+                pdf_dest._id_translated[ind.pdf] = {}
+                pdf_dest._id_translated[ind.pdf]["PreventGC"] = ind.pdf  # type: ignore
             if (
                 not force_duplicate
-                and ind.idnum in pdf_dest._id_translated[id(ind.pdf)]
+                and ind.idnum in pdf_dest._id_translated[ind.pdf]
             ):
                 obj = pdf_dest.get_object(
-                    pdf_dest._id_translated[id(ind.pdf)][ind.idnum]
+                    pdf_dest._id_translated[ind.pdf][ind.idnum]
                 )
                 assert obj is not None
                 return obj
-            pdf_dest._id_translated[id(ind.pdf)][ind.idnum] = i
+            pdf_dest._id_translated[ind.pdf][ind.idnum] = i
         pdf_dest._objects.append(clone)
         clone.indirect_reference = IndirectObject(i, 0, pdf_dest)
         return clone
@@ -250,11 +250,11 @@ class IndirectObject(PdfObject):
         if self.pdf == pdf_dest and not force_duplicate:
             # Already duplicated and no extra duplication required
             return self
-        if id(self.pdf) not in pdf_dest._id_translated:
-            pdf_dest._id_translated[id(self.pdf)] = {}
+        if self.pdf not in pdf_dest._id_translated:
+            pdf_dest._id_translated[self.pdf] = {}
 
-        if self.idnum in pdf_dest._id_translated[id(self.pdf)]:
-            dup = pdf_dest.get_object(pdf_dest._id_translated[id(self.pdf)][self.idnum])
+        if self.idnum in pdf_dest._id_translated[self.pdf]:
+            dup = pdf_dest.get_object(pdf_dest._id_translated[self.pdf][self.idnum])
             if force_duplicate:
                 assert dup is not None
                 assert dup.indirect_reference is not None


### PR DESCRIPTION
pypdf uses id(obj) to keep track of objects in `_id_translated`. This identifier is **not** unique for different objects, only for objects existing at the same time. e.g. In CPython id(obj), is just a memory address. This cannot be used to tell whether we already have referenced a page or not. It might point to a page of a since-deleted PdfReader, silently corrupting out output.

The bug manifests rarely, and the corrupted output document usually looks OK at first glance (but has missing/duplicated content), the following is my best reproducer so far, adapted from https://stackoverflow.com/questions/78186323/

```python3
# python3 repro.py < resources/multilang.pdf

import gc, io, sys
from pypdf import PdfReader, PdfWriter

def pdfsize(fin):
    pdfout = PdfWriter()
    pageout = pdfout.add_blank_page(width=10, height=10)
    reader = None
    for i in range(80):
        fin.seek(0)
        del reader
        gc.collect(0)
        reader = PdfReader(fin, strict=True)
        for pagein in reader.pages:
            pageout.merge_page(pagein)
    with io.BytesIO() as fout:
        pdfout.write(fout)
        return fout.tell()

if __name__ == "__main__":
    with io.BytesIO() as fin:
        fin.write(sys.stdin.buffer.read())
        for i in range(50):
            if i == 0:
                first_size = pdfsize(fin)
                first_size = pdfsize(fin)
            current_size = pdfsize(fin)
            if not first_size == current_size:
                raise RuntimeError(
                    f"generated PDF file size changed after repeating {i} times {first_size=} != {current_size=}"
                )
```

The attached draft replaces `dict[id(obj)]` with `dict[weakref(obj)]` - For the simple insert/lookup/delete cases, that behaves the same. Yet no-longer-existing objects are cleared automatically, removing the possible collision.

There is [another instance of id(obj)](https://github.com/py-pdf/pypdf/blob/e35df5a/pypdf/_page.py#L343) outside of `__repr__()` methods in `PageObject.hash_value_data` - I have not determined whether that can cause related problems.

Essentially resubmitting https://github.com/py-pdf/pypdf/pull/1995 as a replacement for https://github.com/py-pdf/pypdf/pull/1841 which has memory usage side-effects and does not fully avoid https://github.com/py-pdf/pypdf/issues/1788 anyway.