### PR TITLE
STY: Move self._startxref initialization

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -117,7 +117,7 @@ class PdfReader(PdfDocCommon):
         self.strict = strict
         self.flattened_pages: Optional[List[PageObject]] = None
 
-        #: Storage of parsed PDF objects.
+        # Storage of parsed PDF objects.
         self.resolved_objects: Dict[Tuple[Any, Any], Optional[PdfObject]] = {}
 
         self._startxref: int = 0
@@ -127,7 +127,7 @@ class PdfReader(PdfDocCommon):
         self.xref_objStm: Dict[int, Tuple[Any, Any]] = {}
         self.trailer = DictionaryObject()
 
-        # map page indirect_reference number to page number
+        # Map page indirect_reference number to page number
         self._page_id2num: Optional[Dict[Any, Any]] = None
 
         self._validated_root: Optional[DictionaryObject] = None

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -120,6 +120,7 @@ class PdfReader(PdfDocCommon):
         #: Storage of parsed PDF objects.
         self.resolved_objects: Dict[Tuple[Any, Any], Optional[PdfObject]] = {}
 
+        self._startxref: int = 0
         self.xref_index = 0
         self.xref: Dict[int, Dict[Any, Any]] = {}
         self.xref_free_entry: Dict[int, Dict[Any, Any]] = {}
@@ -152,7 +153,6 @@ class PdfReader(PdfDocCommon):
             with open(stream, "rb") as fh:
                 stream = BytesIO(fh.read())
             self._stream_opened = True
-        self._startxref: int = 0
         self.read(stream)
         self.stream = stream
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -117,7 +117,7 @@ class PdfReader(PdfDocCommon):
         self.strict = strict
         self.flattened_pages: Optional[List[PageObject]] = None
 
-        # Storage of parsed PDF objects.
+        #: Storage of parsed PDF objects.
         self.resolved_objects: Dict[Tuple[Any, Any], Optional[PdfObject]] = {}
 
         self._startxref: int = 0


### PR DESCRIPTION
Move from method _initialize_stream to __init__, where other xref-related initialization occurs.