### PR TITLE
STY: Simplify warnings & debugging in layout mode text extraction

### DIFF
--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -252,7 +252,6 @@ def y_coordinate_groups(
     return ty_groups
 
 
-
 def text_show_operations(
     ops: Iterator[Tuple[List[Any], bytes]],
     fonts: Dict[str, Font],
@@ -323,6 +322,7 @@ def text_show_operations(
             "utf-8",
         )
     return bt_groups
+
 
 def fixed_char_width(bt_groups: List[BTGroup], scale_weight: float = 1.25) -> float:
     """

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -324,7 +324,6 @@ def text_show_operations(
         )
     return bt_groups
 
-
 def fixed_char_width(bt_groups: List[BTGroup], scale_weight: float = 1.25) -> float:
     """
     Calculate average character width weighted by the length of the rendered


### PR DESCRIPTION
The existing code for warning if there is rotated text or uninterpretable fonts is slightly overcomplicated. It follows two nested loops to decide if there is text to warn, and needs local variables to flag if a warning is already emitted. It also comingles debug-only logic with the operational code by re-checking for each group of operators if they will be debugged later.

This PR clarifies both by waiting until all operators are collected before searching them for warn-able data, or deciding if to debug them. This removes the need for several variables, nested loops, and several conditional expressions within the loop.