### PR TITLE
DEP: Amend decode_permissions

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1278,33 +1278,6 @@ class PdfDocCommon:
         """
         return IndirectObject(num, gen, self).get_object()
 
-    def decode_permissions(
-        self, permissions_code: int
-    ) -> Dict[str, bool]:  # pragma: no cover
-        """Take the permissions as an integer, return the allowed access."""
-        deprecate_with_replacement(
-            old_name="decode_permissions",
-            new_name="user_access_permissions",
-            removed_in="5.0.0",
-        )
-
-        permissions_mapping = {
-            "print": UserAccessPermissions.PRINT,
-            "modify": UserAccessPermissions.MODIFY,
-            "copy": UserAccessPermissions.EXTRACT,
-            "annotations": UserAccessPermissions.ADD_OR_MODIFY,
-            "forms": UserAccessPermissions.FILL_FORM_FIELDS,
-            # Do not fix typo, as part of official, but deprecated API.
-            "accessability": UserAccessPermissions.EXTRACT_TEXT_AND_GRAPHICS,
-            "assemble": UserAccessPermissions.ASSEMBLE_DOC,
-            "print_high_quality": UserAccessPermissions.PRINT_TO_REPRESENTATION,
-        }
-
-        return {
-            key: permissions_code & flag != 0
-            for key, flag in permissions_mapping.items()
-        }
-
     @property
     def user_access_permissions(self) -> Optional[UserAccessPermissions]:
         """Get the user access permissions for encrypted documents. Returns None if not encrypted."""

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -48,7 +48,11 @@ from typing import (
 from ._encryption import Encryption
 from ._page import PageObject, _VirtualList
 from ._page_labels import index2label as page_index2page_label
-from ._utils import logger_warning, parse_iso8824_date
+from ._utils import (
+    deprecation_with_replacement,
+    logger_warning,
+    parse_iso8824_date,
+)
 from .constants import CatalogAttributes as CA
 from .constants import CatalogDictionary as CD
 from .constants import (
@@ -1273,6 +1277,33 @@ class PdfDocCommon:
 
         """
         return IndirectObject(num, gen, self).get_object()
