### PR TITLE
TST: Replace broken Apache Tika Corpora urls

### DIFF
--- a/tests/example_files.yaml
+++ b/tests/example_files.yaml
@@ -62,16 +62,12 @@
   url: https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf
 - local_filename: tika-924546.pdf
   url: https://github.com/user-attachments/files/18381697/tika-924546.pdf
-- local_filename: tika-924546.pdf
-  url: https://github.com/user-attachments/files/18381697/tika-924546.pdf
 - local_filename: issue-1801.png
   url: https://user-images.githubusercontent.com/1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png
 - local_filename: grimm10
   url: https://github.com/py-pdf/pypdf/files/11336817/grimm10.pdf
 - local_filename: labeled-edges-center-image.png
   url: https://user-images.githubusercontent.com/4083478/236685544-a1940b06-fb42-4bb1-b589-1e4ad429d68e.png
-- local_filename: pdf_font_garbled.pdf
-  url: https://github.com/py-pdf/pypdf/files/11219022/pdf_font_garbled.pdf
 - local_filename: watermark1.png
   url: https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png
 - local_filename: tika-977609.pdf
@@ -104,8 +100,6 @@
   url: https://github.com/py-pdf/pypdf/files/12144094/im1.png.txt
 - local_filename: iss1982_im2.png
   url: https://github.com/py-pdf/pypdf/files/12144093/im2.png.txt
-- local_filename: tika-972174.pdf
-  url: https://github.com/user-attachments/files/18381744/tika-972174.pdf
 - local_filename: usa.png
   url: https://github.com/py-pdf/pypdf/assets/4083478/56c93021-33cd-4387-ae13-5cbe7e673f42
 - local_filename: paid.pdf

--- a/tests/example_files.yaml
+++ b/tests/example_files.yaml
@@ -13,17 +13,17 @@
 - local_filename: The%20lean%20times%20in%20the%20Peruvian%20economy.pdf
   url: https://github.com/alexanderquispe/1REI05/raw/main/reports/report_1/The%20lean%20times%20in%20the%20Peruvian%20economy.pdf
 - local_filename: tika-908104.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/908/908104.pdf
+  url: https://github.com/user-attachments/files/18382273/tika-908104.pdf
 - local_filename: tika-923406.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/923/923406.pdf
+  url: https://github.com/user-attachments/files/18382274/tika-923406.pdf
 - local_filename: tika-955562.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/955/955562.pdf
+  url: https://github.com/user-attachments/files/18382288/tika-955562.pdf
 - local_filename: tika-959173.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/959/959173.pdf
+  url: https://github.com/user-attachments/files/18382295/tika-959173.pdf
 - local_filename: waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf
   url: https://github.com/py-pdf/pypdf/files/10773829/waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf
 - local_filename: tika-957144.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/957/957144.pdf
+  url: https://github.com/user-attachments/files/18382302/tika-957144.pdf
 - local_filename: ascii charset.pdf
   url: https://github.com/py-pdf/pypdf/files/9472500/main.pdf
 - local_filename: cmap1370.pdf
@@ -49,21 +49,21 @@
 - local_filename: NewJersey.pdf
   url: https://github.com/py-pdf/pypdf/files/12090692/New.Jersey.Coinbase.staking.securities.charges.2023-0606_Coinbase-Penalty-and-C-D.pdf
 - local_filename: tika-952445.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/952/952445.pdf
+  url: https://github.com/user-attachments/files/18382348/tika-952445.pdf
 - local_filename: tika-921632.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/921/921632.pdf
+  url: https://github.com/user-attachments/files/18382354/tika-921632.pdf
 - local_filename: tika-976970.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/976/976970.pdf
+  url: https://github.com/user-attachments/files/18382397/tika-976970.pdf
 - local_filename: tika-914102.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/914/914102.pdf
+  url: https://github.com/user-attachments/files/18381687/tika-914102.pdf
 - local_filename: iss1737.pdf
   url: https://github.com/py-pdf/pypdf/files/11068604/tt1.pdf
 - local_filename: issue-1801.pdf
   url: https://github.com/py-pdf/pypdf/files/11250359/test_img.pdf
 - local_filename: tika-924546.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf
