### PR TITLE
DEV: Remove ignore Ruff rules D404 and D406

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,6 @@ ignore = [
     "D212",    # I want multiline-docstrings to start at the second line
     "D400",    # First line should end with a period
     "D401",    # First line of docstring should be in imperative mood - false positives
-    "D404",    # First word of the docstring should not be "This"
-    "D406",    # Section name should end with a newline ("Returns")
     "D415",    # First line should end with a period
     "D417",    # Missing argument descriptions in the docstring
     "DTZ001",  # The use of `datetime.datetime()` without `tzinfo` is necessary


### PR DESCRIPTION
D404: First word of the docstring should not be "This". D406: Section name should end with a newline.