### PR TITLE
BUG: Handle IndirectObject in CCITTFaxDecode filter

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -531,7 +531,7 @@ class CCITTFaxDecode:
         if isinstance(rows, IndirectObject):
             rows = rows.get_object()  # type: ignore
 
-        return CCITParameters(K=k, columns=columns, rows=rows)
+        return CCITParameters(K=k, columns=columns, rows=cast(int, rows))
 
     @staticmethod
     def decode(

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -474,7 +474,7 @@ class JPXDecode:
 
 @dataclass
 class CCITParameters:
-    """TABLE 3.9 Optional parameters for the CCITTFaxDecode filter."""
+    """§7.4.6, optional parameters for the CCITTFaxDecode filter."""
 
     K: int = 0
     EndOfBlock: Union[int, None] = None
@@ -529,7 +529,7 @@ class CCITTFaxDecode:
                 if CCITT.K in parameters_unwrapped:
                     k = parameters_unwrapped[CCITT.K].get_object()  # type: ignore
         if isinstance(rows, IndirectObject):
-            rows = rows.get_object()
+            rows = rows.get_object()  # type: ignore
 
         return CCITParameters(K=k, columns=columns, rows=rows)
 

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -477,11 +477,11 @@ class CCITParameters:
     """§7.4.6, optional parameters for the CCITTFaxDecode filter."""
 
     K: int = 0
+    columns: int = 0
+    rows: int = 0
     EndOfBlock: Union[int, None] = None
     EndOfLine: Union[int, None] = None
     EncodedByteAlign: Union[int, None] = None
-    columns: int = 0
-    rows: int = 0
     DamagedRowsBeforeError: Union[int, None] = None
 
     @property

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -528,10 +528,8 @@ class CCITTFaxDecode:
                     columns = parameters_unwrapped[CCITT.COLUMNS].get_object()  # type: ignore
                 if CCITT.K in parameters_unwrapped:
                     k = parameters_unwrapped[CCITT.K].get_object()  # type: ignore
-        if isinstance(rows, IndirectObject):
-            rows = rows.get_object()  # type: ignore
 
-        return CCITParameters(K=k, columns=columns, rows=cast(int, rows))
+        return CCITParameters(K=k, columns=columns, rows=int(rows))
 
     @staticmethod
     def decode(

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -399,6 +399,10 @@ class IndirectObject(PdfObject):
         # in this case we are looking for the pointed data
         return self.get_object().__float__()  # type: ignore
 
+    def __int__(self) -> int:
+        # in this case we are looking for the pointed data
+        return self.get_object().__int__()  # type: ignore
+
     def __str__(self) -> str:
         # in this case we are looking for the pointed data
         return self.get_object().__str__()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -206,7 +206,7 @@ def test_ccitt_get_parameters(parameters, expected_k):
 
 def test_ccitt_get_parameters__indirect_object():
     class Pdf:
-        def get_object(self, reference):
+        def get_object(self, reference) -> NumberObject:
             return NumberObject(42)
 
     parameters = CCITTFaxDecode._get_parameters(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -196,7 +196,7 @@ def test_ccitparameters():
     ("parameters", "expected_k"),
     [
         (None, 0),
-        (ArrayObject([{"/K": 1}, {"/Columns": 13}]), 1),
+        (ArrayObject([{"/K": NumberObject(1)}, {"/Columns": NumberObject(13)}]), 1),
     ],
 )
 def test_ccitt_get_parameters(parameters, expected_k):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -18,7 +18,7 @@ from pypdf.filters import (
     CCITTFaxDecode,
     FlateDecode,
 )
-from pypdf.generic import ArrayObject, DictionaryObject, NameObject, NumberObject
+from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, NameObject, NumberObject
 
 from . import PILContext, get_data_from_url
 from .test_encryption import HAS_AES
@@ -202,6 +202,17 @@ def test_ccitparameters():
 def test_ccitt_get_parameters(parameters, expected_k):
     parameters = CCITTFaxDecode._get_parameters(parameters=parameters, rows=0)
     assert parameters.K == expected_k  # noqa: SIM300
+
+
+def test_ccitt_get_parameters__indirect_object():
+    class Pdf:
+        def get_object(self, reference):
+            return NumberObject(42)
+
+    parameters = CCITTFaxDecode._get_parameters(
+        parameters=None, rows=IndirectObject(13, 1, Pdf())
+    )
+    assert parameters.rows == 42
 
 
 def test_ccitt_fax_decode():


### PR DESCRIPTION
Additionally, use a *dataclass* for the parameter to simplify debugging.