### PR TITLE
ROB: robustify .set_data()

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1013,10 +1013,12 @@ class EncodedStreamObject(StreamObject):
     def set_data(self, data: bytes) -> None:  # deprecated
         from ..filters import FlateDecode
 
-        if self.get(SA.FILTER, "") == FT.FLATE_DECODE:
+        if self.get(SA.FILTER, "") in (FT.FLATE_DECODE, [FT.FLATE_DECODE]):
             if not isinstance(data, bytes):
                 raise TypeError("data must be bytes")
-            assert self.decoded_self is not None
+            if self.decoded_self is None:
+                self.get_data()  # to create self.decoded_self
+            assert self.decoded_self is not None, "mypy"
             self.decoded_self.set_data(data)
             super().set_data(FlateDecode.encode(data))
         else:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1327,6 +1327,22 @@ def test_encodedstream_set_data():
 
 
 @pytest.mark.enable_socket()
+def test_set_data_2():
+    """
+    Modify a stream not yet loaded and
+    where the filter is ["/FlateDecode"]
+    """
+    url = "https://github.com/user-attachments/files/16796095/f5471sm-2.pdf"
+    name = "iss2780.pdf"
+    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer.root_object["/AcroForm"]["/XFA"][7].set_data(b"test")
+    assert writer.root_object["/AcroForm"]["/XFA"][7].get_object()["/Filter"] == [
+        "/FlateDecode"
+    ]
+    assert writer.root_object["/AcroForm"]["/XFA"][7].get_object().get_data() == b"test"
+
+
+@pytest.mark.enable_socket()
 def test_calling_indirect_objects():
     """Cope with cases where attributes/items are called from indirectObject"""
     url = "https://github.com/user-attachments/files/15605648/2021_book_security.pdf"


### PR DESCRIPTION
cope with objects where the filter is ["/FlateDecode"] and/or which data has not been read yet