### PR TITLE
ROB: Skip destination page being None in PdfWriter

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2758,6 +2758,8 @@ class PdfWriter(PdfDocCommon):
             ):
                 # already exists : should not duplicate it
                 pass
+            elif dest["/Page"] is None:
+                pass
             elif isinstance(dest["/Page"], NullObject):
                 pass
             elif isinstance(dest["/Page"], int):

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2758,9 +2758,7 @@ class PdfWriter(PdfDocCommon):
             ):
                 # already exists : should not duplicate it
                 pass
-            elif dest["/Page"] is None:
-                pass
-            elif isinstance(dest["/Page"], NullObject):
+            elif dest["/Page"] is None or isinstance(dest["/Page"], NullObject):
                 pass
             elif isinstance(dest["/Page"], int):
                 # the page reference is a page number normally not a PDF Reference

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2484,6 +2484,16 @@ def test_append_pdf_with_dest_without_page(caplog):
     assert len(writer.named_destinations) == 3
 
 
+@pytest.mark.enable_socket
+def test_destination_is_none():
+    """Tests for PR#2963"""
+    url = "https://raw.githubusercontent.com/dxsooo/pypdf/refs/heads/main/resources/3.pdf"
+    name = "pr2963.pdf"
+    source_data = BytesIO(get_data_from_url(url, name=name))
+    writer = PdfWriter()
+    writer.append(source_data)
+
+
 def test_stream_not_closed():
     """Tests for #2905"""
     src = RESOURCE_ROOT / "pdflatex-outline.pdf"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2486,12 +2486,12 @@ def test_append_pdf_with_dest_without_page(caplog):
 
 @pytest.mark.enable_socket
 def test_destination_page_is_none():
-    """Tests for PR#2963"""
+    """Tests for #2963"""
     url = "https://github.com/user-attachments/files/17879461/3.pdf"
-    name = "pr2963.pdf"
-    source_data = BytesIO(get_data_from_url(url, name=name))
+    name = "iss2963.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     writer = PdfWriter()
-    writer.append(source_data)
+    writer.append(reader)
 
 
 def test_stream_not_closed():

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2487,7 +2487,7 @@ def test_append_pdf_with_dest_without_page(caplog):
 @pytest.mark.enable_socket
 def test_destination_is_none():
     """Tests for PR#2963"""
-    url = "https://raw.githubusercontent.com/dxsooo/pypdf/refs/heads/main/resources/3.pdf"
+    url = "https://github.com/user-attachments/files/17879461/3.pdf"
     name = "pr2963.pdf"
     source_data = BytesIO(get_data_from_url(url, name=name))
     writer = PdfWriter()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2485,7 +2485,7 @@ def test_append_pdf_with_dest_without_page(caplog):
 
 
 @pytest.mark.enable_socket
-def test_destination_is_none():
+def test_destination_page_is_none():
     """Tests for PR#2963"""
     url = "https://github.com/user-attachments/files/17879461/3.pdf"
     name = "pr2963.pdf"


### PR DESCRIPTION
Some PDFs happen `dest["/Page"]` is none which causes 

`AttributeError: 'NoneType' object has no attribute 'indirect_reference'`

in the following code