### PR TITLE
TST: simplify test_get_images

### DIFF
--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1432,4 +1432,9 @@ def test_invalid_index():
     reader = PdfReader(src_abs)
     with pytest.raises(TypeError):
         _ = reader.pages["0"]
+
+
+def test_negative_index():
+    src_abs = RESOURCE_ROOT / "git.pdf"
+    reader = PdfReader(src_abs)
     assert reader.pages[0] == reader.pages[-1]

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1425,3 +1425,10 @@ def test_missing_basefont_in_type3():
     name = "missing-base-font.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     reader.pages[0]._get_fonts()
+
+
+def test_invalid_index():
+    src_abs = RESOURCE_ROOT / "git.pdf"
+    reader = PdfReader(src_abs)
+    with pytest.raises(TypeError):
+        _ = reader.pages["0"]

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1432,3 +1432,4 @@ def test_invalid_index():
     reader = PdfReader(src_abs)
     with pytest.raises(TypeError):
         _ = reader.pages["0"]
+    assert reader.pages[0] == reader.pages[-1]

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -217,7 +217,7 @@ def test_get_outline(src, outline_elements):
         (SAMPLE_ROOT / "019-grayscale-image/grayscale-image.pdf", ["X0.png"]),
     ],
 )
-def test_get_images(src, expected_images):
+def test_get_images(src, expected_images, tmp_path):
     from PIL import Image
 
     src_abs = RESOURCE_ROOT / src
@@ -228,6 +228,8 @@ def test_get_images(src, expected_images):
     assert len(images_extracted) == len(expected_images)
     for image, expected_image in zip(images_extracted, expected_images):
         assert image.name == expected_image
+        with open(tmp_path / f"test-out-{image.name}", "wb") as fp:
+            fp.write(image.data)
         assert (
             image.name.split(".")[-1].upper()
             == Image.open(io.BytesIO(image.data)).format

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -228,8 +228,6 @@ def test_get_images(src, expected_images, tmp_path):
     assert len(images_extracted) == len(expected_images)
     for image, expected_image in zip(images_extracted, expected_images):
         assert image.name == expected_image
-        with open(tmp_path / f"test-out-{image.name}", "wb") as fp:
-            fp.write(image.data)
         assert (
             image.name.split(".")[-1].upper()
             == Image.open(io.BytesIO(image.data)).format

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -217,7 +217,7 @@ def test_get_outline(src, outline_elements):
         (SAMPLE_ROOT / "019-grayscale-image/grayscale-image.pdf", ["X0.png"]),
     ],
 )
-def test_get_images(src, expected_images, tmp_path):
+def test_get_images(src, expected_images):
     from PIL import Image
 
     src_abs = RESOURCE_ROOT / src

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -222,30 +222,16 @@ def test_get_images(src, expected_images):
 
     src_abs = RESOURCE_ROOT / src
     reader = PdfReader(src_abs)
-
-    with pytest.raises(TypeError):
-        page = reader.pages["0"]
-
-    page = reader.pages[-1]
     page = reader.pages[0]
-
     images_extracted = page.images
+
     assert len(images_extracted) == len(expected_images)
     for image, expected_image in zip(images_extracted, expected_images):
         assert image.name == expected_image
-        try:
-            fn = f"{src}-test-out-{image.name}"
-            with open(fn, "wb") as fp:
-                fp.write(image.data)
-                assert (
-                    image.name.split(".")[-1].upper()
-                    == Image.open(io.BytesIO(image.data)).format
-                )
-        finally:
-            try:
-                Path(fn).unlink()
-            except Exception:
-                pass
+        assert (
+            image.name.split(".")[-1].upper()
+            == Image.open(io.BytesIO(image.data)).format
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2428 

Imho, the test does too many things. Thus, instead of replacing with e.g. `txt_file_path fixture`, I removed things:
- write to file: The written file is never used. What was the reason to add it here in this test? -> Update: added back with `tmp_path`
- TypeError: does not seem to fit into this test -> Update: new test in test_page.py
