### PR TITLE
Introducing pypdf Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install pypdf[crypto]
 ```
 
 > **NOTE**: `pypdf` 3.1.0 and above include significant improvements compared to
-guide](https://pypdf.readthedocs.io/en/latest/user/migration-1-to-2.html) for
+> previous versions. Please refer to [the migration
 > guide](https://pypdf.readthedocs.io/en/latest/user/migration-1-to-2.html) for
 > more information.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/-documentation-green)](https://pypdf.readthedocs.io/en/stable/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/py-pdf/pypdf)](https://github.com/py-pdf/pypdf)
 [![codecov](https://codecov.io/gh/py-pdf/pypdf/branch/main/graph/badge.svg?token=id42cGNZ5Z)](https://codecov.io/gh/py-pdf/pypdf)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20pypdf%20Guru-006BFF)](https://gurubase.io/g/pypdf)
 
 # pypdf
 
@@ -35,7 +36,7 @@ pip install pypdf[crypto]
 ```
 
 > **NOTE**: `pypdf` 3.1.0 and above include significant improvements compared to
-> previous versions. Please refer to [the migration
+guide](https://pypdf.readthedocs.io/en/latest/user/migration-1-to-2.html) for
 > guide](https://pypdf.readthedocs.io/en/latest/user/migration-1-to-2.html) for
 > more information.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [pypdf Guru](https://gurubase.io/g/pypdf) to Gurubase. pypdf Guru uses the data from this repo and data from the [docs](https://pypdf.readthedocs.io/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "pypdf Guru", which highlights that pypdf now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable pypdf Guru in Gurubase, just let me know that's totally fine.
