### PR TITLE
DEV: Remove ignore Ruff rule RET502

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2057,7 +2057,7 @@ class PdfWriter(PdfDocCommon):
         if isinstance(to_delete, (list, tuple)):
             for to_d in to_delete:
                 self.remove_objects_from_page(page, to_d)
-            return
+            return None
         assert isinstance(to_delete, ObjectDeletionFlag)
 
         if to_delete & ObjectDeletionFlag.LINKS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,6 @@ ignore = [
     "PTH123",  # `open()` should be replaced by `Path.open()`
     "PYI042",  # Type alias `mode_str_type` should be CamelCase
     "RET501",  # Do not explicitly `return None` in function if it is the only possible return value
-    "RET502",  # Do not implicitly `return None` in function able to return non-`None` value
     "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
     "RET505",  # Unnecessary `else` after `return` statement
     "RUF001",  # Detect confusable Unicode-to-Unicode units. Introduces bugs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ ignore = [
     "PT014",   # Ruff bug: Duplicate of test case at index 1 in `@pytest_mark.parametrize`
     "PTH123",  # `open()` should be replaced by `Path.open()`
     "PYI042",  # Type alias `mode_str_type` should be CamelCase
-    "RET502",  # Do not implicitly `return None` in function able to return non-`None` value
     "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
     "RET505",  # Unnecessary `else` after `return` statement
     "RUF001",  # Detect confusable Unicode-to-Unicode units. Introduces bugs

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -168,5 +168,5 @@ class PILContext:
         ImageFile.LOAD_TRUNCATED_IMAGES = self._saved_load_truncated_images
         if type_:
             # Error.
-            return
+            return None
         return True


### PR DESCRIPTION
RET502: Do not implicitly "return None" in function able to return non-"None" value.