### PR TITLE
ROB: Raise PdfReadError when missing /Root in trailer.

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -190,7 +190,10 @@ class PdfReader(PdfDocCommon):
     @property
     def root_object(self) -> DictionaryObject:
         """Provide access to "/Root". Standardized with PdfWriter."""
-        return cast(DictionaryObject, self.trailer[TK.ROOT].get_object())
+        root = self.trailer[TK.ROOT]
+        if root is None:
+            raise PdfReadError('Cannot find "/Root" key in trailer')
+        return cast(DictionaryObject, root.get_object())
 
     @property
     def _info(self) -> Optional[DictionaryObject]:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -607,9 +607,9 @@ def test_read_unknown_zero_pages(caplog):
         "startxref on same line as offset",
     ]
     assert normalize_warnings(caplog.text) == warnings
-    with pytest.raises(AttributeError) as exc:
+    with pytest.raises(PdfReadError) as exc:
         len(reader.pages)
-    assert exc.value.args[0] == "'NoneType' object has no attribute 'get_object'"
+    assert exc.value.args[0] == 'Cannot find "/Root" key in trailer'
 
 
 def test_read_encrypted_without_decryption():


### PR DESCRIPTION
Fixes #2806.

When running the same code as described in #2806 with the same PDF, now this happens:
```python
>>> list(reader.pages)
Object 493 0 not defined.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/pypdf/pypdf/_page.py", line 2356, in __len__
    return self.length_function()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/pypdf/pypdf/_doc_common.py", line 352, in get_num_pages
    self._flatten()
  File "/pypdf/pypdf/_doc_common.py", line 1100, in _flatten
    catalog = self.root_object
              ^^^^^^^^^^^^^^^^
  File "/pypdf/pypdf/_reader.py", line 195, in root_object
    raise PdfReadError('Cannot find "/Root" key in trailer')
pypdf.errors.PdfReadError: Cannot find "/Root" key in trailer

```