+  url: https://github.com/user-attachments/files/18381697/tika-924546.pdf
 - local_filename: tika-924546.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf
+  url: https://github.com/user-attachments/files/18381697/tika-924546.pdf
 - local_filename: issue-1801.png
   url: https://user-images.githubusercontent.com/1658117/232842886-9d1b0726-3a5b-430d-8464-595d919c266c.png
 - local_filename: grimm10
@@ -75,11 +75,11 @@
 - local_filename: watermark1.png
   url: https://user-images.githubusercontent.com/4083478/236793172-09340aef-3440-4c8a-af85-a91cdad27d46.png
 - local_filename: tika-977609.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf
+  url: https://github.com/user-attachments/files/18381754/tika-977609.pdf
 - local_filename: tifimage.png
   url: https://user-images.githubusercontent.com/4083478/236793166-288b4b59-dee3-49fd-a04e-410aab06199a.png
 - local_filename: tika-972174.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf
+  url: https://github.com/user-attachments/files/18381744/tika-972174.pdf
 - local_filename: tika-972174_p0-im0.png
   url: https://user-images.githubusercontent.com/4083478/238288207-b77dd38c-34b4-4f4f-810a-bf9db7ca0414.png
 - local_filename: Vitocal.pdf
@@ -105,7 +105,7 @@
 - local_filename: iss1982_im2.png
   url: https://github.com/py-pdf/pypdf/files/12144093/im2.png.txt
 - local_filename: tika-972174.pdf
