### PR TITLE
TST: Fix warning assertions to use `pytest.warns()`

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -189,7 +189,7 @@ def test_ascii85decode_five_zero_bytes():
 
 
 def test_ccitparameters():
-    with pytest.raises(
+    with pytest.warns(
         DeprecationWarning,
         match="CCITParameters is deprecated and will be removed in pypdf 6.0.0. Use CCITTParameters instead",
     ):

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -234,7 +234,7 @@ def test_name_object(caplog):
 
     caplog.clear()
     b = BytesIO()
-    with pytest.raises(DeprecationWarning):
+    with pytest.warns(DeprecationWarning):
         NameObject("hello").write_to_stream(b)
 
     caplog.clear()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -744,7 +744,7 @@ def test_decode_permissions():
 
     print_ = base.copy()
     print_["print"] = True
-    with pytest.raises(
+    with pytest.warns(
         DeprecationWarning,
         match="decode_permissions is deprecated and will be removed in pypdf 5.0.0. Use user_access_permissions instead",  # noqa: E501
     ):
@@ -752,7 +752,7 @@ def test_decode_permissions():
 
     modify = base.copy()
     modify["modify"] = True
-    with pytest.raises(
+    with pytest.warns(
         DeprecationWarning,
         match="decode_permissions is deprecated and will be removed in pypdf 5.0.0. Use user_access_permissions instead",  # noqa: E501
     ):


### PR DESCRIPTION
Use `pytest.warns()` to assert for warnings, so that the test suite passes without `-Werror`.