### PR TITLE
MAINT: remove unused code

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -33,6 +33,7 @@ from io import BytesIO, UnsupportedOperation
 from pathlib import Path
 from types import TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -47,7 +48,6 @@ from typing import (
 
 from ._doc_common import PdfDocCommon, convert_to_int
 from ._encryption import Encryption, PasswordType
-from ._page import PageObject
 from ._utils import (
     StrByteType,
     StreamType,
@@ -81,6 +81,9 @@ from .generic import (
     read_object,
 )
 from .xmp import XmpInformation
+
+if TYPE_CHECKING:
+    from ._page import PageObject
 
 
 class PdfReader(PdfDocCommon):
@@ -272,22 +275,6 @@ class PdfReader(PdfDocCommon):
             return cast(XmpInformation, self.root_object.xmp_metadata)
         finally:
             self._override_encryption = False
-
-    def _get_page(self, page_number: int) -> PageObject:
-        """
-        Retrieve a page by number from this PDF file.
-
-        Args:
-            page_number: The page number to retrieve
-                (pages begin at zero)
-
-        Returns:
-            A :class:`PageObject<pypdf._page.PageObject>` instance.
-        """
-        if self.flattened_pages is None:
-            self._flatten()
-        assert self.flattened_pages is not None, "hint for mypy"
-        return self.flattened_pages[page_number]
 
     def _get_page_number_by_indirect(
         self, indirect_reference: Union[None, int, NullObject, IndirectObject]

--- a/tests/example_files.yaml
+++ b/tests/example_files.yaml
@@ -13,17 +13,17 @@
 - local_filename: The%20lean%20times%20in%20the%20Peruvian%20economy.pdf
   url: https://github.com/alexanderquispe/1REI05/raw/main/reports/report_1/The%20lean%20times%20in%20the%20Peruvian%20economy.pdf
 - local_filename: tika-908104.pdf
-  url: https://github.com/user-attachments/files/16676292/tika-908104.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/908/908104.pdf
 - local_filename: tika-923406.pdf
-  url: https://github.com/user-attachments/files/16676293/tika-923406.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/923/923406.pdf
 - local_filename: tika-955562.pdf
-  url: https://github.com/user-attachments/files/16676295/tika-955562.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/955/955562.pdf
 - local_filename: tika-959173.pdf
-  url: https://github.com/user-attachments/files/16676297/tika-959173.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/959/959173.pdf
 - local_filename: waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf
   url: https://github.com/py-pdf/pypdf/files/10773829/waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf
 - local_filename: tika-957144.pdf
-  url: https://github.com/user-attachments/files/16676308/tika-957144.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/957/957144.pdf
 - local_filename: ascii charset.pdf
   url: https://github.com/py-pdf/pypdf/files/9472500/main.pdf
 - local_filename: cmap1370.pdf
@@ -49,19 +49,21 @@
 - local_filename: NewJersey.pdf
   url: https://github.com/py-pdf/pypdf/files/12090692/New.Jersey.Coinbase.staking.securities.charges.2023-0606_Coinbase-Penalty-and-C-D.pdf
 - local_filename: tika-952445.pdf
-  url: https://github.com/user-attachments/files/16676335/tika-952445.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/952/952445.pdf
 - local_filename: tika-921632.pdf
-  url: https://github.com/user-attachments/files/16676334/tika-921632.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/921/921632.pdf
 - local_filename: tika-976970.pdf
-  url: https://github.com/user-attachments/files/16676340/tika-976970.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/976/976970.pdf
 - local_filename: tika-914102.pdf
-  url: https://github.com/user-attachments/files/16676352/tika-914102.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/914/914102.pdf
 - local_filename: iss1737.pdf
   url: https://github.com/py-pdf/pypdf/files/11068604/tt1.pdf
 - local_filename: issue-1801.pdf
   url: https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf
 - local_filename: tika-924546.pdf
-  url: https://github.com/user-attachments/files/16676366/tika-924546.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf
+- local_filename: tika-924546.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf
 - local_filename: issue-1801.png
   url: https://user-images.githubusercontent.com/1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png
 - local_filename: grimm10
@@ -73,11 +75,11 @@
 - local_filename: watermark1.png
   url: https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png
 - local_filename: tika-977609.pdf
-  url: https://github.com/user-attachments/files/16676477/tika-977609.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf
 - local_filename: tifimage.png
   url: https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png
 - local_filename: tika-972174.pdf
-  url: https://github.com/user-attachments/files/16676369/tika-972174.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf
 - local_filename: tika-972174_p0-im0.png
   url: https://user-images.githubusercontent.com/4083478/238288207-b77dd38c-34b4-4f4f-810a-bf9db7ca0414.png
 - local_filename: Vitocal.pdf
@@ -102,6 +104,8 @@
   url: https://github.com/py-pdf/pypdf/files/12144094/im1.png.txt
 - local_filename: iss1982_im2.png
   url: https://github.com/py-pdf/pypdf/files/12144093/im2.png.txt
+- local_filename: tika-972174.pdf
+  url: https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf
 - local_filename: usa.png
   url: https://github.com/py-pdf/pypdf/assets/4083478/56c93021-33cd-4387-ae13-5cbe7e673f42
 - local_filename: paid.pdf

--- a/tests/example_files.yaml
+++ b/tests/example_files.yaml
@@ -13,17 +13,17 @@
 - local_filename: The%20lean%20times%20in%20the%20Peruvian%20economy.pdf
   url: https://github.com/alexanderquispe/1REI05/raw/main/reports/report_1/The%20lean%20times%20in%20the%20Peruvian%20economy.pdf
 - local_filename: tika-908104.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/908/908104.pdf
+  url: https://github.com/user-attachments/files/16676292/tika-908104.pdf
 - local_filename: tika-923406.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/923/923406.pdf
+  url: https://github.com/user-attachments/files/16676293/tika-923406.pdf
 - local_filename: tika-955562.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/955/955562.pdf
+  url: https://github.com/user-attachments/files/16676295/tika-955562.pdf
 - local_filename: tika-959173.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/959/959173.pdf
+  url: https://github.com/user-attachments/files/16676297/tika-959173.pdf
 - local_filename: waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf
   url: https://github.com/py-pdf/pypdf/files/10773829/waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf
 - local_filename: tika-957144.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/957/957144.pdf
+  url: https://github.com/user-attachments/files/16676308/tika-957144.pdf
 - local_filename: ascii charset.pdf
   url: https://github.com/py-pdf/pypdf/files/9472500/main.pdf
 - local_filename: cmap1370.pdf
@@ -49,21 +49,19 @@
 - local_filename: NewJersey.pdf
   url: https://github.com/py-pdf/pypdf/files/12090692/New.Jersey.Coinbase.staking.securities.charges.2023-0606_Coinbase-Penalty-and-C-D.pdf
 - local_filename: tika-952445.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/952/952445.pdf
+  url: https://github.com/user-attachments/files/16676335/tika-952445.pdf
 - local_filename: tika-921632.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/921/921632.pdf
+  url: https://github.com/user-attachments/files/16676334/tika-921632.pdf
 - local_filename: tika-976970.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/976/976970.pdf
+  url: https://github.com/user-attachments/files/16676340/tika-976970.pdf
 - local_filename: tika-914102.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/914/914102.pdf
+  url: https://github.com/user-attachments/files/16676352/tika-914102.pdf
 - local_filename: iss1737.pdf
   url: https://github.com/py-pdf/pypdf/files/11068604/tt1.pdf
 - local_filename: issue-1801.pdf
   url: https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf
 - local_filename: tika-924546.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf
-- local_filename: tika-924546.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf
+  url: https://github.com/user-attachments/files/16676366/tika-924546.pdf
 - local_filename: issue-1801.png
   url: https://user-images.githubusercontent.com/1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png
 - local_filename: grimm10
@@ -75,11 +73,11 @@
 - local_filename: watermark1.png
   url: https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png
 - local_filename: tika-977609.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf
+  url: https://github.com/user-attachments/files/16676477/tika-977609.pdf
 - local_filename: tifimage.png
   url: https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png
 - local_filename: tika-972174.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf
+  url: https://github.com/user-attachments/files/16676369/tika-972174.pdf
 - local_filename: tika-972174_p0-im0.png
   url: https://user-images.githubusercontent.com/4083478/238288207-b77dd38c-34b4-4f4f-810a-bf9db7ca0414.png
 - local_filename: Vitocal.pdf
@@ -104,8 +102,6 @@
   url: https://github.com/py-pdf/pypdf/files/12144094/im1.png.txt
 - local_filename: iss1982_im2.png
   url: https://github.com/py-pdf/pypdf/files/12144093/im2.png.txt
-- local_filename: tika-972174.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf
 - local_filename: usa.png
   url: https://github.com/py-pdf/pypdf/assets/4083478/56c93021-33cd-4387-ae13-5cbe7e673f42
 - local_filename: paid.pdf

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -434,7 +434,7 @@ def test_get_form(src, expected, expected_get_fields, txt_file_path):
 def test_get_page_number(src, page_number):
     src = RESOURCE_ROOT / src
     reader = PdfReader(src)
-    reader._get_page(0)
+    reader.get_page(0)
     page = reader.pages[page_number]
     assert reader.get_page_number(page) == page_number
 


### PR DESCRIPTION
remove _get_page from reader which is redundant with get_page
faced again some issues with a broken link from tika. Replace them with github links.