-  url: https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf
+  url: https://github.com/user-attachments/files/18381744/tika-972174.pdf
 - local_filename: usa.png
   url: https://github.com/py-pdf/pypdf/assets/4083478/56c93021-33cd-4387-ae13-5cbe7e673f42
 - local_filename: paid.pdf

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -637,27 +637,27 @@ def test_remove_child_in_tree():
     ("url", "name", "caplog_content"),
     [
         (  # parse_content_stream_peek_percentage
-            "https://corpora.tika.apache.org/base/docs/govdocs1/985/985770.pdf",
+            "https://github.com/user-attachments/files/18381763/tika-985770.pdf",
             "tika-985770.pdf",
             "",
         ),
         (  # read_inline_image_no_has_q
-            "https://corpora.tika.apache.org/base/docs/govdocs1/998/998719.pdf",
+            "https://github.com/user-attachments/files/18381775/tika-998719.pdf",
             "tika-998719.pdf",
             "",
         ),
         (  # read_inline_image_loc_neg_1
-            "https://corpora.tika.apache.org/base/docs/govdocs1/935/935066.pdf",
+            "https://github.com/user-attachments/files/18381706/tika-935066.pdf",
             "tika-935066.pdf",
             "",
         ),
         (  # object_read_from_stream_unicode_error
-            "https://corpora.tika.apache.org/base/docs/govdocs1/974/974966.pdf",
+            "https://github.com/user-attachments/files/18381750/tika-974966.pdf",
             "tika-974966.pdf",
             "",
         ),
         (  # dict_read_from_stream
-            "https://corpora.tika.apache.org/base/docs/govdocs1/984/984877.pdf",
+            "https://github.com/user-attachments/files/18381762/tika-984877.pdf",
             "tika-984877.pdf",
             "Multiple definitions in dictionary at byte 0x1084 for key /Length",
         ),
@@ -683,7 +683,7 @@ def test_extract_text(caplog, url: str, name: str, caplog_content: str):
 @pytest.mark.slow
 @pytest.mark.enable_socket
 def test_text_string_write_to_stream():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924562.pdf"
+    url = "https://github.com/user-attachments/files/18381698/tika-924562.pdf"
     name = "tika-924562.pdf"
 
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
@@ -695,7 +695,7 @@ def test_text_string_write_to_stream():
 
 @pytest.mark.enable_socket
 def test_bool_repr(tmp_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/932/932449.pdf"
+    url = "https://github.com/user-attachments/files/18381703/tika-932449.pdf"
     name = "tika-932449.pdf"
 
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -226,7 +226,7 @@ def test_merge_write_closed_fh_with_writer(pdf_file_path):
 
 @pytest.mark.enable_socket
 def test_trim_outline_list_with_writer(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/995/995175.pdf"
+    url = "https://github.com/user-attachments/files/18381771/tika-995175.pdf"
     name = "tika-995175.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -238,7 +238,7 @@ def test_trim_outline_list_with_writer(pdf_file_path):
 
 @pytest.mark.enable_socket
 def test_zoom_with_writer(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/994/994759.pdf"
+    url = "https://github.com/user-attachments/files/18381769/tika-994759.pdf"
     name = "tika-994759.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -250,7 +250,7 @@ def test_zoom_with_writer(pdf_file_path):
 @pytest.mark.enable_socket
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_zoom_xyz_no_left_with_add_page(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/933/933322.pdf"
+    url = "https://github.com/user-attachments/files/18381704/tika-933322.pdf"
     name = "tika-933322.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -262,7 +262,7 @@ def test_zoom_xyz_no_left_with_add_page(pdf_file_path):
 
 @pytest.mark.enable_socket
 def test_zoom_xyz_no_left_with_writer(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/933/933322.pdf"
+    url = "https://github.com/user-attachments/files/18381704/tika-933322.pdf"
     name = "tika-933322.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -274,7 +274,7 @@ def test_zoom_xyz_no_left_with_writer(pdf_file_path):
 @pytest.mark.enable_socket
 @pytest.mark.slow
 def test_outline_item_with_writer(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/997/997511.pdf"
+    url = "https://github.com/user-attachments/files/18381773/tika-997511.pdf"
     name = "tika-997511.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -286,7 +286,7 @@ def test_outline_item_with_writer(pdf_file_path):
 @pytest.mark.enable_socket
 @pytest.mark.slow
 def test_trim_outline_with_writer(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/982/982336.pdf"
+    url = "https://github.com/user-attachments/files/18381759/tika-982336.pdf"
     name = "tika-982336.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -298,7 +298,7 @@ def test_trim_outline_with_writer(pdf_file_path):
 @pytest.mark.enable_socket
 @pytest.mark.slow
 def test1_with_writer(pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/923/923621.pdf"
+    url = "https://github.com/user-attachments/files/18381696/tika-923621.pdf"
     name = "tika-923621.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -311,7 +311,7 @@ def test1_with_writer(pdf_file_path):
 @pytest.mark.slow
 def test_sweep_recursion1_with_writer(pdf_file_path):
     # TODO: This test looks like an infinite loop.
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
+    url = "https://github.com/user-attachments/files/18381697/tika-924546.pdf"
     name = "tika-924546.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -330,11 +330,11 @@ def test_sweep_recursion1_with_writer(pdf_file_path):
     [
         (
             # TODO: This test looks like an infinite loop.
-            "https://corpora.tika.apache.org/base/docs/govdocs1/924/924794.pdf",
+            "https://github.com/user-attachments/files/18381700/tika-924794.pdf",
             "tika-924794.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf",
+            "https://github.com/user-attachments/files/18381697/tika-924546.pdf",
             "tika-924546.pdf",
         ),
     ],
@@ -352,7 +352,7 @@ def test_sweep_recursion2_with_writer(url, name, pdf_file_path):
 
 @pytest.mark.enable_socket
 def test_sweep_indirect_list_newobj_is_none_with_writer(caplog, pdf_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/906/906769.pdf"
+    url = "https://github.com/user-attachments/files/18381681/tika-906769.pdf"
     name = "tika-906769.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -390,7 +390,7 @@ def test_iss1344_with_writer(caplog):
 
 @pytest.mark.enable_socket
 def test_articles_with_writer(caplog):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
+    url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "924666.pdf"
     m = PdfWriter()
     m.append(PdfReader(BytesIO(get_data_from_url(url, name=name))), (2, 10))

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -400,12 +400,12 @@ def test_iss_1142():
     [
         # keyerror_potentially_empty_page
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/964/964029.pdf",
+            "https://github.com/user-attachments/files/18381736/tika-964029.pdf",
             "tika-964029.pdf",
         ),
         # 1140 / 1141:
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/932/932446.pdf",
+            "https://github.com/user-attachments/files/18381702/tika-932446.pdf",
             "tika-932446.pdf",
         ),
         # iss 1134:
@@ -419,7 +419,7 @@ def test_iss_1142():
             "WFCA.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/964/964029.pdf",
+            "https://github.com/user-attachments/files/18381736/tika-964029.pdf",
             "tika-964029.pdf",
         ),  # single_quote_op
         (
@@ -442,7 +442,7 @@ def test_extract_text(url, name):
 @pytest.mark.enable_socket
 @pytest.mark.slow
 def test_extract_text_page_pdf_impossible_decode_xform(caplog):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972962.pdf"
+    url = "https://github.com/user-attachments/files/18381748/tika-972962.pdf"
     name = "tika-972962.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     for page in reader.pages:
@@ -454,7 +454,7 @@ def test_extract_text_page_pdf_impossible_decode_xform(caplog):
 @pytest.mark.enable_socket
 @pytest.mark.slow
 def test_extract_text_operator_t_star():  # L1266, L1267
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/967/967943.pdf"
+    url = "https://github.com/user-attachments/files/18381740/tika-967943.pdf"
     name = "tika-967943.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     for page in reader.pages:
@@ -941,7 +941,7 @@ def test_annotation_setter(pdf_file_path):
 @pytest.mark.enable_socket
 @pytest.mark.xfail(reason="#1091")
 def test_text_extraction_issue_1091():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/966/966635.pdf"
+    url = "https://github.com/user-attachments/files/18381737/tika-966635.pdf"
     name = "tika-966635.pdf"
     stream = BytesIO(get_data_from_url(url, name=name))
     with pytest.warns(PdfReadWarning):
@@ -952,7 +952,7 @@ def test_text_extraction_issue_1091():
 
 @pytest.mark.enable_socket
 def test_empyt_password_1088():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/941/941536.pdf"
+    url = "https://github.com/user-attachments/files/18381712/tika-941536.pdf"
     name = "tika-941536.pdf"
     stream = BytesIO(get_data_from_url(url, name=name))
     reader = PdfReader(stream)
@@ -1221,7 +1221,7 @@ def test_pages_printing():
 
 @pytest.mark.enable_socket
 def test_del_pages():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/941/941536.pdf"
+    url = "https://github.com/user-attachments/files/18381712/tika-941536.pdf"
     name = "tika-941536.pdf"
     writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
     ll = len(writer.pages)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -920,7 +920,7 @@ def test_form_topname_with_and_without_acroform(caplog):
 @pytest.mark.enable_socket
 def test_extract_text_xref_issue_2(caplog):
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/981/981961.pdf"
+    url = "https://github.com/user-attachments/files/18381758/tika-981961.pdf"
     msg = [
         "incorrect startxref pointer(2)",
         "parsing for Object Streams",
@@ -935,7 +935,7 @@ def test_extract_text_xref_issue_2(caplog):
 @pytest.mark.slow
 def test_extract_text_xref_issue_3(caplog):
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/977/977774.pdf"
+    url = "https://github.com/user-attachments/files/18381755/tika-977774.pdf"
     msg = [
         "incorrect startxref pointer(3)",
     ]
@@ -948,7 +948,7 @@ def test_extract_text_xref_issue_3(caplog):
 @pytest.mark.enable_socket
 def test_extract_text_pdf15():
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/976/976030.pdf"
+    url = "https://github.com/user-attachments/files/18381751/tika-976030.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name="tika-976030.pdf")))
     for page in reader.pages:
         page.extract_text()
@@ -957,7 +957,7 @@ def test_extract_text_pdf15():
 @pytest.mark.enable_socket
 def test_extract_text_xref_table_21_bytes_clrf():
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/956/956939.pdf"
+    url = "https://github.com/user-attachments/files/18381723/tika-956939.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name="tika-956939.pdf")))
     for page in reader.pages:
         page.extract_text()
@@ -965,7 +965,7 @@ def test_extract_text_xref_table_21_bytes_clrf():
 
 @pytest.mark.enable_socket
 def test_get_fields():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/972/972486.pdf"
+    url = "https://github.com/user-attachments/files/18381747/tika-972486.pdf"
     name = "tika-972486.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     fields = reader.get_fields()
@@ -1000,14 +1000,14 @@ def test_get_full_qualified_fields():
 @pytest.mark.filterwarnings("ignore::pypdf.errors.PdfReadWarning")
 def test_get_fields_read_else_block():
     # covers also issue 1089
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/934/934771.pdf"
+    url = "https://github.com/user-attachments/files/18381705/tika-934771.pdf"
     name = "tika-934771.pdf"
     PdfReader(BytesIO(get_data_from_url(url, name=name)))
 
 
 @pytest.mark.enable_socket
 def test_get_fields_read_else_block2():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/914/914902.pdf"
+    url = "https://github.com/user-attachments/files/18381689/tika-914902.pdf"
     name = "tika-914902.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     fields = reader.get_fields()
@@ -1017,14 +1017,14 @@ def test_get_fields_read_else_block2():
 @pytest.mark.enable_socket
 @pytest.mark.filterwarnings("ignore::pypdf.errors.PdfReadWarning")
 def test_get_fields_read_else_block3():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/957/957721.pdf"
+    url = "https://github.com/user-attachments/files/18381726/tika-957721.pdf"
     name = "tika-957721.pdf"
     PdfReader(BytesIO(get_data_from_url(url, name=name)))
 
 
 @pytest.mark.enable_socket
 def test_metadata_is_none():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/963/963692.pdf"
+    url = "https://github.com/user-attachments/files/18381735/tika-963692.pdf"
     name = "tika-963692.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     assert reader.metadata is None
@@ -1032,7 +1032,7 @@ def test_metadata_is_none():
 
 @pytest.mark.enable_socket
 def test_get_fields_read_write_report(txt_file_path):
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/909/909655.pdf"
+    url = "https://github.com/user-attachments/files/18381683/tika-909655.pdf"
     name = "tika-909655.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     with open(txt_file_path, "w") as fp:
@@ -1054,7 +1054,7 @@ def test_xfa(src):
 
 @pytest.mark.enable_socket
 def test_xfa_non_empty():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/942/942050.pdf"
+    url = "https://github.com/user-attachments/files/18381713/tika-942050.pdf"
     name = "tika-942050.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     assert list(reader.xfa.keys()) == [
@@ -1236,7 +1236,7 @@ def test_named_destination(url, name):
 
 @pytest.mark.enable_socket
 def test_outline_with_missing_named_destination():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/913/913678.pdf"
+    url = "https://github.com/user-attachments/files/18381686/tika-913678.pdf"
     name = "tika-913678.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     # outline items in document reference a named destination that is not defined
@@ -1245,7 +1245,7 @@ def test_outline_with_missing_named_destination():
 
 @pytest.mark.enable_socket
 def test_outline_with_empty_action():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf"
+    url = "https://github.com/user-attachments/files/18381697/tika-924546.pdf"
     name = "tika-924546.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     # outline items (entitled Tables and Figures) utilize an empty action (/A)
@@ -1336,7 +1336,7 @@ def test_thread():
     name = "UTA_OSHA.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     assert reader.threads is None
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
+    url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     assert isinstance(reader.threads, ArrayObject)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -634,7 +634,7 @@ def test_merge_output(caplog):
         ),
         (
             "https://github.com/user-attachments/files/18382223/965118.pdf",
-            "tika-952016.pdf",
+            "tika-965118.pdf",
         ),
         (
             "https://github.com/user-attachments/files/18381729/tika-959184.pdf",
@@ -797,7 +797,7 @@ def test_get_xfa(url, name):
         ),
         (
             "https://github.com/user-attachments/files/18382162/914133.pdf",
-            "tika-988698.pdf",
+            "tika-914133.pdf",
             False,
         ),
         (

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -247,12 +247,12 @@ def test_rotate_45():
         (True, "https://github.com/py-pdf/pypdf/files/8884493/998167.pdf", [0]),
         (
             True,
-            "https://corpora.tika.apache.org/base/docs/govdocs1/971/971703.pdf",
+            "https://github.com/user-attachments/files/18382039/971703.pdf",
             [0, 1, 5, 8, 14],
         ),
         (  # faulty PDF, wrongly linearized and with 2 trailer, second with /Root
             True,
-            "https://corpora.tika.apache.org/base/docs/govdocs1/989/989691.pdf",
+            "https://github.com/user-attachments/files/18382034/989691.pdf",
             [0],
         ),
     ],
@@ -317,7 +317,7 @@ def test_orientations():
             "sample-files/013-reportlab-overlay/reportlab-overlay.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/935/935981.pdf",
+            "https://github.com/user-attachments/files/18381707/tika-935981.pdf",
             "sample-files/013-reportlab-overlay/reportlab-overlay.pdf",
         ),
     ],
@@ -346,7 +346,7 @@ def test_overlay(pdf_file_path, base_path, overlay_path):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/924/924546.pdf",
+            "https://github.com/user-attachments/files/18381697/tika-924546.pdf",
             "tika-924546.pdf",
         )
     ],
@@ -366,7 +366,7 @@ def test_merge_with_warning(tmp_path, url, name):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/980/980613.pdf",
+            "https://github.com/user-attachments/files/18381757/tika-980613.pdf",
             "tika-980613.pdf",
         )
     ],
@@ -385,7 +385,7 @@ def test_merge(tmp_path, url, name):
     ("url", "name", "expected_metadata"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/935/935996.pdf",
+            "https://github.com/user-attachments/files/18381708/tika-935996.pdf",
             "tika-935996.pdf",
             {
                 "/Author": "Unknown",
@@ -417,61 +417,61 @@ def test_get_metadata(url, name, expected_metadata):
             None,  # iss #1090 is now fixed
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/942/942358.pdf",
+            "https://github.com/user-attachments/files/18381715/tika-942358.pdf",
             "tika-942358.pdf",
             False,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/911/911260.pdf",
+            "https://github.com/user-attachments/files/18381684/tika-911260.pdf",
             "tika-911260.pdf",
             False,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/992/992472.pdf",
+            "https://github.com/user-attachments/files/18381766/tika-992472.pdf",
             "tika-992472.pdf",
             False,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/978/978477.pdf",
+            "https://github.com/user-attachments/files/18381756/tika-978477.pdf",
             "tika-978477.pdf",
             False,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/960/960317.pdf",
+            "https://github.com/user-attachments/files/18381731/tika-960317.pdf",
             "tika-960317.pdf",
             False,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/930/930513.pdf",
+            "https://github.com/user-attachments/files/18381701/tika-930513.pdf",
             "tika-930513.pdf",
             False,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/918/918113.pdf",
+            "https://github.com/user-attachments/files/18381691/tika-918113.pdf",
             "tika-918113.pdf",
             True,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/940/940704.pdf",
+            "https://github.com/user-attachments/files/18381711/tika-940704.pdf",
             "tika-940704.pdf",
             True,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/976/976488.pdf",
+            "https://github.com/user-attachments/files/18381752/tika-976488.pdf",
             "tika-976488.pdf",
             True,
             None,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/948/948176.pdf",
+            "https://github.com/user-attachments/files/18381716/tika-948176.pdf",
             "tika-948176.pdf",
             True,
             None,
@@ -497,23 +497,23 @@ def test_extract_text(url, name, strict, exception):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/938/938702.pdf",
+            "https://github.com/user-attachments/files/18381710/tika-938702.pdf",
             "tika-938702.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/957/957304.pdf",
+            "https://github.com/user-attachments/files/18381725/tika-957304.pdf",
             "tika-957304.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/915/915194.pdf",
+            "https://github.com/user-attachments/files/18381690/tika-915194.pdf",
             "tika-915194.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/950/950337.pdf",
+            "https://github.com/user-attachments/files/18381717/tika-950337.pdf",
             "tika-950337.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/962/962292.pdf",
+            "https://github.com/user-attachments/files/18381734/tika-962292.pdf",
             "tika-962292.pdf",
         ),
     ],
@@ -533,7 +533,7 @@ def test_compress_raised(url, name):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/961/961883.pdf",
+            "https://github.com/user-attachments/files/18381733/tika-961883.pdf",
             "tika-961883.pdf",
         ),
     ],
@@ -558,7 +558,7 @@ def test_get_fields_warns(tmp_path, caplog, url, name):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/942/942050.pdf",
+            "https://github.com/user-attachments/files/18381713/tika-942050.pdf",
             "tika-942050.pdf",
         ),
     ],