+
+    def decode_permissions(
+        self, permissions_code: int
+    ) -> Dict[str, bool]:  # pragma: no cover
+        """Take the permissions as an integer, return the allowed access."""
+        deprecation_with_replacement(
+            old_name="decode_permissions",
+            new_name="user_access_permissions",
+            removed_in="6.0.0",
+        )
+
+        permissions_mapping = {
+            "print": UserAccessPermissions.PRINT,
+            "modify": UserAccessPermissions.MODIFY,
+            "copy": UserAccessPermissions.EXTRACT,
+            "annotations": UserAccessPermissions.ADD_OR_MODIFY,
+            "forms": UserAccessPermissions.FILL_FORM_FIELDS,
+            # Do not fix typo, as part of official, but deprecated API.
+            "accessability": UserAccessPermissions.EXTRACT_TEXT_AND_GRAPHICS,
+            "assemble": UserAccessPermissions.ASSEMBLE_DOC,
+            "print_high_quality": UserAccessPermissions.PRINT_TO_REPRESENTATION,
+        }
+
+        return {
+            key: permissions_code & flag != 0
+            for key, flag in permissions_mapping.items()
+        }
 
     @property
     def user_access_permissions(self) -> Optional[UserAccessPermissions]:

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -48,11 +48,7 @@ from typing import (
 from ._encryption import Encryption
 from ._page import PageObject, _VirtualList
 from ._page_labels import index2label as page_index2page_label
-from ._utils import (
-    deprecate_with_replacement,
-    logger_warning,
-    parse_iso8824_date,
-)
+from ._utils import logger_warning, parse_iso8824_date
 from .constants import CatalogAttributes as CA
 from .constants import CatalogDictionary as CD
 from .constants import (

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -14,6 +14,7 @@ from pypdf.constants import ImageAttributes as IA
 from pypdf.constants import PageAttributes as PG
 from pypdf.constants import UserAccessPermissions as UAP
 from pypdf.errors import (
+    DeprecationError,
     EmptyFileError,
     FileNotDecryptedError,
     PdfReadError,
@@ -727,6 +728,36 @@ def test_issue604(caplog, strict):
         # oi can be destination or a list:preferred to just print them
         for oi in outline:
             out.append(get_dest_pages(oi))  # noqa: PERF401
+
+
+def test_decode_permissions():
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+    base = {
+        "accessability": False,  # Do not fix typo, as part of official, but deprecated API.
+        "annotations": False,
+        "assemble": False,
+        "copy": False,
+        "forms": False,
+        "modify": False,
+        "print_high_quality": False,
+        "print": False,
+    }
+
+    print_ = base.copy()
+    print_["print"] = True
+    with pytest.raises(
+        DeprecationError,
+        match="decode_permissions is deprecated and will be removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
+    ):
+        assert reader.decode_permissions(4) == print_
+
+    modify = base.copy()
+    modify["modify"] = True
+    with pytest.raises(
+        DeprecationError,
+        match="decode_permissions is deprecated and will be removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
+    ):
+        assert reader.decode_permissions(8) == modify
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -747,7 +747,7 @@ def test_decode_permissions():
     print_["print"] = True
     with pytest.raises(
         DeprecationError,
-        match="decode_permissions is deprecated and was removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
+        match="decode_permissions is deprecated and was removed in pypdf 6.0.0. Use user_access_permissions instead",
     ):
         assert reader.decode_permissions(4) == print_
 
@@ -755,7 +755,7 @@ def test_decode_permissions():
     modify["modify"] = True
     with pytest.raises(
         DeprecationError,
-        match="decode_permissions is deprecated and was removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
+        match="decode_permissions is deprecated and was removed in pypdf 6.0.0. Use user_access_permissions instead",
     ):
         assert reader.decode_permissions(8) == modify
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -747,7 +747,7 @@ def test_decode_permissions():
     print_["print"] = True
     with pytest.raises(
         DeprecationError,
-        match="decode_permissions is deprecated and will be removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
+        match="decode_permissions is deprecated and was removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
     ):
         assert reader.decode_permissions(4) == print_
 
@@ -755,7 +755,7 @@ def test_decode_permissions():
     modify["modify"] = True
     with pytest.raises(
         DeprecationError,
-        match="decode_permissions is deprecated and will be removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
+        match="decode_permissions is deprecated and was removed in pypdf 6.0.0. Use user_access_permissions instead",  # noqa: E501
     ):
         assert reader.decode_permissions(8) == modify
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -729,36 +729,6 @@ def test_issue604(caplog, strict):
             out.append(get_dest_pages(oi))  # noqa: PERF401
 
 
-def test_decode_permissions():
-    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
-    base = {
-        "accessability": False,  # Do not fix typo, as part of official, but deprecated API.
-        "annotations": False,
-        "assemble": False,
-        "copy": False,
-        "forms": False,
-        "modify": False,
-        "print_high_quality": False,
-        "print": False,
-    }
-
-    print_ = base.copy()
-    print_["print"] = True
-    with pytest.raises(
-        DeprecationWarning,
-        match="decode_permissions is deprecated and will be removed in pypdf 5.0.0. Use user_access_permissions instead",  # noqa: E501
-    ):
-        assert reader.decode_permissions(4) == print_
-
-    modify = base.copy()
-    modify["modify"] = True
-    with pytest.raises(
-        DeprecationWarning,
-        match="decode_permissions is deprecated and will be removed in pypdf 5.0.0. Use user_access_permissions instead",  # noqa: E501
-    ):
-        assert reader.decode_permissions(8) == modify
-
-
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_user_access_permissions():
     # Not encrypted.


### PR DESCRIPTION
This was deprecated, with replacement user_access_permissions. Removal was scheduled for version 5.0.0 or later.