### PR TITLE
ROB: Ignore odd-length strings when processing cmap lines

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -1,3 +1,4 @@
+import binascii
 from binascii import unhexlify
 from math import ceil
 from typing import Any, Dict, List, Tuple, Union, cast
@@ -304,7 +305,10 @@ def process_cm_line(
     elif b"endbfchar" in line:
         process_char = False
     elif process_rg:
-        multiline_rg = parse_bfrange(line, map_dict, int_entry, multiline_rg)
+        try:
+            multiline_rg = parse_bfrange(line, map_dict, int_entry, multiline_rg)
+        except binascii.Error as error:
+            logger_warning(f"Skipping broken line {line!r}: {error}", __name__)
     elif process_char:
         parse_bfchar(line, map_dict, int_entry)
     return process_rg, process_char, multiline_rg

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -281,3 +281,14 @@ def test_iss2966():
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     assert "Lorem ipsum dolor sit amet" in reader.pages[0].extract_text()
 
+
+@pytest.mark.enable_socket
+def test_binascii_odd_length_string(caplog):
+    """Tests for #2216"""
+    url = "https://github.com/user-attachments/files/18199642/iss2216.pdf"
+    name = "iss2216.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+
+    page = reader.pages[0]
+    assert "\n(Many other theorems may\n" in page.extract_text()
+    assert "Skipping broken line b'143f   143f   10300': Odd-length string\n" in caplog.text


### PR DESCRIPTION
Closes #2216.