### PR TITLE
ROB: Avoid index errors on empty lines in xref table

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -747,6 +747,8 @@ class PdfReader(PdfDocCommon):
             cnt = 0
             while cnt < size:
                 line = stream.read(20)
+                if not line:
+                    raise PdfReadError("Unexpected empty line in Xref table.")
 
                 # It's very clear in section 3.4.3 of the PDF spec
                 # that all cross-reference table lines are a fixed

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1796,3 +1796,13 @@ def test_issue3151(caplog):
     name = "issue3151.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     assert len(reader.pages) == 742
+
+
+@pytest.mark.enable_socket
+def test_issue2886(caplog):
+    """Tests for #2886"""
+    url = "https://github.com/user-attachments/files/17187711/crash-e8a85d82de01cab5eb44e7993304d8b9d1544970.pdf"
+    name = "issue2886.pdf"
+
+    with pytest.raises(PdfReadError, match="Unexpected empty line in Xref table."):
+        _ = PdfReader(BytesIO(get_data_from_url(url, name=name)))


### PR DESCRIPTION
Closes #2886.