@@ -575,7 +575,7 @@ def test_get_fields_no_warning(tmp_path, url, name):
 
 @pytest.mark.enable_socket
 def test_scale_rectangle_indirect_object():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/999/999944.pdf"
+    url = "https://github.com/user-attachments/files/18381778/tika-999944.pdf"
     name = "tika-999944.pdf"
     data = BytesIO(get_data_from_url(url, name=name))
     reader = PdfReader(data)
@@ -617,43 +617,43 @@ def test_merge_output(caplog):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/994/994636.pdf",
+            "https://github.com/user-attachments/files/18381767/tika-994636.pdf",
             "tika-994636.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/952/952133.pdf",
+            "https://github.com/user-attachments/files/18381719/tika-952133.pdf",
             "tika-952133.pdf",
         ),
         (  # JPXDecode
-            "https://corpora.tika.apache.org/base/docs/govdocs1/914/914568.pdf",
+            "https://github.com/user-attachments/files/18381688/tika-914568.pdf",
             "tika-914568.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/952/952016.pdf",
+            "https://github.com/user-attachments/files/18381718/tika-952016.pdf",
             "tika-952016.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/965/965118.pdf",
+            "https://github.com/user-attachments/files/18382223/965118.pdf",
             "tika-952016.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/959/959184.pdf",
+            "https://github.com/user-attachments/files/18381729/tika-959184.pdf",
             "tika-959184.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/958/958496.pdf",
+            "https://github.com/user-attachments/files/18381727/tika-958496.pdf",
             "tika-958496.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/972/972174.pdf",
+            "https://github.com/user-attachments/files/18381744/tika-972174.pdf",
             "tika-972174.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/972/972243.pdf",
+            "https://github.com/user-attachments/files/18381745/tika-972243.pdf",
             "tika-972243.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/969/969502.pdf",
+            "https://github.com/user-attachments/files/18381743/tika-969502.pdf",
             "tika-969502.pdf",
         ),
         ("https://arxiv.org/pdf/2201.00214.pdf", "arxiv-2201.00214.pdf"),
