### PR TITLE
ENH: Create /Font if not exists (#2670)

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -836,19 +836,15 @@ class PdfWriter(PdfDocCommon):
 
         if "/Font" not in dr or not isinstance(dr["/Font"], DictionaryObject):
             dr[NameObject("/Font")] = DictionaryObject()
-
-        font_dict = dr["/Font"]
-
-        # Check if the specific font (e.g., Helvetica) is in /Font
-        font_name = NameObject("/Helvetica")
-        if font_name not in font_dict:
+            font_dict = dr["/Font"]
             font_entry = DictionaryObject({
                 NameObject("/Type"): NameObject("/Font"),
                 NameObject("/Subtype"): NameObject("/Type1"),
                 NameObject("/BaseFont"): NameObject("/Helvetica"),
                 NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
             })
-            font_dict[font_name] = font_entry
+            font_to_add = NameObject("/Helvetica")
+            font_dict[font_to_add] = font_entry
 
         dr = dr.get("/Font", DictionaryObject()).get_object()
         if font_name not in dr:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -833,6 +833,23 @@ class PdfWriter(PdfDocCommon):
                 ),
             ).get_object(),
         )
+
+        if "/Font" not in dr or not isinstance(dr["/Font"], DictionaryObject):
+            dr[NameObject("/Font")] = DictionaryObject()
+
+        font_dict = dr["/Font"]
+
+        # Check if the specific font (e.g., Helvetica) is in /Font
+        font_name = NameObject("/Helvetica")
+        if font_name not in font_dict:
+            font_entry = DictionaryObject({
+                NameObject("/Type"): NameObject("/Font"),
+                NameObject("/Subtype"): NameObject("/Type1"),
+                NameObject("/BaseFont"): NameObject("/Helvetica"),
+                NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
+            })
+            font_dict[font_name] = font_entry
+
         dr = dr.get("/Font", DictionaryObject()).get_object()
         if font_name not in dr:
             # ...or AcroForm dictionary

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -839,7 +839,7 @@ class PdfWriter(PdfDocCommon):
             font_dict = dr["/Font"]
             font_entry = DictionaryObject({
                 NameObject("/Type"): NameObject("/Font"),
-                NameObject("/Subtype"): NameObject("/Type1"),
+                NameObject("/Subtype"): NameObject("/TrueType"),
                 NameObject("/BaseFont"): NameObject("/Helvetica"),
                 NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
             })

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -44,6 +44,29 @@ RESOURCE_ROOT = PROJECT_ROOT / "resources"
 SAMPLE_ROOT = Path(PROJECT_ROOT) / "sample-files"
 GHOSTSCRIPT_BINARY = shutil.which("gs")
 
+def test_fill_form_without_font(pdf_file_path):
+    reader = PdfReader(RESOURCE_ROOT / "form.pdf")
+    writer = PdfWriter()
+
+    writer.append(reader, [0])
+    writer.append(RESOURCE_ROOT / "crazyones.pdf", [0])
+
+    writer.update_page_form_field_values(
+        writer.pages[0], {"foo": "some filled in text"}, flags=1
+    )
+
+    # check if no fields to fill in the page
+    writer.update_page_form_field_values(
+        writer.pages[1], {"foo": "some filled in text"}, flags=1
+    )
+
+    writer.update_page_form_field_values(
+        writer.pages[0], {"foo": "some filled in text"}
+    )
+
+    # write "output" to pypdf-output.pdf
+    with open(pdf_file_path, "wb") as output_stream:
+        writer.write(output_stream)
 
 def _get_write_target(convert) -> Any:
     target = convert
@@ -51,7 +74,6 @@ def _get_write_target(convert) -> Any:
         with NamedTemporaryFile(suffix=".pdf", delete=False) as temporary:
             target = temporary.name
     return target
-
 
 def test_writer_exception_non_binary(tmp_path, caplog):
     src = RESOURCE_ROOT / "pdflatex-outline.pdf"


### PR DESCRIPTION
Updates the _writer.py to create the /DR and /Font dictionaries, and add a font (Helvetica) if they don't exist. This enables filling out PDF forms.

Response to issue #2670 