### PR TITLE
DOC: Fix some typos in documentation

### DIFF
--- a/docs/dev/pypdf-writing.md
+++ b/docs/dev/pypdf-writing.md
@@ -34,7 +34,7 @@ has the following core steps:
 
 ## How others do it
 
-Looking at altrnative software designs and implementations can help to improve
+Looking at alternative software designs and implementations can help to improve
 our choices.
 
 ### fpdf2

--- a/docs/meta/project-governance.md
+++ b/docs/meta/project-governance.md
@@ -90,7 +90,7 @@ The community can expect the following:
   easier for maintainers to see that the contribution will not harm the overall
   project. Their contributions are documented in the git history and in the
   public issues. [Let us know](https://github.com/py-pdf/pypdf/discussions/798)
-  if you would appriciate something else!
+  if you would appreciate something else!
 * Every **community member** uses a respectful language. We are all human, we
   get upset about things we care and other things than what's visible on the
   internet go on in our live. pypdf does not pay its contributors - keep all

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -942,7 +942,7 @@ class PdfWriter(PdfDocCommon):
         Args:
             page: `PageObject` - references **PDF writer's page** where the
                 annotations and field data will be updated.
-                `List[Pageobject]` - provides list of page to be processsed.
+                `List[Pageobject]` - provides list of pages to be processed.
                 `None` - all pages.
             fields: a Python dictionary of field names (/T) and text
                 values (/V).


### PR DESCRIPTION
Most of them were found by `codespell` and `typos`.