### PR TITLE
BUG: Highlighted Text Cannot Be Printed

### DIFF
--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -239,6 +239,7 @@ class Highlight(MarkupAnnotation):
         self.update(
             {
                 NameObject("/Subtype"): NameObject("/Highlight"),
+                NameObject("/F"): NumberObject(4),
                 NameObject("/Rect"): RectangleObject(rect),
                 NameObject("/QuadPoints"): quad_points,
                 NameObject("/C"): ArrayObject(

--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -2,6 +2,7 @@ import sys
 from abc import ABC
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
+from ..constants import AnnotationFlag
 from ..generic import ArrayObject, DictionaryObject
 from ..generic._base import (
     BooleanObject,
@@ -233,13 +234,13 @@ class Highlight(MarkupAnnotation):
         rect: Union[RectangleObject, Tuple[float, float, float, float]],
         quad_points: ArrayObject,
         highlight_color: str = "ff0000",
+        printing: bool = False,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.update(
             {
                 NameObject("/Subtype"): NameObject("/Highlight"),
-                NameObject("/F"): NumberObject(4),
                 NameObject("/Rect"): RectangleObject(rect),
                 NameObject("/QuadPoints"): quad_points,
                 NameObject("/C"): ArrayObject(
@@ -247,6 +248,8 @@ class Highlight(MarkupAnnotation):
                 ),
             }
         )
+        if printing:
+            self.flags = AnnotationFlag.PRINT
 
 
 class Ellipse(MarkupAnnotation):

--- a/pypdf/generic/__init__.py
+++ b/pypdf/generic/__init__.py
@@ -309,6 +309,7 @@ class AnnotationBuilder:
         rect: Union[RectangleObject, Tuple[float, float, float, float]],
         quad_points: ArrayObject,
         highlight_color: str = "ff0000",
+        printing: bool = False,
     ) -> DictionaryObject:
         """
         Add a highlight annotation to the document.
@@ -319,6 +320,8 @@ class AnnotationBuilder:
             quad_points: An ArrayObject of 8 FloatObjects. Must match a word or
                 a group of words, otherwise no highlight will be shown.
             highlight_color: The color used for the highlight.
+            printing: Whether to print out the highlight annotation when the page
+                is printed.
 
         Returns:
             A dictionary object representing the annotation.
@@ -329,7 +332,7 @@ class AnnotationBuilder:
         from ..annotations import Highlight
 
         return Highlight(
-            rect=rect, quad_points=quad_points, highlight_color=highlight_color
+            rect=rect, quad_points=quad_points, highlight_color=highlight_color, printing=printing
         )
 
     @staticmethod

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -883,10 +883,37 @@ def test_annotation_builder_highlight(pdf_file_path):
                     FloatObject(705.4493),
                 ]
             ),
-            printing=True,
+            printing=False
         )
     writer.add_annotation(0, highlight_annotation)
     for annot in writer.pages[0]["/Annots"]:
+        obj = annot.get_object()
+        subtype = obj["/Subtype"]
+        if subtype == "/Highlight":
+            assert "/F" not in obj or obj["/F"] == NumberObject(0)
+
+    writer.add_page(page)
+    # Act
+    with pytest.warns(DeprecationWarning):
+        highlight_annotation = AnnotationBuilder.highlight(
+            rect=(95.79332, 704.31777, 138.55779, 724.6855),
+            highlight_color="ff0000",
+            quad_points=ArrayObject(
+                [
+                    FloatObject(100.060779),
+                    FloatObject(723.55398),
+                    FloatObject(134.29033),
+                    FloatObject(723.55398),
+                    FloatObject(100.060779),
+                    FloatObject(705.4493),
+                    FloatObject(134.29033),
+                    FloatObject(705.4493),
+                ]
+            ),
+            printing=True
+        )
+    writer.add_annotation(1, highlight_annotation)
+    for annot in writer.pages[1]["/Annots"]:
         obj = annot.get_object()
         subtype = obj["/Subtype"]
         if subtype == "/Highlight":

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -883,8 +883,14 @@ def test_annotation_builder_highlight(pdf_file_path):
                     FloatObject(705.4493),
                 ]
             ),
+            printing=True,
         )
     writer.add_annotation(0, highlight_annotation)
+    for annot in writer.pages[0]["/Annots"]:
+        obj = annot.get_object()
+        subtype = obj["/Subtype"]
+        if subtype == "/Highlight":
+            assert obj["/F"] == NumberObject(4)
 
     # Assert: You need to inspect the file manually
     with open(pdf_file_path, "wb") as fp:


### PR DESCRIPTION
Currently, pypdf does not set annotation flags when highlighting text. The flag at bit 3 needs to be set in order to print highlighted text. 
![image](https://github.com/py-pdf/pypdf/assets/7867461/1e0e9456-d1c1-48de-a909-c904b5f1d7e3)
