### PR TITLE
MAINT: Use collections.abc.Callable

### DIFF
--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -10,9 +10,6 @@ from __future__ import annotations
 import datetime
 import decimal
 import re
-from collections.abc import (
-    Callable,
-)
 from typing import (
     Any,
     Dict,
@@ -29,6 +26,9 @@ from xml.parsers.expat import ExpatError
 from ._utils import StreamType, deprecate_no_replacement
 from .errors import PdfReadError
 from .generic import ContentStream, PdfObject
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
 
 RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import datetime
 import decimal
 import re
-from collections.abc import Callable
+if TYPE_CHECKING:
+    from collections.abc import Callable
 from typing import (
     Any,
     Dict,
@@ -19,6 +20,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
+    TYPE_CHECKING,
 )
 from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -7,9 +7,9 @@ https://en.wikipedia.org/wiki/Extensible_Metadata_Platform
 import datetime
 import decimal
 import re
+from collections.abc import Callable
 from typing import (
     Any,
-    Callable,
     Dict,
     Iterator,
     List,

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -182,7 +182,7 @@ def _getter_langalt(
 
 def _getter_single(
     namespace: str, name: str, converter: Callable[[str], Any] = _identity
-) -> Callable[["XmpInformation"], Optional[Any]]:
+) -> Callable[[XmpInformation], Optional[Any]]:
     def get(self: "XmpInformation") -> Optional[Any]:
         cached = self.cache.get(namespace, {}).get(name)
         if cached:

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -28,7 +28,7 @@ from ._utils import StreamType, deprecate_no_replacement
 from .errors import PdfReadError
 from .generic import ContentStream, PdfObject
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from collections.abc import Callable
 
 RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import re
+from collections.abc import Callable
 from typing import (
     Any,
     Dict,
@@ -18,10 +19,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
-    TYPE_CHECKING,
 )
-if TYPE_CHECKING:
-    from collections.abc import Callable
 from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement
 from xml.parsers.expat import ExpatError

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -10,18 +10,22 @@ from __future__ import annotations
 import datetime
 import decimal
 import re
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from collections.abc import Callable
-from typing import (
-    Any,
-    Dict,
-    Iterator,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-    TYPE_CHECKING,
-)
+    from typing import (
+        Any,
+        Dict,
+        Iterator,
+        List,
+        Optional,
+        TypeVar,
+        Union,
+    )
 from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement
 from xml.parsers.expat import ExpatError

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -4,6 +4,9 @@ Anything related to Extensible Metadata Platform (XMP) metadata.
 https://en.wikipedia.org/wiki/Extensible_Metadata_Platform
 """
 
+# Remove once Python 3.8 support is dropped
+from __future__ import annotations
+
 import datetime
 import decimal
 import re

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
+    TYPE_CHECKING,
 )
 from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import datetime
 import decimal
 import re
-from collections.abc import Callable
+from collections.abc import (
+    Callable,
+)
 from typing import (
     Any,
     Dict,
@@ -110,8 +112,8 @@ def _converter_date(value: str) -> datetime.datetime:
 
 def _getter_bag(
     namespace: str, name: str
-) -> Callable[["XmpInformation"], Optional[List[str]]]:
-    def get(self: "XmpInformation") -> Optional[List[str]]:
+) -> Callable[[XmpInformation], Optional[List[str]]]:
+    def get(self: XmpInformation) -> Optional[List[str]]:
         cached = self.cache.get(namespace, {}).get(name)
         if cached:
             return cached
@@ -132,8 +134,8 @@ def _getter_bag(
 
 def _getter_seq(
     namespace: str, name: str, converter: Callable[[Any], Any] = _identity
-) -> Callable[["XmpInformation"], Optional[List[Any]]]:
-    def get(self: "XmpInformation") -> Optional[List[Any]]:
+) -> Callable[[XmpInformation], Optional[List[Any]]]:
+    def get(self: XmpInformation) -> Optional[List[Any]]:
         cached = self.cache.get(namespace, {}).get(name)
         if cached:
             return cached
@@ -158,8 +160,8 @@ def _getter_seq(
 
 def _getter_langalt(
     namespace: str, name: str
-) -> Callable[["XmpInformation"], Optional[Dict[Any, Any]]]:
-    def get(self: "XmpInformation") -> Optional[Dict[Any, Any]]:
+) -> Callable[[XmpInformation], Optional[Dict[Any, Any]]]:
+    def get(self: XmpInformation) -> Optional[Dict[Any, Any]]:
         cached = self.cache.get(namespace, {}).get(name)
         if cached:
             return cached
@@ -183,7 +185,7 @@ def _getter_langalt(
 def _getter_single(
     namespace: str, name: str, converter: Callable[[str], Any] = _identity
 ) -> Callable[[XmpInformation], Optional[Any]]:
-    def get(self: "XmpInformation") -> Optional[Any]:
+    def get(self: XmpInformation) -> Optional[Any]:
         cached = self.cache.get(namespace, {}).get(name)
         if cached:
             return cached

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -20,12 +20,11 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
+if TYPE_CHECKING:
+    from collections.abc import Callable
 from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement
 from xml.parsers.expat import ExpatError
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 from ._utils import StreamType, deprecate_no_replacement
 from .errors import PdfReadError

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -13,8 +13,6 @@ import re
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import (

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -24,12 +24,12 @@ from xml.dom.minidom import Document, parseString
 from xml.dom.minidom import Element as XmlElement
 from xml.parsers.expat import ExpatError
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 from ._utils import StreamType, deprecate_no_replacement
 from .errors import PdfReadError
 from .generic import ContentStream, PdfObject
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"


### PR DESCRIPTION
typing.Callable is a deprecated alias to collections.abc.Callable.