### PR TITLE
DEV: Remove an exclusion from tool.coverage.report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,6 @@ exclude_lines = [
     # Don't complain if tests don't hit defensive assertion code:
     "raise AssertionError",
     "raise NotImplementedError",
-
-    # Don't complain if non-runnable code isn't run:
-    "if __name__ == .__main__.:",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
The line removed from being excluded is: "if __name__ == .__main__.:". Note the two periods around __main__.