@@ -687,7 +687,7 @@ def test_image_extraction(url, name):
 @pytest.mark.enable_socket
 def test_image_extraction_strict():
     # Emits log messages
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/914/914102.pdf"
+    url = "https://github.com/user-attachments/files/18381687/tika-914102.pdf"
     name = "tika-914102.pdf"
     data = BytesIO(get_data_from_url(url, name=name))
     reader = PdfReader(data, strict=True)
@@ -717,7 +717,7 @@ def test_image_extraction_strict():
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/977/977609.pdf",
+            "https://github.com/user-attachments/files/18381754/tika-977609.pdf",
             "tika-977609.pdf",
         ),
     ],
@@ -751,7 +751,7 @@ def test_image_extraction2(url, name):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/918/918137.pdf",
+            "https://github.com/user-attachments/files/18381692/tika-918137.pdf",
             "tika-918137.pdf",
         ),
         (
@@ -771,11 +771,11 @@ def test_get_outline(url, name):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/935/935981.pdf",
+            "https://github.com/user-attachments/files/18381707/tika-935981.pdf",
             "tika-935981.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/937/937334.pdf",
+            "https://github.com/user-attachments/files/18381709/tika-937334.pdf",
             "tika-937334.pdf",
         ),
     ],
@@ -791,22 +791,22 @@ def test_get_xfa(url, name):
     ("url", "name", "strict"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/988/988698.pdf",
+            "https://github.com/user-attachments/files/18381765/tika-988698.pdf",
             "tika-988698.pdf",
             False,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/914/914133.pdf",
+            "https://github.com/user-attachments/files/18382162/914133.pdf",
             "tika-988698.pdf",
             False,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/912/912552.pdf",
+            "https://github.com/user-attachments/files/18381685/tika-912552.pdf",
             "tika-912552.pdf",
             False,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/914/914102.pdf",
+            "https://github.com/user-attachments/files/18381687/tika-914102.pdf",
             "tika-914102.pdf",
             True,
         ),
