### PR TITLE
DEV: Add tool.ruff.lint.pydocstyle to pyproject.toml

### DIFF
--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -47,7 +47,7 @@ def _get_imagemode(
     """
     Returns:
         Image mode, not taking into account mask (transparency).
-        ColorInversion is required (like for some DeviceCMYK)
+        ColorInversion is required (like for some DeviceCMYK).
 
     """
     if depth > MAX_IMAGE_MODE_NESTING_DEPTH:

--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -45,7 +45,7 @@ def _get_imagemode(
     depth: int = 0,
 ) -> Tuple[mode_str_type, bool]:
     """
-    Returns
+    Returns:
         Image mode not taking into account mask(transparency)
         ColorInversion is required (like for some DeviceCMYK)
 

--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -46,7 +46,7 @@ def _get_imagemode(
 ) -> Tuple[mode_str_type, bool]:
     """
     Returns:
-        Image mode, not taking into account mask (transparency)
+        Image mode, not taking into account mask (transparency).
         ColorInversion is required (like for some DeviceCMYK)
 
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,9 @@ max-complexity = 54  # Recommended: 10
 "tests/*" = ["S101", "ANN001", "ANN201","D104", "S105", "S106", "D103", "B018", "B017"]
 "tests/test_workflows.py" =  ["T201"]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.lint.pylint]
 allow-magic-value-types = ["bytes", "float", "int", "str"]
 max-args = 12  # Recommended: 5


### PR DESCRIPTION
[tool.ruff.lint.pydocstyle]
convention = "google"

Append a colon, as pydocstyle found one section name should end with a colon.