### PR TITLE
BUG: Get font information more reliably when removing text

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2252,10 +2252,12 @@ class PdfWriter(PdfDocCommon):
             # Font names need to be converted to resource names for easier removal
             if font_names:
                 # Recursively loop through the page to gather font info
-                def get_font_info(obj, font_info = {}, key = None):
+                def get_font_info(obj: Any, font_info: Optional[Dict[str, Any]] = None, key: Optional[str] = None) -> Dict[str, Any]:
+                    if font_info is None:
+                        font_info = {}
                     if isinstance(obj, dict):
                         if obj.get("/Type") == "/Font":
-                            font_name = obj.get("/BaseFont")
+                            font_name = obj.get("/BaseFont", "")
                             # Normalize font names like "/RRXFFV+Palatino-Bold" to "Palatino-Bold"
                             normalized_font_name = font_name.lstrip("/").split("+")[-1]
                             if normalized_font_name not in font_info:
@@ -2265,9 +2267,9 @@ class PdfWriter(PdfDocCommon):
                                 }
                             if key not in font_info[normalized_font_name]["resource_names"]:
                                 font_info[normalized_font_name]["resource_names"].append(key)
-                        for key in obj.keys():
-                            font_info = get_font_info(obj[key], font_info, key)
-                    elif isinstance(obj, list) or isinstance(obj, ArrayObject):
+                        for k, v in obj.items():
+                            font_info = get_font_info(obj[k], font_info, k)
+                    elif isinstance(obj, (list, ArrayObject)):
                         for child_obj in obj:
                             font_info = get_font_info(child_obj, font_info)
                     elif isinstance(obj, IndirectObject):

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2118,9 +2118,11 @@ class PdfWriter(PdfDocCommon):
                         and (operands[0] in images)
                     )
                 ):
-                    if to_delete & ObjectDeletionFlag.TEXT and not text_filters:
-                        del content.operations[i]
-                    elif to_delete & ObjectDeletionFlag.TEXT and font_id in font_ids_to_delete:
+                    if (
+                        not to_delete & ObjectDeletionFlag.TEXT
+                        or (to_delete & ObjectDeletionFlag.TEXT and not text_filters)
+                        or (to_delete & ObjectDeletionFlag.TEXT and font_id in font_ids_to_delete)
+                    ):
                         del content.operations[i]
                     else:
                         i += 1
@@ -2248,7 +2250,7 @@ class PdfWriter(PdfDocCommon):
             resource_ids_to_remove = []
 
             # Content streams reference fonts and other resources with names like "/F1" or "/T1_0"
-            # Font names need to be converted to resource names for easier removal
+            # Font names need to be converted to resource names/IDs for easier removal
             if font_names:
                 # Recursively loop through the page to gather font info
                 def get_font_info(

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2271,7 +2271,7 @@ class PdfWriter(PdfDocCommon):
                                 }
                             if key not in font_info[normalized_font_name]["resource_names"]:
                                 font_info[normalized_font_name]["resource_names"].append(key)
-                        for k in obj.keys():
+                        for k in obj:
                             font_info = get_font_info(obj[k], font_info, k)
                     elif isinstance(obj, (list, ArrayObject)):
                         for child_obj in obj:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2252,7 +2252,7 @@ class PdfWriter(PdfDocCommon):
             # Content streams reference fonts and other resources with names like "/F1" or "/T1_0"
             # Font names need to be converted to resource names/IDs for easier removal
             if font_names:
-                # Recursively loop through the page to gather font info
+                # Recursively loop through page objects to gather font info
                 def get_font_info(
                     obj: Any,
                     font_info: Optional[Dict[str, Any]] = None,
@@ -2260,6 +2260,8 @@ class PdfWriter(PdfDocCommon):
                 ) -> Dict[str, Any]:
                     if font_info is None:
                         font_info = {}
+                    if isinstance(obj, IndirectObject):
+                        obj = obj.get_object()
                     if isinstance(obj, dict):
                         if obj.get("/Type") == "/Font":
                             font_name = obj.get("/BaseFont", "")
@@ -2277,8 +2279,6 @@ class PdfWriter(PdfDocCommon):
                     elif isinstance(obj, (list, ArrayObject)):
                         for child_obj in obj:
                             font_info = get_font_info(child_obj, font_info)
