### PR TITLE
BUG: The font list order of pypdf.annotations.FreeText is different(#1435)

### DIFF
--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -103,12 +103,17 @@ class FreeText(MarkupAnnotation):
         self[NameObject("/Subtype")] = NameObject("/FreeText")
         self[NameObject("/Rect")] = RectangleObject(rect)
 
+        # Table 225 of the 1.7 reference ("CSS2 style attributes used in rich text strings")
         font_str = "font: "
-        if bold:
-            font_str = f"{font_str}bold "
         if italic:
             font_str = f"{font_str}italic "
-        font_str = f"{font_str}{font} {font_size}"
+        else:
+            font_str = f"{font_str}normal "
+        if bold:
+            font_str = f"{font_str}bold "
+        else:
+            font_str = f"{font_str}normal "
+        font_str = f"{font_str}{font_size} {font}"
         font_str = f"{font_str};text-align:left;color:#{font_color}"
 
         default_appearance_string = ""

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -93,6 +93,24 @@ def test_text_annotation(pdf_file_path):
 
 
 def test_free_text_annotation(pdf_file_path):
+    free_text_annotation = FreeText(
+        text="Hello World",
+        rect=(0, 0, 0, 0),
+    )
+    assert free_text_annotation["/DS"] == "font: normal normal 14pt Helvetica;text-align:left;color:#000000"
+    free_text_annotation = FreeText(
+        text="Hello World",
+        rect=(50, 550, 200, 650),
+        font="Arial",
+        bold=True,
+        italic=True,
+        font_size="20pt",
+        font_color="00ff00",
+        border_color=None,
+        background_color=None,
+    )
+    assert free_text_annotation["/DS"] == "font: italic bold 20pt Arial;text-align:left;color:#00ff00"
+
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -93,24 +93,6 @@ def test_text_annotation(pdf_file_path):
 
 
 def test_free_text_annotation(pdf_file_path):
-    free_text_annotation = FreeText(
-        text="Hello World",
-        rect=(0, 0, 0, 0),
-    )
-    assert free_text_annotation["/DS"] == "font: normal normal 14pt Helvetica;text-align:left;color:#000000"
-    free_text_annotation = FreeText(
-        text="Hello World",
-        rect=(50, 550, 200, 650),
-        font="Arial",
-        bold=True,
-        italic=True,
-        font_size="20pt",
-        font_color="00ff00",
-        border_color=None,
-        background_color=None,
-    )
-    assert free_text_annotation["/DS"] == "font: italic bold 20pt Arial;text-align:left;color:#00ff00"
-
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)
@@ -148,6 +130,26 @@ def test_free_text_annotation(pdf_file_path):
     # Assert: You need to inspect the file manually
     with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
+
+
+def test_free_text_annotation__font_specifier():
+    free_text_annotation = FreeText(
+        text="Hello World",
+        rect=(0, 0, 0, 0),
+    )
+    assert free_text_annotation["/DS"] == "font: normal normal 14pt Helvetica;text-align:left;color:#000000"
+    free_text_annotation = FreeText(
+        text="Hello World",
+        rect=(50, 550, 200, 650),
+        font="Arial",
+        bold=True,
+        italic=True,
+        font_size="20pt",
+        font_color="00ff00",
+        border_color=None,
+        background_color=None,
+    )
+    assert free_text_annotation["/DS"] == "font: italic bold 20pt Arial;text-align:left;color:#00ff00"
 
 
 def test_annotationdictionary():


### PR DESCRIPTION
Close #1435

The order of the list was different.
![image](https://github.com/user-attachments/assets/931cf8f4-3bfd-4ac6-8f98-a153f2e9928d)

It seems difficult to obtain the actual font size etc. Is it necessary to test?
