### PR TITLE
ENH: add function merge pdfs in same directory

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -30,6 +30,7 @@
 import decimal
 import enum
 import hashlib
+import os
 import re
 import struct
 import uuid
@@ -2623,6 +2624,23 @@ class PdfWriter(PdfDocCommon):
                 import_outline,
                 excluded_fields,
             )
+
+    def append_path(
+            self,
+            file_path,
+    ) -> None:
+        for f in os.listdir(file_path):
+            if f.endswith(".pdf"):
+                reader = PdfReader(file_path / f)
+                if reader.is_encrypted:
+                    password = input(f"Please input password of {str(f)} :")
+                    try:
+                        reader.decrypt(password)
+                        self.append(reader)
+                    except Exception as e:
+                        print(f"Error reading PDF: {str(e)}")
+                    continue
+                self.append(file_path / f)
 
     def merge(
         self,

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -409,3 +409,11 @@ def test_deprecate_pdfmerger():
 def test_get_reference():
     writer = PdfWriter(RESOURCE_ROOT / "crazyones.pdf")
     assert writer.get_reference(writer.pages[0]) == writer.pages[0].indirect_reference
+
+
+@pytest.mark.enable_socket
+def test_merge_path(tmp_path):
+    merger = PdfWriter()
+    merger.append_path(RESOURCE_ROOT)
+    merger.write(tmp_path / tmp_filename)
+    merger.close()


### PR DESCRIPTION
allow to merge pdfs in same directory by invoking writer.append_path(), avoid to add pdf file by file into a list to append, and allow user to enter password if pdf is encrypted.