@@ -824,22 +824,22 @@ def test_get_fonts(url, name, strict):
     ("url", "name", "strict"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/942/942303.pdf",
+            "https://github.com/user-attachments/files/18382060/tika-942303.pdf",
             "tika-942303.pdf",
             True,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/935/935981.pdf",
+            "https://github.com/user-attachments/files/18381707/tika-935981.pdf",
             "tika-935981.pdf",
             True,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/967/967399.pdf",
+            "https://github.com/user-attachments/files/18381738/tika-967399.pdf",
             "tika-967399.pdf",
             True,
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/935/935981.pdf",
+            "https://github.com/user-attachments/files/18381707/tika-935981.pdf",
             "tika-935981.pdf",
             False,
         ),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -837,7 +837,7 @@ def test_append_pages_from_reader_append():
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_sweep_indirect_references_nullobject_exception(pdf_file_path):
     # TODO: Check this more closely... this looks weird
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
+    url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     merger = PdfWriter()
@@ -851,11 +851,11 @@ def test_sweep_indirect_references_nullobject_exception(pdf_file_path):
     ("url", "name"),
     [
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf",
+            "https://github.com/user-attachments/files/18381699/tika-924666.pdf",
             "test_sweep_indirect_references_nullobject_exception.pdf",
         ),
         (
-            "https://corpora.tika.apache.org/base/docs/govdocs1/922/922840.pdf",
+            "https://github.com/user-attachments/files/18381694/tika-922840.pdf",
             "test_write_outline_item_on_page_fitv.pdf",
         ),
         ("https://github.com/py-pdf/pypdf/files/10715624/test.pdf", "iss1627.pdf"),
