### PR TITLE
ENH: Adding support for reading .metadata.keywords

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -243,6 +243,21 @@ class DocumentInformation(DictionaryObject):
         """
         return self.get(DI.MOD_DATE)
 
+    @property
+    def keywords(self) -> Optional[str]:
+        """
+        Read-only property accessing the document's keywords.
+
+        Returns a ``TextStringObject`` or ``None`` if keywords are not
+        specified.
+        """
+        return self._get_text(DI.KEYWORDS)
+
+    @property
+    def keywords_raw(self) -> Optional[str]:
+        """The "raw" version of keywords; can return a ``ByteStringObject``."""
+        return self.get(DI.KEYWORDS)
+
 
 class PdfDocCommon:
     """

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -107,6 +107,8 @@ def test_read_metadata(pdf_path, expected):
         docinfo.creation_date_raw
         docinfo.modification_date
         docinfo.modification_date_raw
+        docinfo.keywords
+        docinfo.keywords_raw
         if "/Title" in metadict:
             assert isinstance(docinfo.title, str)
             assert metadict["/Title"] == docinfo.title


### PR DESCRIPTION
This missing entry was spotted while exposing metadata in https://github.com/py-pdf/pdfly/pull/73