### PR TITLE
ROB: ignore annotation with Go-To action missing a /D name attribute (#3211)

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2968,7 +2968,10 @@ class PdfWriter(PdfDocCommon):
                             anc[NameObject("/Dest")] = ArrayObject([p] + d[1:])
                             outlist.append(self._add_object(anc))
             else:
-                d = cast("DictionaryObject", ano["/A"])["/D"]
+                annot_obj = cast("DictionaryObject", ano["/A"])
+                if "/D" not in annot_obj:
+                    continue
+                d = annot_obj["/D"]
                 if isinstance(d, NullObject):
                     continue
                 if isinstance(d, str):


### PR DESCRIPTION
This PR fixes a bug encountered in issue #3211. 

I've being looking through the official Acrobat PDF standard specifications, and this `/D` field _should_ be present for Go-To actions, however the code already has a case where this /D is a NullObject, so I guess it is fine to consider the non-existence case similarly. 