### PR TITLE
BUG: Avoid extracting inline images twice and dropping other operators

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -765,7 +765,7 @@ class PageObject(DictionaryObject):
                 )
             elif ope in (b"BI", b"EI", b"ID"):  # pragma: no cover
                 raise PdfReadError(
-                    f"{ope!r} operator met whereas not expected,"
+                    f"{ope!r} operator met whereas not expected, "
                     "please share usecase with pypdf dev team"
                 )
             """backup

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1361,6 +1361,7 @@ class ContentStream(DecodedStreamObject):
                 data = stream.read(
                     ceil(cast(int, settings["/W"]) * lcs) * cast(int, settings["/H"])
                 )
+            # Move to the `EI` if possible.
             ei = read_non_whitespace(stream)
             stream.seek(-1, 1)
         else:
@@ -1369,6 +1370,7 @@ class ContentStream(DecodedStreamObject):
         ei = stream.read(3)
         stream.seek(-1, 1)
         if ei[0:2] != b"EI" or ei[2:3] not in WHITESPACES:
+            # Deal with wrong/missing `EI` tags.
             stream.seek(savpos, 0)
             data = extract_inline_default(stream)
         return {"settings": settings, "data": data}

--- a/pypdf/generic/_image_inline.py
+++ b/pypdf/generic/_image_inline.py
@@ -224,11 +224,12 @@ def extract_inline_default(stream: StreamType) -> bytes:
             if data_buffered[pos_ei - 1 : pos_ei] not in WHITESPACES and tok3 not in {
                 b"Q",
                 b"E",
-            }:  # for Q ou EMC
+            }:  # for Q or EMC
                 stream.seek(saved_pos, 0)
                 continue
             # Data contains [\s]EI[\s](Q|EMC): 4 chars are sufficients
             # remove E(I) wrongly inserted earlier
+            stream.seek(saved_pos - 1, 0)
             stream_out.truncate(sav_pos_ei)
             break
 


### PR DESCRIPTION
This PR fixes a regression introduced in version 4.3.0 which would always try to extract inline images twice due to setting the wrong input stream position. The corresponding behavior is not directly obvious and only becomes visible with some PDF files as the one used in the test, where the faulty change would silently drop a `Q` operator and thus basically destroy the remaining layout of the PDF file.

During analysis, I have added some basic comments and fixed a faulty error message I stumbled upon as well.

Fixes #2927.