### PR TITLE
STY: Import TextStringObject at the top of file

### DIFF
--- a/pypdf/_xobj_image_helpers.py
+++ b/pypdf/_xobj_image_helpers.py
@@ -15,6 +15,7 @@ from .generic import (
     EncodedStreamObject,
     IndirectObject,
     NullObject,
+    TextStringObject,
 )
 
 if sys.version_info[:2] >= (3, 10):
@@ -184,8 +185,6 @@ def _handle_flate(
         data = bits2byte(data, size, 4)
     img = _extended_image_frombytes(mode, size, data)
     if color_space == "/Indexed":
-        from .generic import TextStringObject
-
         if isinstance(lookup, (EncodedStreamObject, DecodedStreamObject)):
             lookup = lookup.get_data()
         if isinstance(lookup, TextStringObject):


### PR DESCRIPTION
EncodedStreamObject and DecodedStreamObject are only used once within the same if statement as TextStringObject. For consistency import TextStringObject with these at the top of the file.