@@ -1042,7 +1042,7 @@ def test_iss471():
 
 @pytest.mark.enable_socket
 def test_reset_translation():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
+    url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     writer = PdfWriter()
@@ -1080,7 +1080,7 @@ def test_threads_empty():
 
 @pytest.mark.enable_socket
 def test_append_without_annots_and_articles():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
+    url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     writer = PdfWriter()
@@ -1099,7 +1099,7 @@ def test_append_without_annots_and_articles():
 
 @pytest.mark.enable_socket
 def test_append_multiple():
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/924/924666.pdf"
+    url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     writer = PdfWriter()

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -166,7 +166,7 @@ def test_xmpmm_instance_id(url, name, xmpmm_instance_id):
 @pytest.mark.enable_socket
 def test_xmp_dc_description_extraction():
     """XMP dc_description is correctly extracted."""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/953/953770.pdf"
+    url = "https://github.com/user-attachments/files/18381721/tika-953770.pdf"
     name = "tika-953770.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     xmp_metadata = reader.xmp_metadata
@@ -182,7 +182,7 @@ def test_xmp_dc_description_extraction():
 @pytest.mark.enable_socket
 def test_dc_creator_extraction():
     """XMP dc_creator is correctly extracted."""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/953/953770.pdf"
+    url = "https://github.com/user-attachments/files/18381721/tika-953770.pdf"
     name = "tika-953770.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     xmp_metadata = reader.xmp_metadata
@@ -194,7 +194,7 @@ def test_dc_creator_extraction():
 @pytest.mark.enable_socket
 def test_custom_properties_extraction():
     """XMP custom_properties is correctly extracted."""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/986/986065.pdf"
+    url = "https://github.com/user-attachments/files/18381764/tika-986065.pdf"
     name = "tika-986065.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     xmp_metadata = reader.xmp_metadata
@@ -206,7 +206,7 @@ def test_custom_properties_extraction():
 @pytest.mark.enable_socket
 def test_dc_subject_extraction():
     """XMP dc_subject is correctly extracted."""
-    url = "https://corpora.tika.apache.org/base/docs/govdocs1/959/959519.pdf"
+    url = "https://github.com/user-attachments/files/18381730/tika-959519.pdf"
     name = "tika-959519.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     xmp_metadata = reader.xmp_metadata


### PR DESCRIPTION
Relates to #3035. Alternative to #3038.