### PR TITLE
DEV: Only run further release steps on tagging

### DIFF
--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -17,6 +17,7 @@ jobs:
   build_and_publish:
     name: Create a GitHub release page
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/create-github-release.yaml
+++ b/.github/workflows/create-github-release.yaml
@@ -5,10 +5,6 @@ on:
     tags:
       - '*.*.*'
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Create git tag"]
-    types:
-      - completed
 
 permissions:
   contents: write
@@ -17,7 +13,6 @@ jobs:
   build_and_publish:
     name: Create a GitHub release page
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -5,16 +5,11 @@ on:
     tags:
       - '*.*.*'
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Create git tag"]
-    types:
-      - completed
 
 jobs:
   build_and_publish:
     name: Publish a new version
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -14,6 +14,7 @@ jobs:
   build_and_publish:
     name: Publish a new version
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Fixes #2596 which led to always executing (and failing) the secondary workflows for a release.