### PR TITLE
MAINT: Remove import except block

### DIFF
--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -33,10 +33,10 @@ from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 
 try:
+    # https://cryptography.io/en/latest/changelog/#v43-0-0
     from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 except ImportError:
     from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
-    # https://cryptography.io/en/latest/changelog/#v43-0-0
     deprecate_with_replacement(
             "cryptography.hazmat.primitives.ciphers.algorithms",
             "cryptography.hazmat.decrepit.ciphers.algorithms",

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -28,14 +28,10 @@
 import secrets
 
 from cryptography import __version__
+from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
+
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
-
-try:
-    # 43.0.0 - https://cryptography.io/en/latest/changelog/#v43-0-0
-    from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
-except ImportError:
-    from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives.ciphers.base import Cipher
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -31,19 +31,19 @@ from ._utils import deprecate_with_replacement
 from cryptography import __version__
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
-from cryptography.hazmat.primitives.ciphers.base import Cipher
-from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 
 try:
     from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 except ImportError:
-    # https://cryptography.io/en/latest/changelog/#v43-0-0
     from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
+    # https://cryptography.io/en/latest/changelog/#v43-0-0
     deprecate_with_replacement(
             "cryptography.hazmat.primitives.ciphers.algorithms",
             "cryptography.hazmat.decrepit.ciphers.algorithms",
             "5.0.0"
     )
+from cryptography.hazmat.primitives.ciphers.base import Cipher
+from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 
 from pypdf._crypt_providers._base import CryptBase
 

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -36,7 +36,11 @@ try:
     from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 except ImportError:
     # https://cryptography.io/en/latest/changelog/#v43-0-0
-    deprecate_with_replacement("cryptography.hazmat.primitives.ciphers.algorithms import ARC4", "cryptography.hazmat.decrepit.ciphers.algorithms", "5.0.0")
+    deprecate_with_replacement(
+            "cryptography.hazmat.primitives.ciphers.algorithms",
+            "cryptography.hazmat.decrepit.ciphers.algorithms",
+            "5.0.0"
+    )
     from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives.ciphers.base import Cipher
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -31,19 +31,19 @@ from ._utils import deprecate_with_replacement
 from cryptography import __version__
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
+from cryptography.hazmat.primitives.ciphers.base import Cipher
+from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 
 try:
-    # https://cryptography.io/en/latest/changelog/#v43-0-0
     from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 except ImportError:
+    # https://cryptography.io/en/latest/changelog/#v43-0-0
     from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
     deprecate_with_replacement(
             "cryptography.hazmat.primitives.ciphers.algorithms",
             "cryptography.hazmat.decrepit.ciphers.algorithms",
             "5.0.0"
     )
-from cryptography.hazmat.primitives.ciphers.base import Cipher
-from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 
 from pypdf._crypt_providers._base import CryptBase
 

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -29,7 +29,6 @@ import secrets
 
 from cryptography import __version__
 from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
-
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
 from cryptography.hazmat.primitives.ciphers.base import Cipher

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -26,11 +26,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import secrets
+from ._utils import deprecate_with_replacement
 
 from cryptography import __version__
-from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
+
+try:
+    from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
+except ImportError:
+    # https://cryptography.io/en/latest/changelog/#v43-0-0
+    deprecate_with_replacement("cryptography.hazmat.primitives.ciphers.algorithms import ARC4", "cryptography.hazmat.decrepit.ciphers.algorithms", "5.0.0")
+    from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives.ciphers.base import Cipher
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -35,13 +35,13 @@ from cryptography.hazmat.primitives.ciphers.algorithms import AES
 try:
     from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
     # https://cryptography.io/en/latest/changelog/#v43-0-0
     deprecate_with_replacement(
             "cryptography.hazmat.primitives.ciphers.algorithms",
             "cryptography.hazmat.decrepit.ciphers.algorithms",
             "5.0.0"
     )
-    from cryptography.hazmat.primitives.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives.ciphers.base import Cipher
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 


### PR DESCRIPTION
pypdf is now using version 43.0.3 of cryptography, so the fallback for previous versions can be removed.
https://cryptography.io/en/latest/changelog/#v43-0-0