### PR TITLE
DOC: Move PDF specification links

### DIFF
--- a/docs/dev/pdf-format.md
+++ b/docs/dev/pdf-format.md
@@ -2,13 +2,13 @@
 
 It is recommended to look in the PDF specification for details and clarifications.
 
-[PDF Specification Archive](https://pdfa.org/resource/pdf-specification-archive/)
+* [PDF Specification Archive](https://pdfa.org/resource/pdf-specification-archive/)
 
-[Portable Document Format Reference Manual, 1993. ISBN 0-201-62628-4](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.0.pdf)
+* [Portable Document Format Reference Manual, 1993. ISBN 0-201-62628-4](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.0.pdf)
 
-[ISO 32000-1:2008 (PDF 1.7)](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf)
+* [ISO 32000-1:2008 (PDF 1.7)](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf)
 
-ISO 32000-2:2020 (PDF 2.0)
+* ISO 32000-2:2020 (PDF 2.0)
 
 Below is only intended to give a very rough overview of the format.
 

--- a/docs/dev/pdf-format.md
+++ b/docs/dev/pdf-format.md
@@ -1,7 +1,16 @@
 # The PDF Format
 
 It is recommended to look in the PDF specification for details and clarifications.
-This is only intended to give a very rough overview of the format.
+
+[PDF Specification Archive](https://pdfa.org/resource/pdf-specification-archive/)
+
+[Portable Document Format Reference Manual, 1993. ISBN 0-201-62628-4](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.0.pdf)
+
+[ISO 32000-1:2008 (PDF 1.7)](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf)
+
+ISO 32000-2:2020 (PDF 2.0)
+
+Below is only intended to give a very rough overview of the format.
 
 ## Overall Structure
 

--- a/docs/dev/pdf-format.md
+++ b/docs/dev/pdf-format.md
@@ -3,11 +3,8 @@
 It is recommended to look in the PDF specification for details and clarifications.
 
 * [PDF Specification Archive](https://pdfa.org/resource/pdf-specification-archive/)
-
 * [Portable Document Format Reference Manual, 1993. ISBN 0-201-62628-4](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.0.pdf)
-
 * [ISO 32000-1:2008 (PDF 1.7)](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf)
-
 * ISO 32000-2:2020 (PDF 2.0)
 
 Below is only intended to give a very rough overview of the format.

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -1,3 +1,7 @@
+"""
+Various constants, enums and flags to aid readability.
+"""
+
 from enum import Enum, IntFlag, auto, unique
 from typing import Dict, Tuple
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -1,6 +1,4 @@
-"""
-Various constants, enums and flags to aid readability.
-"""
+"""Various constants, enums, and flags to aid readability."""
 
 from enum import Enum, IntFlag, auto, unique
 from typing import Dict, Tuple

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -1,16 +1,3 @@
-"""
-PDF Specification Archive
-https://pdfa.org/resource/pdf-specification-archive/
-
-Portable Document Format Reference Manual, 1993. ISBN 0-201-62628-4
-https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.0.pdf
-
-ISO 32000-1:2008 (PDF 1.7)
-https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf
-
-ISO 32000-2:2020 (PDF 2.0)
-"""
-
 from enum import Enum, IntFlag, auto, unique
 from typing import Dict, Tuple
 


### PR DESCRIPTION
Move from constants.py to pdf-format.md, a more natural location.