### PR TITLE
DEV: Remove Ruff rule PLW0602

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,6 @@ ignore = [
     "PERF203", # `try`-`except` within a loop incurs performance overhead
     "PGH003",  # Use specific rule codes when ignoring type issues
     "PLC0206", # Extracting value from dictionary without calling `.items()`
-    "PLW0602", # Using global for `CUSTOM_RTL_SPECIAL_CHARS` but no assignment is done
     "PLW0603", # Using the global statement to update `CUSTOM_RTL_SPECIAL_CHARS` is discouraged
     "PLW1510", # `subprocess.run` without explicit `check` argument
     "PLW2901", # `with` statement variable `img` overwritten by assignment target


### PR DESCRIPTION
PLW0602: Using a global but no assignment is done.