### PR TITLE
BUG: UnboundLocalError("local variable 'v' referenced before assignme…

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -516,6 +516,7 @@ def _type1_alternative(
     txt = txt.split(b"eexec\n")[0]  # only clear part
     txt = txt.split(b"/Encoding")[1]  # to get the encoding part
     lines = txt.replace(b"\r", b"\n").split(b"\n")
+    v = ""
     for li in lines:
         if li.startswith(b"dup"):
             words = [_w for _w in li.split(b" ") if _w != b""]


### PR DESCRIPTION
Commit to fix the following error:

raised unexpected: UnboundLocalError("local variable 'v' referenced before assignment")

map_dict[chr(i)] = v
UnboundLocalError: local variable 'v' referenced before assignment