### PR TITLE
MAINT: New LZW decoding implementation

### DIFF
--- a/pypdf/_codecs/_codecs.py
+++ b/pypdf/_codecs/_codecs.py
@@ -235,7 +235,7 @@ class LzwCodec(Codec):
                     self._add_entry_decode(self.decoding_table[old_code], string[0])
                 old_code = code
             else:
-                # The code not in the table and not one of the special codes
+                # The code is not in the table and not one of the special codes
                 string = (
                     self.decoding_table[old_code] + self.decoding_table[old_code][:1]
                 )

--- a/pypdf/_codecs/_codecs.py
+++ b/pypdf/_codecs/_codecs.py
@@ -139,35 +139,6 @@ class LzwCodec(Codec):
 
         return bytes(output)
 
-    def _next_code_encode(self, data: bytes) -> int:
-        self.bitpos: int
-        self._next_bits: int
-
-        fillbits = self.bits_per_code
-        value = 0
-
-        while fillbits > 0:
-            if self._byte_pointer >= len(data):
-                return -1
-
-            nextbits = data[self._byte_pointer]
-            bits_available = 8 - self.bitpos
-            bits_to_use = min(bits_available, fillbits)
-
-            value |= (
-                (nextbits >> (8 - self.bitpos - bits_to_use))
-                & (0xFF >> (8 - bits_to_use))
-            ) << (fillbits - bits_to_use)
-
-            fillbits -= bits_to_use
-            self.bitpos += bits_to_use
-
-            if self.bitpos == 8:
-                self.bitpos = 0
-                self._byte_pointer += 1
-
-        return value
-
     def _initialize_decoding_table(self) -> None:
         self.decoding_table = [bytes([i]) for i in range(self.CLEAR_TABLE_MARKER)] + [
             b""

--- a/pypdf/_codecs/_codecs.py
+++ b/pypdf/_codecs/_codecs.py
@@ -165,6 +165,37 @@ class LzwCodec(Codec):
         except IndexError:
             return self.EOD_MARKER
 
+    # The following method has been converted to Python from PDFsharp:
+    # https://github.com/empira/PDFsharp/blob/5fbf6ed14740bc4e16786816882d32e43af3ff5d/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Filters/LzwDecode.cs
+    #
+    # Original license:
+    #
+    # -------------------------------------------------------------------------
+    # Copyright (c) 2001-2024 empira Software GmbH, Troisdorf (Cologne Area),
+    # Germany
+    #
+    # http://docs.pdfsharp.net
+    #
+    # MIT License
+    #
+    # Permission is hereby granted, free of charge, to any person obtaining a
+    # copy of this software and associated documentation files (the "Software"),
+    # to deal in the Software without restriction, including without limitation
+    # the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    # and/or sell copies of the Software, and to permit persons to whom the
+    # Software is furnished to do so, subject to the following conditions:
+    #
+    # The above copyright notice and this permission notice shall be included
+    # in all copies or substantial portions of the Software.
+    #
+    # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    # DEALINGS IN THE SOFTWARE.
+    # --------------------------------------------------------------------------
     def decode(self, data: bytes) -> bytes:
         """
         The following code was converted to Python from the following code:

--- a/pypdf/_codecs/_codecs.py
+++ b/pypdf/_codecs/_codecs.py
@@ -206,9 +206,6 @@ class LzwCodec(Codec):
         self._next_data = 0
         self._next_bits = 0
 
-        if data[0] == 0x00 and data[1] == 0x01:
-            raise Exception("LZW flavor not supported.")
-
         output_stream = io.BytesIO()
 
         self._initialize_decoding_table()

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -388,6 +388,7 @@ class LZWDecode:
             http://www.rasip.fer.hr/research/compress/algorithms/fund/lz/lzw.html
 
             and the PDFReference
+
             Raises:
               PdfReadError: If the stop code is missing
             """

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -366,12 +366,6 @@ class RunLengthDecode:
 
 
 class LZWDecode:
-    """
-    Taken from:
-
-    https://github.com/katjas/PDFrenderer/blob/master/src/com/sun/pdfview/decode/LZWDecode.java
-    """
-
     class Decoder:
         STOP = 257
         CLEARDICT = 256
@@ -380,18 +374,6 @@ class LZWDecode:
             self.data = data
 
         def decode(self) -> bytes:
-            """
-            TIFF 6.0 specification explains in sufficient details the steps to
-            implement the LZW encode() and decode() algorithms.
-
-            algorithm derived from:
-            http://www.rasip.fer.hr/research/compress/algorithms/fund/lz/lzw.html
-
-            and the PDFReference
-
-            Raises:
-              PdfReadError: If the stop code is missing
-            """
             return LzwCodec().decode(self.data)
 
     @staticmethod

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -368,6 +368,7 @@ class RunLengthDecode:
 class LZWDecode:
     """
     Taken from:
+
     https://github.com/katjas/PDFrenderer/blob/master/src/com/sun/pdfview/decode/LZWDecode.java
     """
 
@@ -382,8 +383,10 @@ class LZWDecode:
             """
             TIFF 6.0 specification explains in sufficient details the steps to
             implement the LZW encode() and decode() algorithms.
+
             algorithm derived from:
             http://www.rasip.fer.hr/research/compress/algorithms/fund/lz/lzw.html
+
             and the PDFReference
             Raises:
               PdfReadError: If the stop code is missing

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -41,7 +41,7 @@ from base64 import a85decode
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
-from ._codecs._codecs import LzwCodec
+from ._codecs._codecs import LzwCodec as _LzwCodec
 from ._utils import (
     WHITESPACES_AS_BYTES,
     deprecate,
@@ -374,7 +374,7 @@ class LZWDecode:
             self.data = data
 
         def decode(self) -> bytes:
-            return LzwCodec().decode(self.data)
+            return _LzwCodec().decode(self.data)
 
     @staticmethod
     def _decodeb(
@@ -624,7 +624,7 @@ def decode_stream_data(stream: Any) -> bytes:  # utils.StreamObject
             elif filter_type in (FT.RUN_LENGTH_DECODE, FTA.RL):
                 data = RunLengthDecode.decode(data)
             elif filter_type in (FT.LZW_DECODE, FTA.LZW):
-                data = LzwCodec().decode(data)
+                data = LZWDecode._decodeb(data, params)
             elif filter_type in (FT.ASCII_85_DECODE, FTA.A85):
                 data = ASCII85Decode.decode(data)
             elif filter_type == FT.DCT_DECODE:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -41,3 +41,18 @@ def test_encode_lzw(plain, expected_encoded):
     codec = LzwCodec()
     actual_encoded = codec.encode(plain)
     assert actual_encoded == expected_encoded
+
+
+@pytest.mark.parametrize(
+    ("encoded", "expected_decoded"),
+    [
+        # _pack_codes_into_bytes([256, 65, 66, 67, 68, 256, 256, 69, 70, 71, 72, 257])
+        (b"\x80\x10HD2$\x02\x00E#\x11\xc9\x10\x10", b"ABCDEFGH", id="Clear twice"),
+        # _pack_codes_into_bytes([65, 66, 67, 68, 257])
+        (b" \x90\x88dH\x08", b"ABCD", id="No explicit initial clear marker"),
+    ],
+)
+def test_decode_lzw(encoded, expected_decoded):
+    codec = LzwCodec()
+    actual_decoded = codec.encode(encoded)
+    assert actual_decoded == expected_decoded

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -47,9 +47,9 @@ def test_encode_lzw(plain, expected_encoded):
     ("encoded", "expected_decoded"),
     [
         # _pack_codes_into_bytes([256, 65, 66, 67, 68, 256, 256, 69, 70, 71, 72, 257])
-        (b"\x80\x10HD2$\x02\x00E#\x11\xc9\x10\x10", b"ABCDEFGH", id="Clear twice"),
+        (b"\x80\x10HD2$\x02\x00E#\x11\xc9\x10\x10", b"ABCDEFGH"),  # Clear twice.
         # _pack_codes_into_bytes([65, 66, 67, 68, 257])
-        (b" \x90\x88dH\x08", b"ABCD", id="No explicit initial clear marker"),
+        (b" \x90\x88dH\x08", b"ABCD"),  # No explicit initial clear marker.
     ],
 )
 def test_decode_lzw(encoded, expected_decoded):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -54,5 +54,5 @@ def test_encode_lzw(plain, expected_encoded):
 )
 def test_decode_lzw(encoded, expected_decoded):
     codec = LzwCodec()
-    actual_decoded = codec.encode(encoded)
+    actual_decoded = codec.decode(encoded)
     assert actual_decoded == expected_decoded

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -235,9 +235,7 @@ def test_decompress_zlib_error(caplog):
 def test_lzw_decode_neg1():
     reader = PdfReader(BytesIO(get_data_from_url(name="tika-921632.pdf")))
     page = reader.pages[47]
-    with pytest.raises(PdfReadError) as exc:
-        page.extract_text()
-    assert exc.value.args[0] == "Missed the stop code in LZWDecode!"
+    assert page.extract_text().startswith("Chapter 2")
 
 
 @pytest.mark.enable_socket()
@@ -249,6 +247,7 @@ def test_issue_399():
 @pytest.mark.enable_socket()
 def test_image_without_pillow(tmp_path):
     import os
+
     name = "tika-914102.pdf"
     pdf_path = Path(__file__).parent / "pdf_cache" / name
     pdf_path_str = str(pdf_path.resolve()).replace("\\", "/")


### PR DESCRIPTION
The basis for this implementation is https://github.com/empira/PDFsharp/blob/master/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Filters/LzwDecode.cs (MIT licensed)

As this removes the `LZWDecode` class from a public module, we have to do a major release when we release this change.