### PR TITLE
TST: update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ package = "./pypdf"
 exclude = [".github/*", "docs/*", "resources/*", "sample-files/*", "sample-files/.github/*", "sample-files/.gitignore", "sample-files/.pre-commit-config.yaml",  "requirements/*", "tests/*", ".flake8", ".gitignore", ".gitmodules", ".pylintrc", "tox.ini", "make_release.py", "mutmut-test.sh", ".pre-commit-config.yaml", ".gitblame-ignore-revs", "Makefile", "mutmut_config.py"]
 
 [tool.pytest.ini_options]
-addopts = "--disable-socket"
+addopts = "-m 'not enable_socket'"
 filterwarnings = ["error"]
 markers = [
     "slow: Test which require more than a second",


### PR DESCRIPTION
addopts = "--disable-socket" did not work as it should. update addopts to "-m 'not enable_socket'" to skip failing cases brought by FileNotFoundError.

now by default, simply run 'pytest' (as suggested by README) will not encounter slow and FileNotFoundError cases. 