### PR TITLE
STY: Consistency of spaces after period

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,13 +93,13 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
+# The theme to use for HTML and HTML Help pages. See the documentation for
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
+# further. For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
     "canonical_url": "",

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -514,7 +514,7 @@ class PdfReader(PdfDocCommon):
     def read_object_header(self, stream: StreamType) -> Tuple[int, int]:
         # Should never be necessary to read out whitespace, since the
         # cross-reference table should put us in the right spot to read the
-        # object header.  In reality... some files have stupid cross reference
+        # object header. In reality some files have stupid cross reference
         # tables that are off by whitespace bytes.
         extra = False
         skip_over_comment(stream)
@@ -736,8 +736,8 @@ class PdfReader(PdfDocCommon):
 
                 # On the other hand, some malformed PDF files
                 # use a single character EOL without a preceding
-                # space.  Detect that case, and seek the stream
-                # back one character.  (0-9 means we've bled into
+                # space. Detect that case, and seek the stream
+                # back one character (0-9 means we've bled into
                 # the next xref entry, t means we've bled into the
                 # text "trailer"):
                 if line[-1] in b"0123456789t":
@@ -896,7 +896,7 @@ class PdfReader(PdfDocCommon):
                 __name__,
             )
             return None
-        # bad xref character at startxref.  Let's see if we can find
+        # bad xref character at startxref. Let's see if we can find
         # the xref table nearby, as we've observed this error with an
         # off-by-one before.
         stream.seek(-11, 1)
@@ -1063,7 +1063,7 @@ class PdfReader(PdfDocCommon):
         owner password, and then stores the resulting decryption key if either
         password is correct.
 
-        It does not matter which password was matched.  Both passwords provide
+        It does not matter which password was matched. Both passwords provide
         the correct decryption key that will allow the document to be used with
         this library.
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -170,8 +170,8 @@ class PdfWriter(PdfDocCommon):
         pages.update(
             {
                 NameObject(PA.TYPE): NameObject("/Pages"),
-                NameObject(PA.COUNT): NumberObject(0),
                 NameObject(PA.KIDS): ArrayObject(),
+                NameObject(PA.COUNT): NumberObject(0),
             }
         )
         self._pages = self._add_object(pages)
@@ -749,7 +749,7 @@ class PdfWriter(PdfDocCommon):
 
         Args:
             reader: a PdfReader object from which to copy page
-                annotations to this writer object.  The writer's annots
+                annotations to this writer object. The writer's annots
                 will then be updated.
             after_page_append:
                 Callback function that is invoked after each page is appended to
@@ -1186,10 +1186,10 @@ class PdfWriter(PdfDocCommon):
             user_password: The password which allows for opening
                 and reading the PDF file with the restrictions provided.
             owner_password: The password which allows for
-                opening the PDF files without any restrictions.  By default,
+                opening the PDF files without any restrictions. By default,
                 the owner password is the same as the user password.
             use_128bit: flag as to whether to use 128bit
-                encryption.  When false, 40bit encryption will be used.
+                encryption. When false, 40bit encryption will be used.
                 By default, this flag is on.
             permissions_flag: permissions as described in
                 Table 3.20 of the PDF 1.7 specification. A bit value of 1 means
@@ -1413,7 +1413,7 @@ class PdfWriter(PdfDocCommon):
             # an array update the value
             if isinstance(parent, (DictionaryObject, ArrayObject)):
                 if isinstance(data, StreamObject):
-                    # a dictionary value is a stream.  streams must be indirect
+                    # a dictionary value is a stream; streams must be indirect
                     # objects, so we need to change this value.
                     data = self._resolve_indirect_object(self._add_object(data))
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -170,8 +170,8 @@ class PdfWriter(PdfDocCommon):
         pages.update(
             {
                 NameObject(PA.TYPE): NameObject("/Pages"),
-                NameObject(PA.KIDS): ArrayObject(),
                 NameObject(PA.COUNT): NumberObject(0),
+                NameObject(PA.KIDS): ArrayObject(),
             }
         )
         self._pages = self._add_object(pages)

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -557,8 +557,8 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 
     def get_original_bytes(self) -> bytes:
         # We're a text string object, but the library is trying to get our raw
-        # bytes.  This can happen if we auto-detected this string as text, but
-        # we were wrong.  It's pretty common.  Return the original bytes that
+        # bytes. This can happen if we auto-detected this string as text, but
+        # we were wrong. It's pretty common. Return the original bytes that
         # would have been used to create this object, based upon the autodetect
         # method.
         if self.autodetect_utf16:
@@ -574,8 +574,8 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
             raise Exception("no information about original bytes")  # pragma: no cover
 
     def get_encoded_bytes(self) -> bytes:
-        # Try to write the string out as a PDFDocEncoding encoded string.  It's
-        # nicer to look at in the PDF file.  Sadly, we take a performance hit
+        # Try to write the string out as a PDFDocEncoding encoded string. It's
+        # nicer to look at in the PDF file. Sadly, we take a performance hit
         # here for trying...
         try:
             if self.autodetect_utf16:

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -426,7 +426,7 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
 
         Returns:
           Returns a :class:`~pypdf.xmp.XmpInformation` instance
-          that can be used to access XMP metadata from the document.  Can also
+          that can be used to access XMP metadata from the document. Can also
           return None if no metadata was found on the document root.
         """
         from ..xmp import XmpInformation
@@ -1158,10 +1158,10 @@ class ContentStream(DecodedStreamObject):
                     operands = []
             elif peek == b"%":
                 # If we encounter a comment in the content stream, we have to
-                # handle it here.  Typically, read_object will handle
+                # handle it here. Typically, read_object will handle
                 # encountering a comment -- but read_object assumes that
                 # following the comment must be the object we're trying to
-                # read.  In this case, it could be an operator instead.
+                # read. In this case, it could be an operator instead.
                 while peek not in (b"\r", b"\n", b""):
                     peek = stream.read(1)
             else:

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -95,7 +95,7 @@ def read_string_from_stream(
                     tok = b_(chr(int(tok, base=8)))
                 elif tok in b"\n\r":
                     # This case is  hit when a backslash followed by a line
-                    # break occurs.  If it's a multi-char EOL, consume the
+                    # break occurs. If it's a multi-char EOL, consume the
                     # second character:
                     tok = stream.read(1)
                     if tok not in b"\n\r":

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -38,15 +38,15 @@ XMPMM_NAMESPACE = "http://ns.adobe.com/xap/1.0/mm/"
 # documented meaning.
 #
 # Elements in the namespace are key/value-style storage,
-# where the element name is the key and the content is the value.  The keys
+# where the element name is the key and the content is the value. The keys
 # are transformed into valid XML identifiers by substituting an invalid
 # identifier character with \u2182 followed by the unicode hex ID of the
-# original character.  A key like "my car" is therefore "my\u21820020car".
+# original character. A key like "my car" is therefore "my\u21820020car".
 #
 # \u2182 is the unicode character \u{ROMAN NUMERAL TEN THOUSAND}
 #
-# The pdfx namespace should be avoided.  A
-# custom data schema and sensical XML elements could be used instead, as is
+# The pdfx namespace should be avoided.
+# A custom data schema and sensical XML elements could be used instead, as is
 # suggested by Adobe's own documentation on XMP under "Extensibility of
 # Schemas".
 PDFX_NAMESPACE = "http://ns.adobe.com/pdfx/1.3/"


### PR DESCRIPTION
Remove two spaces after a period so everywhere one space is used. Also, in _writer.py initialize PA.KIDS before PA.COUNT to match PDF specification table order.