### PR TITLE
DEV: Remove unused dependencies

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,8 +1,4 @@
 coverage
-flake8
-flake8_implicit_str_concat
-flake8-bugbear
-flake8-print
 fpdf2==2.4.1
 mypy
 pillow
@@ -15,6 +11,5 @@ pytest-xdist
 pytest-cov
 # ruff  # only take this for 3.11
 typeguard
-types-dataclasses
 types-Pillow
 pyyaml


### PR DESCRIPTION
We have migrated from `flake8` to `ruff` and thus do not need to maintain the `flake8` dependencies anymore.

`types-dataclasses` is the accompanying package of `dataclasses`, only providing backports for Python < 3.7 which we dropped already: https://pypi.org/project/types-dataclasses/