### PR TITLE
DOC: Modified exception message to be more informative

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2520,7 +2520,7 @@ class _VirtualList(Sequence[PageObject]):
             cls = type(self)
             return cls(indices.__len__, lambda idx: self[indices[idx]])
         if not isinstance(index, int):
-            raise TypeError("Sequence indices must be integers")
+            raise TypeError("Sequence index must be a single integer")
         len_self = len(self)
         if index < 0:
             # support negative indexes


### PR DESCRIPTION
I tried accessing `PdfReader().pages` with `[index, index]` instead of `[index:index]` . The consequent exception message was “Sequence indices must be integers”, which was unhelpful, as the passed indices really were `int` objects.

Although this is not a problem for the seasoned python user-who is perhaps more aware of the intricacies of python indexing, it can be problematic for someone who is new or is only a tourist in the world of python, which seems likely given the nature of the project. Consequently, they would benefit from an exception message that chisels out how the data structure is to be engaged with with greater precision.

So I suggest changing the exception message to “Sequence index must be a single integer".

	modified:   pypdf/_page.py