-                    elif isinstance(obj, IndirectObject):
-                        font_info = get_font_info(obj.get_object(), font_info)
                     return font_info
 
                 # Add relevant resource names for removal

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2252,7 +2252,11 @@ class PdfWriter(PdfDocCommon):
             # Font names need to be converted to resource names for easier removal
             if font_names:
                 # Recursively loop through the page to gather font info
-                def get_font_info(obj: Any, font_info: Optional[Dict[str, Any]] = None, key: Optional[str] = None) -> Dict[str, Any]:
+                def get_font_info(
+                    obj: Any,
+                    font_info: Optional[Dict[str, Any]] = None,
+                    key: Optional[str] = None
+                ) -> Dict[str, Any]:
                     if font_info is None:
                         font_info = {}
                     if isinstance(obj, dict):
@@ -2267,7 +2271,7 @@ class PdfWriter(PdfDocCommon):
                                 }
                             if key not in font_info[normalized_font_name]["resource_names"]:
                                 font_info[normalized_font_name]["resource_names"].append(key)
-                        for k, v in obj.items():
+                        for k in obj.keys():
                             font_info = get_font_info(obj[k], font_info, k)
                     elif isinstance(obj, (list, ArrayObject)):
                         for child_obj in obj:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1391,15 +1391,15 @@ def test_new_removes():
     writer.clone_document_from_reader(reader)
     b = BytesIO()
     writer.write(b)
-    reader = PdfReader(b)
-    text = reader.pages[0].extract_text()
+    temp_reader = PdfReader(b)
+    text = temp_reader.pages[0].extract_text()
     assert "Arbeitsschritt" in text
     assert "Modelltechnik" in text
     writer.remove_text(font_names=["LiberationSans-Bold"])
     b = BytesIO()
     writer.write(b)
-    reader = PdfReader(b)
-    text = reader.pages[0].extract_text()
+    temp_reader = PdfReader(b)
+    text = temp_reader.pages[0].extract_text()
     assert "Arbeitsschritt" not in text
     assert "Modelltechnik" in text
 
@@ -1408,15 +1408,15 @@ def test_new_removes():
     writer.clone_document_from_reader(reader)
     b = BytesIO()
     writer.write(b)
-    reader = PdfReader(b)
-    text = reader.pages[0].extract_text()
+    temp_reader = PdfReader(b)
+    text = temp_reader.pages[0].extract_text()
     assert "Arbeitsschritt" in text
     assert "Modelltechnik" in text
     writer.remove_text(font_names=["ComicSans-Oblique"])
     b = BytesIO()
     writer.write(b)
-    reader = PdfReader(b)
-    text = reader.pages[0].extract_text()
+    temp_reader = PdfReader(b)
+    text = temp_reader.pages[0].extract_text()
     assert "Arbeitsschritt" in text
     assert "Modelltechnik" in text
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1386,6 +1386,7 @@ def test_new_removes():
     assert b"Chap" not in bb
     assert b" TJ" not in bb
 
+    # Test removing text in a specified font
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
     b = BytesIO()
@@ -1400,6 +1401,23 @@ def test_new_removes():
     reader = PdfReader(b)
     text = reader.pages[0].extract_text()
     assert "Arbeitsschritt" not in text
+    assert "Modelltechnik" in text
+
+    # Test removing text in a specified font that doesn't exist (nothing should happen)
+    writer = PdfWriter()
+    writer.clone_document_from_reader(reader)
+    b = BytesIO()
+    writer.write(b)
+    reader = PdfReader(b)
+    text = reader.pages[0].extract_text()
+    assert "Arbeitsschritt" in text
+    assert "Modelltechnik" in text
+    writer.remove_text(font_names=["ComicSans-Oblique"])
+    b = BytesIO()
+    writer.write(b)
+    reader = PdfReader(b)
+    text = reader.pages[0].extract_text()
+    assert "Arbeitsschritt" in text
     assert "Modelltechnik" in text
 
     url = "https://github.com/py-pdf/pypdf/files/10832029/tt2.pdf"


### PR DESCRIPTION
Last month I contributed pull request https://github.com/py-pdf/pypdf/pull/3216, an enhancement to `PdfWriter.removeText()` that allows users to remove only the specified fonts. Since then, I've come across a few PDFs where my simple logic to find fonts wasn't working. This fix walks through the PDF structure to find font references more reliably. I also added a few explanatory comments.