### PR TITLE
ROB: Fix infinite loop case when reading null objects within an Array

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1452,7 +1452,6 @@ def read_object(
     elif tok == b"(":
         return read_string_from_stream(stream, forced_encoding)
     elif tok == b"e" and stream.read(6) == b"endobj":
-        stream.seek(-6, 1)
         return NullObject()
     elif tok == b"n":
         return NullObject.read_from_stream(stream)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -312,6 +312,15 @@ def test_read_object_empty():
     assert isinstance(read_object(stream, pdf), NullObject)
 
 
+def test_read_object_empty_in_array():
+    stream = BytesIO(b"[endobj")
+    pdf = None
+    result = read_object(stream, pdf)
+    assert isinstance(result, ArrayObject)
+    assert len(result) == 1
+    assert isinstance(result[0], NullObject)
+
+
 def test_read_object_invalid():
     stream = BytesIO(b"hello")
     pdf = None


### PR DESCRIPTION
Found some PDFs in the wild where instantiating a PdfReader object would fail due to an infinite loop regarding this case.

The PDFs themselves were corrupted. Other programs I tested them with such as Mac Preview and poppler pdftotext would error out. But it would be best to not infinite loop and use up all system memory when attempting to load them.