### PR TITLE
TST: Fix image similarity for upcoming Ubuntu 24.04

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2578,4 +2578,4 @@ def test_inline_image_q_operator_handling(tmp_path):
         ]
     )
     assert png_path.is_file()
-    assert image_similarity(png_path, expected_png_path) >= 0.999999
+    assert image_similarity(png_path, expected_png_path) >= 0.99999


### PR DESCRIPTION
Tests started to fail on Ubuntu 24.04 due to using a too large threshold.

Valid cases now have 0.9999915926764715 and invalid ones 0.9993737673623087.