### PR TITLE
STY: Idiomatic iteration in _fixed_width_page.py

### DIFF
--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -90,7 +90,7 @@ def recurs_to_target_op(
         # add new q level. cm's added at this level will be popped at next b'Q'
         text_state_mgr.add_q()
 
-    for operands, op in ops:  # pragma: no branch
+    for operands, op in ops:
         # The loop is broken by the end target, or exits normally when there are no more ops.
         if op == end_target:
             if op == b"Q":
@@ -196,7 +196,11 @@ def recurs_to_target_op(
             text_state_mgr.set_font(fonts[operands[0]], operands[1])
         else:  # handle Tc, Tw, Tz, TL, and Ts operators
             text_state_mgr.set_state_param(op, operands)
-
+    else:
+        logger_warning(
+            f"Unbalanced target operations, expected {end_target!r}.",
+            __name__,
+        )
     return bt_groups, tj_ops
 
 

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -90,7 +90,8 @@ def recurs_to_target_op(
         # add new q level. cm's added at this level will be popped at next b'Q'
         text_state_mgr.add_q()
 
-    for operands, op in ops:
+    for operands, op in ops:  # pragma: no branch
+        # The loop is broken by the end target, or exits normally when there are no more ops.
         if op == end_target:
             if op == b"Q":
                 text_state_mgr.remove_q()

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -147,7 +147,7 @@ def recurs_to_target_op(
                 if _text:
                     bt_groups.append(bt_group(tj_ops[bt_idx], _text, last_displaced_tx))
                 text_state_mgr.reset_tm()
-            return bt_groups, tj_ops
+            break
         if op == b"q":
             bts, tjs = recurs_to_target_op(
                 ops, text_state_mgr, b"Q", fonts, strip_rotated

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -90,11 +90,7 @@ def recurs_to_target_op(
         # add new q level. cm's added at this level will be popped at next b'Q'
         text_state_mgr.add_q()
 
-    while True:
-        try:
-            operands, op = next(ops)
-        except StopIteration:
-            return bt_groups, tj_ops
+    for operands, op in ops:
         if op == end_target:
             if op == b"Q":
                 text_state_mgr.remove_q()
@@ -199,6 +195,8 @@ def recurs_to_target_op(
             text_state_mgr.set_font(fonts[operands[0]], operands[1])
         else:  # handle Tc, Tw, Tz, TL, and Ts operators
             text_state_mgr.set_state_param(op, operands)
+
+    return bt_groups, tj_ops
 
 
 def y_coordinate_groups(


### PR DESCRIPTION
The loops ...
```python
for item in iterator:
    ...
```
... and ...
```python
while True:
    try:
        item = next(iterator)
    except StopIteration:
        break
    ....
```
... are functionally equivalent. Both consume the `next` value form an iterator and exit when the iterator raises a `StopIteration`. The `for` loop more intuitively represents the intent to iterate the `ops`, and improves clarity that the loop exits if there are no more ops. This also reduces the number of logical paths through the function(s), consolidate the flow control, and eliminates the need for large try/except blocks, which tent to have unintended consequences

Per copilot:
---
The changes in this pull request involve refactoring the code to replace `while True` loops with `for` loops and removing `try`/`except StopIteration` constructs where iterations over `ops` are used. Here's a summary of the changes:

1. **`recurs_to_target_op` Function:**
   - Replaced the `while True` loop with a `for` loop for iterating over `ops`.
   - Simplified the control flow by removing the `try`/`except StopIteration` block.
   - Changed the `return` statement within the loop to `break` for better readability and to avoid returning prematurely.
   - Added a final `return bt_groups, tj_ops` at the end of the function to ensure the results are returned after the loop completes.

2. **`text_show_operations` Function:**
   - Similarly, replaced the `while True` loop with a `for` loop.
   - Removed the `try`/`except StopIteration` block for iterating over `ops`.
   - Adjusted the control flow to eliminate the need for exception handling.

These changes improve code readability, maintainability, and make the control flow more explicit by avoiding infinite loops and exception-based iteration handling.