### PR TITLE
ROB: Skip annotation destination being NullObject in PdfWriter

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3000,6 +3000,8 @@ class PdfWriter(PdfDocCommon):
                             outlist.append(self._add_object(anc))
             else:
                 d = cast("DictionaryObject", ano["/A"])["/D"]
+                if isinstance(d, NullObject):
+                    continue
                 if isinstance(d, str):
                     # it is a named dest
                     if str(d) in self.get_named_dest_root():

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2484,6 +2484,16 @@ def test_append_pdf_with_dest_without_page(caplog):
     assert len(writer.named_destinations) == 3
 
 
+@pytest.mark.enable_socket
+def test_destination_is_nullobject():
+    """Tests for #2958"""
+    url = "https://github.com/user-attachments/files/17822279/C0.00.-.COVER.SHEET.pdf"
+    name = "iss2958.pdf"
+    source_data = BytesIO(get_data_from_url(url, name=name))
+    writer = PdfWriter()
+    writer.append(source_data)
+
+
 def test_stream_not_closed():
     """Tests for #2905"""
     src = RESOURCE_ROOT / "pdflatex-outline.pdf"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2493,7 +2493,7 @@ def test_destination_is_nullobject():
     writer = PdfWriter()
     writer.append(source_data)
 
-    
+
 @pytest.mark.enable_socket
 def test_destination_page_is_none():
     """Tests for #2963"""


### PR DESCRIPTION
Closes #2958.