### PR TITLE
BUG: T* 2D Translation consistent with PDF 1.7 Spec

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2020,6 +2020,12 @@ class PageObject(DictionaryObject):
                 tm_matrix = [float(operand) for operand in operands[:6]]
                 str_widths = compute_str_widths(_actual_str_size["str_widths"])
                 _actual_str_size["str_widths"] = 0.0
+            elif operator == b"T*":
+                check_crlf_space = True
+                tm_matrix[4] -= TL * tm_matrix[2]
+                tm_matrix[5] -= TL * tm_matrix[3]
+                str_widths = compute_str_widths(_actual_str_size["str_widths"])
+                _actual_str_size["str_widths"] = 0.0
             elif operator == b"Tj":
                 check_crlf_space = True
                 text, rtl_dir, _actual_str_size = self._handle_tj(
@@ -2088,8 +2094,6 @@ class PageObject(DictionaryObject):
             elif operator == b"TD":
                 process_operation(b"TL", [-operands[1]])
                 process_operation(b"Td", operands)
-            elif operator == b"T*":
-                process_operation(b"Td", [0, TL])
             elif operator == b"Do":
                 output += text
                 if visitor_text is not None:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2009,8 +2009,7 @@ class PageObject(DictionaryObject):
                 # A special case is a translating only tm:
                 # tm = [1, 0, 0, 1, e, f]
                 # i.e. tm[4] += tx, tm[5] += ty.
-                tx = float(operands[0])
-                ty = float(operands[1])
+                tx, ty = float(operands[0]), float(operands[1])
                 tm_matrix[4] += tx * tm_matrix[0] + ty * tm_matrix[2]
                 tm_matrix[5] += tx * tm_matrix[1] + ty * tm_matrix[3]
                 str_widths = compute_str_widths(_actual_str_size["str_widths"])

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2020,9 +2020,6 @@ class PageObject(DictionaryObject):
                 tm_matrix = [float(operand) for operand in operands[:6]]
                 str_widths = compute_str_widths(_actual_str_size["str_widths"])
                 _actual_str_size["str_widths"] = 0.0
-            elif operator == b"T*":
-                check_crlf_space = True
-                tm_matrix[5] -= TL
             elif operator == b"Tj":
                 check_crlf_space = True
                 text, rtl_dir, _actual_str_size = self._handle_tj(
@@ -2091,6 +2088,8 @@ class PageObject(DictionaryObject):
             elif operator == b"TD":
                 process_operation(b"TL", [-operands[1]])
                 process_operation(b"Td", operands)
+            elif operator == b"T*":
+                process_operation(b"Td", [0, TL])
             elif operator == b"Do":
                 output += text
                 if visitor_text is not None:

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -353,3 +353,18 @@ def test_layout_mode_text_state():
     expected = get_data_from_url(txt_url, name=txt_name).decode("utf-8").replace("\r\n", "\n")
 
     assert expected == reader.pages[0].extract_text(extraction_mode="layout")
+
+
+@pytest.mark.enable_socket
+def test_rotated_line_wrap():
+    """Ensure correct 2D translation of rotated text after a line wrap."""
+    # Get the PDF from issue #3247
+    url = "https://github.com/user-attachments/files/19696918/link16-line-wrap.sanitized.pdf"
+    name = "link16-line-wrap.sanitized.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    # Get the txt from issue #3247 and normalize line endings
+    txt_url = "https://github.com/user-attachments/files/19696917/link16-line-wrap.sanitized.expected.txt"
+    txt_name = "link16-line-wrap.sanitized.expected.txt"
+    expected = get_data_from_url(txt_url, name=txt_name).decode("utf-8").replace("\r\n", "\n")
+
+    assert expected == reader.pages[0].extract_text()


### PR DESCRIPTION
Closes #3247 

Per the [PFD32000.book](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf) 9.4.2, the `T*` is equivalent to `0 -TL TD`. This changes the pypdf implementation to be consistent.