### PR TITLE
DOC: Make code example more robust

### DIFF
--- a/docs/user/file-size.md
+++ b/docs/user/file-size.md
@@ -20,7 +20,8 @@ writer = PdfWriter()
 for page in reader.pages:
     writer.add_page(page)
 
-writer.add_metadata(reader.metadata)
+if reader.metadata is not None:
+    writer.add_metadata(reader.metadata)
 
 with open("smaller-new-file.pdf", "wb") as fp:
     writer.write(fp)


### PR DESCRIPTION
The example failed when a PDF file did not contain any metadata.