### PR TITLE
ROB: Handle images with empty data when processing an image from bytes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ history and [GitHub's 'Contributors' feature](https://github.com/py-pdf/pypdf/gr
 * [ediamondscience](https://github.com/ediamondscience)
 * [Ermeson, Felipe](https://github.com/FelipeErmeson)
 * [Freitag, François](https://github.com/francoisfreitag)
+* [Gagnon, William G.](https://github.com/williamgagnon)
 * [Górny, Michał](https://github.com/mgorny)
 * [Grillo, Miguel](https://github.com/Ineffable22)
 * [Gutteridge, David H.](https://github.com/dhgutteridge)

--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -6,7 +6,7 @@ from typing import Any, List, Tuple, Union, cast
 
 from ._utils import check_if_whitespace_only, logger_warning
 from .constants import ColorSpaces
-from .errors import PdfReadError
+from .errors import PdfReadError, EmptyImageDataError
 from .generic import (
     ArrayObject,
     DecodedStreamObject,
@@ -150,7 +150,7 @@ def _extended_image_frombytes(
         nb_pix = size[0] * size[1]
         data_length = len(data)
         if data_length == 0:
-            raise ValueError("Data is 0 bytes, cannot process an image from empty data.") from exc
+            raise EmptyImageDataError("Data is 0 bytes, cannot process an image from empty data.") from exc
         if data_length % nb_pix != 0:
             raise exc
         k = nb_pix * len(mode) / data_length

--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -6,7 +6,7 @@ from typing import Any, List, Tuple, Union, cast
 
 from ._utils import check_if_whitespace_only, logger_warning
 from .constants import ColorSpaces
-from .errors import PdfReadError, EmptyImageDataError
+from .errors import EmptyImageDataError, PdfReadError
 from .generic import (
     ArrayObject,
     DecodedStreamObject,

--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -148,9 +148,12 @@ def _extended_image_frombytes(
         img = Image.frombytes(mode, size, data)
     except ValueError as exc:
         nb_pix = size[0] * size[1]
-        if len(data) % nb_pix != 0:
+        data_length = len(data)
+        if data_length == 0:
+            raise ValueError("Data is 0 bytes, cannot process an image from empty data.") from exc
+        if data_length % nb_pix != 0:
             raise exc
-        k = nb_pix * len(mode) / len(data)
+        k = nb_pix * len(mode) / data_length
         data = b"".join([bytes((x,) * int(k)) for x in data])
         img = Image.frombytes(mode, size, data)
     return img

--- a/pypdf/errors.py
+++ b/pypdf/errors.py
@@ -59,4 +59,8 @@ class EmptyFileError(PdfReadError):
     """Raised when a PDF file is empty or has no content."""
 
 
+class EmptyImageDataError(PyPdfError):
+    """Raised when trying to process an image that has no data."""
+
+
 STREAM_TRUNCATED_PREMATURELY = "Stream has ended unexpectedly"

--- a/tests/test_xobject_image_helpers.py
+++ b/tests/test_xobject_image_helpers.py
@@ -4,7 +4,7 @@ from io import BytesIO
 import pytest
 
 from pypdf import PdfReader
-from pypdf._xobj_image_helpers import _handle_flate
+from pypdf._xobj_image_helpers import _handle_flate, _extended_image_frombytes
 from pypdf.errors import PdfReadError
 from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject
 
@@ -113,3 +113,12 @@ def test_handle_flate__image_mode_1():
             colors=2,
             obj_as_text="dummy",
         )
+
+
+def test_extended_image_frombytes_zero_data():
+    mode = "RGB"
+    size = (1, 1)
+    data = b""
+
+    with pytest.raises(ValueError, match="Data is 0 bytes, cannot process an image from empty data."):
+        _extended_image_frombytes(mode, size, data)

--- a/tests/test_xobject_image_helpers.py
+++ b/tests/test_xobject_image_helpers.py
@@ -7,7 +7,6 @@ from pypdf import PdfReader
 from pypdf._xobj_image_helpers import _handle_flate, _extended_image_frombytes
 from pypdf.errors import PdfReadError
 from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject
-
 from . import get_data_from_url
 
 

--- a/tests/test_xobject_image_helpers.py
+++ b/tests/test_xobject_image_helpers.py
@@ -5,7 +5,7 @@ import pytest
 
 from pypdf import PdfReader
 from pypdf._xobj_image_helpers import _handle_flate, _extended_image_frombytes
-from pypdf.errors import PdfReadError
+from pypdf.errors import PdfReadError, EmptyImageDataError
 from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject
 from . import get_data_from_url
 
@@ -119,5 +119,5 @@ def test_extended_image_frombytes_zero_data():
     size = (1, 1)
     data = b""
 
-    with pytest.raises(ValueError, match="Data is 0 bytes, cannot process an image from empty data."):
+    with pytest.raises(EmptyImageDataError, match="Data is 0 bytes, cannot process an image from empty data."):
         _extended_image_frombytes(mode, size, data)

--- a/tests/test_xobject_image_helpers.py
+++ b/tests/test_xobject_image_helpers.py
@@ -4,9 +4,10 @@ from io import BytesIO
 import pytest
 
 from pypdf import PdfReader
-from pypdf._xobj_image_helpers import _handle_flate, _extended_image_frombytes
-from pypdf.errors import PdfReadError, EmptyImageDataError
+from pypdf._xobj_image_helpers import _extended_image_frombytes, _handle_flate
+from pypdf.errors import EmptyImageDataError, PdfReadError
 from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject
+
 from . import get_data_from_url
 
 


### PR DESCRIPTION
When extracting an image that contains no data, a `ZeroDivisionError` is thrown in the except block of the `_extended_image_frombytes` method.

This PR adds a check for that specific situation and raises a ValueError when it arises.