### PR TITLE
BUG: Ensure `add_metadata` can deal with `_info = None`

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1587,8 +1587,7 @@ class PdfWriter(PdfDocCommon):
         else:
             if self._info is not None:
                 self._info.clear()
-            else:
-                self._info = DictionaryObject()
+
             self.add_metadata(value)
 
     def add_metadata(self, infos: Dict[str, Any]) -> None:
@@ -1607,7 +1606,8 @@ class PdfWriter(PdfDocCommon):
             if isinstance(value, PdfObject):
                 value = value.get_object()
             args[NameObject(key)] = create_string_object(str(value))
-        assert isinstance(self._info, DictionaryObject)
+        if self._info is None:
+            self._info = DictionaryObject()
         self._info.update(args)
 
     def compress_identical_objects(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -78,6 +78,34 @@ def test_writer_clone():
     assert "PageObject" in str(type(writer.pages[0]))
 
 
+def test_clone_metadata():
+    src = RESOURCE_ROOT / "pdflatex-outline.pdf"
+    reader = PdfReader(src)
+
+    writer = PdfWriter(clone_from=reader)
+    writer.add_metadata({"/foo": "bar"})
+    assert writer.metadata == {
+        **reader.metadata,
+        "/foo": "bar",
+    }
+
+    writer = PdfWriter()
+    writer.clone_document_from_reader(reader)
+    writer.add_metadata({"/foo": "bar"})
+    assert writer.metadata == {
+        **reader.metadata,
+        "/foo": "bar",
+    }
+    writer.metadata = None
+    writer.add_metadata({"/foo": "bar"})
+    assert writer.metadata == {"/foo": "bar"}
+
+    writer = PdfWriter()
+    writer.clone_reader_document_root(reader)
+    writer.add_metadata({"/foo": "bar"})
+    assert writer.metadata == {"/foo": "bar"}
+
+
 def test_writer_clone_bookmarks():
     # Arrange
     src = RESOURCE_ROOT / "Seige_of_Vicksburg_Sample_OCR-crazyones-merged.pdf"


### PR DESCRIPTION
The `assert isinstance` hid the information that `_info` is `Optional`, in which case `add_metadata` would raise an assertion error.

Properly initialise `_info` if it's not set.

Fixes #3036