### PR TITLE
ROB: Handle some None values for broken PDF files

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1847,8 +1847,8 @@ class PageObject(DictionaryObject):
             # file as not damaged, no need to check for TJ or Tj
             return ""
 
-        if "/Font" in resources_dict and (font := cast(DictionaryObject, resources_dict["/Font"])):
-            for f in font:
+        if "/Font" in resources_dict and (font := resources_dict["/Font"]):
+            for f in cast(DictionaryObject, font):
                 cmaps[f] = build_char_map(f, space_width, obj)
         cmap: Tuple[
             Union[str, Dict[int, str]], Dict[str, str], str, Optional[DictionaryObject]

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -5,7 +5,8 @@ from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
 from random import shuffle
-from typing import List, Tuple
+from typing import Any, List, Tuple
+from unittest import mock
 
 import pytest
 
@@ -1471,3 +1472,36 @@ def test_recursive_get_page_from_node():
     writer.insert_page(writer.pages[0], -1)
     with pytest.raises(ValueError):
         writer.insert_page(writer.pages[0], -10)
+
+
+def test_get_contents__none_type():
+    # We can observe this in reality as well, but these documents might be
+    # confidential. Thus use a more complex dummy implementation here while
+    # assigning a value of `None` is not possible from code, but from PDFs
+    # itself.
+    class MyPage(PageObject):
+        def __contains__(self, item) -> bool:
+            assert item == "/Contents"
+            return True
+
+        def __getitem__(self, item) -> Any:
+            assert item == "/Contents"
+
+    page = MyPage()
+    assert page.get_contents() is None
+
+
+def test_extract_text__none_type():
+    class MyPage(PageObject):
+        def __getitem__(self, item) -> Any:
+            if item == "/Contents":
+                return None
+            return super().__getitem__(item)
+
+    page = MyPage()
+    resources = DictionaryObject()
+    none_reference = IndirectObject(1, 0, None)
+    resources[NameObject("/Font")] = none_reference
+    page[NameObject("/Resources")] = resources
+    with mock.patch.object(none_reference, "get_object", return_value=None):
+        assert page.extract_text() == ""


### PR DESCRIPTION
These issues were discovered while trying to extract text and images from some PDF files which were incomplete, but partially fixed.