### PR TITLE
BUG: Line breaks are not generated due to incorrect calculation at the text leading

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1965,7 +1965,6 @@ class PageObject(DictionaryObject):
             elif operator == b"Tw":
                 space_scale = 1.0 + float(operands[0])
             elif operator == b"TL":
-                check_crlf_space = True
                 scale_x = math.sqrt(tm_matrix[0]**2 + tm_matrix[2]**2)
                 TL = float(operands[0]) * font_size * scale_x
             elif operator == b"Tf":

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1965,7 +1965,9 @@ class PageObject(DictionaryObject):
             elif operator == b"Tw":
                 space_scale = 1.0 + float(operands[0])
             elif operator == b"TL":
-                TL = float(operands[0])
+                check_crlf_space = True
+                scale_x = math.sqrt(tm_matrix[0]**2 + tm_matrix[2]**2)
+                TL = float(operands[0]) * font_size * scale_x
             elif operator == b"Tf":
                 if text != "":
                     output += text  # .translate(cmap)

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -211,3 +211,11 @@ def test_space_position_calculation():
     page = reader.pages[3]
     extracted = page.extract_text()
     assert "Shortly after the Geneva BOF session, the" in extracted
+
+
+def test_text_leading_height_unit():
+    """Tests for #2262"""
+    reader = PdfReader(RESOURCE_ROOT / "toy.pdf")
+    page = reader.pages[0]
+    extracted = page.extract_text()
+    assert "Something[cited]\n" in extracted


### PR DESCRIPTION
Close #2262

Due to file copyright issues, I found a similar file in RESOURCE.

As far as I can confirm, there seem to be other problems with the file output, but I think there are no problems when checking this issue.