### PR TITLE
NameObject wrong encoding

### DIFF
--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -628,7 +628,7 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
                 out += self.renumber_table[c]
             except KeyError:
                 try:
-                    out += encode_pdfdocencoding(c)
+                    out += c.encode("latin1")
                 except UnicodeEncodeError:
                     deprecate_no_replacement(
                         f"Only 8-bit characters are allowed by specs in NameObject: ({self})",
@@ -657,10 +657,7 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
         if name != NameObject.surfix:
             raise PdfReadError("name read error")
         name += read_until_regex(stream, NameObject.delimiter_pattern)
-
-        from ._utils import decode_pdfdocencoding
-
-        return NameObject(decode_pdfdocencoding(NameObject.unnumber(name)))
+        return NameObject(NameObject.unnumber(name).decode("latin1"))
 
 
 def encode_pdfdocencoding(unicode_string: str) -> bytes:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -43,7 +43,12 @@ from .._utils import (
     read_until_regex,
     str_,
 )
-from ..errors import STREAM_TRUNCATED_PREMATURELY, PdfReadError, PdfStreamError
+from ..errors import (
+    STREAM_TRUNCATED_PREMATURELY,
+    PdfReadError,
+    PdfStreamError,
+    PyPdfError,
+)
 
 __author__ = "Mathieu Fenniak"
 __author_email__ = "biziqe@mathieu.fenniak.net"
@@ -607,6 +612,8 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
             deprecate_no_replacement(
                 "the encryption_key parameter of write_to_stream", "5.0.0"
             )
+        if "\0" in self:
+            raise PyPdfError("Null character is not allowed in NameObject")
         stream.write(self.renumber())
 
     def renumber(self) -> bytes:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -9,7 +9,7 @@ import pytest
 
 from pypdf import PdfMerger, PdfReader, PdfWriter
 from pypdf.constants import CheckboxRadioButtonAttributes
-from pypdf.errors import PdfReadError, PdfStreamError
+from pypdf.errors import PdfReadError, PdfStreamError, PyPdfError
 from pypdf.generic import (
     AnnotationBuilder,
     ArrayObject,
@@ -262,6 +262,9 @@ def test_name_object(caplog):
         NameObject("/" + n).write_to_stream(bio)
         assert bio.getbuffer() == b
     assert (NameObject.read_from_stream(BytesIO(b"/A#42"), None)) == "/" + "AB"
+
+    with pytest.raises(PyPdfError):
+        NameObject("/\0").write_to_stream(BytesIO())
 
 
 def test_destination_fit_r():

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -202,7 +202,7 @@ def test_name_object(caplog):
             BytesIO(b"/#f1j#d4#aa#0c#ce#87#b4#b3#b0#23J#86#fe#2a#b2jYJ#94"),
             ReaderDummy(),
         )
-        == "/ñjÔª\x0cÎ⁄´³°#Jƒþ*²jYJﬂ"
+        == "/ñjÔª\x0cÎ\x87´³°#J\x86þ*²jYJ\x94"
     )
 
     assert (NameObject.read_from_stream(BytesIO(b"/#JA#231f"), None)) == "/#JA#1f"
@@ -211,7 +211,7 @@ def test_name_object(caplog):
         NameObject.read_from_stream(
             BytesIO(b"/#e4#bd#a0#e5#a5#bd#e4#b8#96#e7#95#8c"), None
         )
-    ) == "/ä½€å¥½ä¸ŒçŁ„"
+    ) == "/ä½\xa0å¥½ä¸\x96ç\x95\x8c"
 
     # to test latin-1 aka stdencoding
     assert (
@@ -265,6 +265,12 @@ def test_name_object(caplog):
 
     with pytest.raises(PyPdfError):
         NameObject("/\0").write_to_stream(BytesIO())
+
+    value = "/" + bytes(range(1, 0x100)).decode("latin1")
+    bio = BytesIO()
+    NameObject(value).write_to_stream(bio)
+    bio.seek(0)
+    assert NameObject.read_from_stream(bio, None) == value
 
 
 def test_destination_fit_r():


### PR DESCRIPTION
Name object  encodes all characters from 1 to 255, so it's not correct to use utf-8.

```
7.3.5 Name objects
Beginning with PDF 1.2 a name object is an atomic symbol uniquely defined by a sequence of any characters (8-bit values) except null (character code 0).
```