### PR TITLE
DEV: Avoid bundling the PDF cache directory in sdists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,21 @@ docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
 package = "./pypdf"
 
 [tool.flit.sdist]
-exclude = [".github/*", "docs/*", "sample-files/.github/*", "sample-files/.gitignore", "sample-files/.pre-commit-config.yaml",  "requirements/*", ".flake8", ".gitignore", ".gitmodules", ".pylintrc", "tox.ini", "make_release.py", ".pre-commit-config.yaml", ".gitblame-ignore-revs", "Makefile"]
+exclude = [
+    ".gitblame-ignore-revs",
+    ".github/*",
+    ".gitignore",
+    ".gitmodules",
+    ".pre-commit-config.yaml",
+    "docs/*",
+    "make_release.py",
+    "Makefile",
+    "requirements/*",
+    "sample-files/.github/*",
+    "sample-files/.gitignore",
+    "sample-files/.pre-commit-config.yaml",
+    "tests/pdf_cache/*",
+]
 include = ["resources/", "tests/"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Otherwise, building the package on local systems leads to sdists being 408 MB instead of 4.8 MB.