### PR TITLE
BUG: test_image_without_pillow cannot find pypdf

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -248,6 +248,7 @@ def test_issue_399():
 
 @pytest.mark.enable_socket()
 def test_image_without_pillow(tmp_path):
+    import os
     name = "tika-914102.pdf"
     pdf_path = Path(__file__).parent / "pdf_cache" / name
     pdf_path_str = str(pdf_path.resolve()).replace("\\", "/")
@@ -273,9 +274,15 @@ for page in reader.pages:
     ), exc.value.args[0]
 """
     )
+    env = os.environ.copy()
+    try:
+        env["PYTHONPATH"] = "." + os.pathsep + env["PYTHONPATH"]
+    except KeyError:
+        env["PYTHONPATH"] = "."
     result = subprocess.run(
         [shutil.which("python"), source_file],  # noqa: S603
         capture_output=True,
+        env=env,
     )
     assert result.returncode == 0
     assert result.stdout == b""


### PR DESCRIPTION
test_image_without_pillow runs a generated script which causes the Python path to exclude the current directory.  The generated script tries to import pypdf and either cannot find it or it finds the version in pyenv instead of the version being tested.  Add "." to PYTHONPATH so the correct version of pypdf is used.

Closes #2849