### PR TITLE
DEV: Move Ruff rule PLW3301

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -534,7 +534,9 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
             for gen in rem_gens:
                 loc = pdf.xref[gen]
                 try:
-                    out = min(out, min([x for x in loc.values() if p < x <= p1]))
+                    values = [x for x in loc.values() if p < x <= p1]
+                    if values:
+                        out = min(out, *values)
                 except ValueError:
                     pass
             return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,12 +206,12 @@ max-complexity = 54  # Recommended: 10
 [tool.ruff.lint.per-file-ignores]
 "_cryptography.py" = ["S304", "S305"]  # Use of insecure cipher / modes, aka RC4 and AES-ECB
 "_encryption.py" = ["S324"]
-"_reader.py" = ["PLW3301"]  # nested-min-max. Nested min and max calls can be flattened into a single call to improve readability.
 "_writer.py" = ["S324"]
 "docs/conf.py" = ["INP001", "PTH100"]
 "json_consistency.py" = ["T201"]
 "make_release.py" = ["S603", "S607", "T201"]
-"pypdf/*" = ["N802", "N803"]  # We first need to deprecate old stuff:
+"pypdf/*" = ["N802", "N803"]  # We first need to deprecate old stuff
+"pypdf/generic/_data_structures.py" = ["PLW3301"]  # nested-min-max. Nested min and max calls can be flattened into a single call to improve readability.
 "sample-files/*" = ["D100", "INP001"]
 "tests/*" = ["ANN001", "ANN201", "B017", "B018", "D103", "D104", "S105", "S106"]
 "tests/test_workflows.py" =  ["T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ ignore = [
     "PLW0603", # Using the global statement to update `CUSTOM_RTL_SPECIAL_CHARS` is discouraged
     "PLW1510", # `subprocess.run` without explicit `check` argument
     "PLW2901", # `with` statement variable `img` overwritten by assignment target
-    "PLW3301", # Nested `min` calls can be flattened
     "PT011",   # `pytest.raises(ValueError)` is too broad, set the `match`
     "PT012",   # `pytest.raises()` block should contain a single simple statement
     "PT014",   # Ruff bug: Duplicate of test case at index 1 in `@pytest_mark.parametrize`
@@ -207,6 +206,7 @@ max-complexity = 54  # Recommended: 10
 [tool.ruff.lint.per-file-ignores]
 "_cryptography.py" = ["S304", "S305"]  # Use of insecure cipher / modes, aka RC4 and AES-ECB
 "_encryption.py" = ["S324"]
+"_reader.py" = ["PLW3301"]  # nested-min-max. Nested min and max calls can be flattened into a single call to improve readability.
 "_writer.py" = ["S324"]
 "docs/conf.py" = ["INP001", "PTH100"]
 "json_consistency.py" = ["T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,6 @@ max-complexity = 54  # Recommended: 10
 "json_consistency.py" = ["T201"]
 "make_release.py" = ["S603", "S607", "T201"]
 "pypdf/*" = ["N802", "N803"]  # We first need to deprecate old stuff
-"pypdf/generic/_data_structures.py" = ["PLW3301"]  # nested-min-max. Nested min and max calls can be flattened into a single call to improve readability.
 "sample-files/*" = ["D100", "INP001"]
 "tests/*" = ["ANN001", "ANN201", "B017", "B018", "D103", "D104", "S105", "S106"]
 "tests/test_workflows.py" =  ["T201"]


### PR DESCRIPTION
Move from tool.ruff.lint (global) to tool.ruff.lint.per-file-ignores. PLW3301: nested-min-max. Nested min and max calls can be flattened into a single call to improve readability.