### PR TITLE
MAINT: Narrow return type for `ContentStream.operations`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ history and [GitHub's 'Contributors' feature](https://github.com/py-pdf/pypdf/gr
 * [maxbeer99](https://github.com/maxbeer99)
 * [McNeil, Karen](https://github.com/karenlmcneil): Arabic Language Support
 * [Mérino, Antoine](https://github.com/Merinorus)
+* [Murphy, Kevin](https://github.com/kmurphy4)
 * [nalin-udhaar](https://github.com/nalin-udhaar)
 * [Paramonov, Alexey](https://github.com/alexey-v-paramonov)
 * [Paternault, Louis](https://framagit.org/spalax)

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -765,7 +765,7 @@ class PageObject(DictionaryObject):
                 )
             elif ope in (b"BI", b"EI", b"ID"):  # pragma: no cover
                 raise PdfReadError(
-                    f"{ope} operator met whereas not expected,"
+                    f"{ope!r} operator met whereas not expected,"
                     "please share usecase with pypdf dev team"
                 )
             """backup

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1401,7 +1401,7 @@ class ContentStream(DecodedStreamObject):
         self._operations = []
 
     @property
-    def operations(self) -> List[Tuple[Any, Any]]:
+    def operations(self) -> List[Tuple[Any, bytes]]:
         if not self._operations and self._data:
             self._parse_content_stream(BytesIO(self._data))
             self._data = b""


### PR DESCRIPTION
Fixes https://github.com/py-pdf/pypdf/pull/2792#discussion_r1837246804.