### PR TITLE
BUG: Fixed reference of value with str.__new__ in TextStringObject

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1047,7 +1047,7 @@ class PdfWriter(PdfDocCommon):
     def update_page_form_field_values(
         self,
         page: Union[PageObject, List[PageObject], None],
-        fields: Dict[str, Any],
+        fields: Dict[str, Union[str, List[str], Tuple[str, str, float]]],
         flags: FA.FfBits = FFBITS_NUL,
         auto_regenerate: Optional[bool] = True,
     ) -> None:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -653,7 +653,7 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
         o.autodetect_utf16 = False
         o.autodetect_pdfdocencoding = False
         o.utf16_bom = b""
-        if value.startswith(("\xfe\xff", "\xff\xfe")):
+        if o.startswith(("\xfe\xff", "\xff\xfe")):
             assert org is not None  # for mypy
             try:
                 o = str.__new__(cls, org.decode("utf-16"))

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -507,6 +507,11 @@ def test_textstringobject_autodetect_utf16():
     assert tso.get_encoded_bytes() == b"\xff\xfef\x00o\x00o\x00"
 
 
+def test_textstringobject__numbers_as_input():
+    _ = TextStringObject(42)
+    _ = TextStringObject(13.37) 
+
+
 def test_remove_child_not_in_tree():
     tree = TreeObject()
     with pytest.raises(ValueError) as exc:

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -509,7 +509,7 @@ def test_textstringobject_autodetect_utf16():
 
 def test_textstringobject__numbers_as_input():
     _ = TextStringObject(42)
-    _ = TextStringObject(13.37) 
+    _ = TextStringObject(13.37)
 
 
 def test_remove_child_not_in_tree():


### PR DESCRIPTION
based on comments from #2949 

- Fixing reference of value with str.__new__ output
- updated type annotation on update_page_form_field_values