### PR TITLE
MAINT: Comform ASCIIHexDecode implementation to specification

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -306,7 +306,12 @@ class ASCIIHexDecode:
                 retval += bytes((int(hex_pair, base=16),))
                 hex_pair = b""
             index += 1
-        assert hex_pair == b""
+        # If the filter encounters the EOD marker after reading
+        # an odd number of hexadecimal digits
+        # it shall behave as if a 0 (zero) followed the last digit
+        if hex_pair != b"":
+            hex_pair += b"0"
+            retval += bytes((int(hex_pair, base=16),))
         return retval
 
 

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -294,7 +294,7 @@ class ASCIIHexDecode:
                 logger_warning(
                     "missing EOD in ASCIIHexDecode, check if output is OK", __name__
                 )
-                break  # Reached end of string even without an EOD
+                break  # Reached end of string without an EOD
             char = data[index : index + 1]
             if char == b">":
                 break
@@ -307,7 +307,7 @@ class ASCIIHexDecode:
                 hex_pair = b""
             index += 1
         # If the filter encounters the EOD marker after reading
-        # an odd number of hexadecimal digits
+        # an odd number of hexadecimal digits,
         # it shall behave as if a 0 (zero) followed the last digit
         if hex_pair != b"":
             hex_pair += b"0"
@@ -356,7 +356,7 @@ class RunLengthDecode:
                 logger_warning(
                     "missing EOD in RunLengthDecode, check if output is OK", __name__
                 )
-                break  # Reached end of string even without an EOD
+                break  # Reached end of string without an EOD
             length = data[index]
             index += 1
             if length == 128:

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -294,7 +294,7 @@ class ASCIIHexDecode:
                 logger_warning(
                     "missing EOD in ASCIIHexDecode, check if output is OK", __name__
                 )
-                break  # Reached end of string even if no EOD
+                break  # Reached end of string even without an EOD
             char = data[index : index + 1]
             if char == b">":
                 break
@@ -356,7 +356,7 @@ class RunLengthDecode:
                 logger_warning(
                     "missing EOD in RunLengthDecode, check if output is OK", __name__
                 )
-                break  # reach End Of String even if no EOD
+                break  # Reached end of string even without an EOD
             length = data[index]
             index += 1
             if length == 128:

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -308,7 +308,8 @@ class ASCIIHexDecode:
             index += 1
         # If the filter encounters the EOD marker after reading
         # an odd number of hexadecimal digits,
-        # it shall behave as if a 0 (zero) followed the last digit
+        # it shall behave as if a 0 (zero) followed the last digit.
+        # For every even number of hexadecimal digits, hex_pair is reset to b"".
         if hex_pair != b"":
             hex_pair += b"0"
             retval += bytes((int(hex_pair, base=16),))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -98,6 +98,8 @@ def test_flate_decode_decompress_with_array_params(params):
             string.ascii_letters.encode(),
         ),
         ("30313233343536373839>", string.digits.encode()),
+        # Check odd number of hexadecimal digits behaves as if a 0 (zero) followed the last digit
+        ("3938373635343332313>", string.digits[::-1].encode()),
         (
             "3  031323334353637   3839>",
             string.digits.encode(),
@@ -120,10 +122,6 @@ def test_ascii_hex_decode_method(data, expected):
     """
     Feeds a bunch of values to ASCIIHexDecode.decode() and ensures the
     correct output is returned.
-
-    TODO What is decode() supposed to do for such inputs as ">>", ">>>" or
-    any other not terminated by ">"? (For the latter case, an exception
-    is currently raised.)
     """
     assert ASCIIHexDecode.decode(data) == expected
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -98,14 +98,14 @@ def test_flate_decode_decompress_with_array_params(params):
             string.ascii_letters.encode(),
         ),
         ("30313233343536373839>", string.digits.encode()),
-        # Check odd number of hexadecimal digits behaves as if a 0 (zero) followed the last digit
-        ("3938373635343332313>", string.digits[::-1].encode()),
         (
             "3  031323334353637   3839>",
             string.digits.encode(),
         ),  # Same as previous, but whitespaced
         ("30313233343536373839616263646566414243444546>", string.hexdigits.encode()),
         ("20090a0d0b0c>", string.whitespace.encode()),
+        # Odd number of hexadecimal digits behaves as if a 0 (zero) followed the last digit
+        ("3938373635343332313>", string.digits[::-1].encode()),
     ],
     ids=[
         "empty",
@@ -116,6 +116,7 @@ def test_flate_decode_decompress_with_array_params(params):
         "digits_whitespace",
         "hexdigits",
         "whitespace",
+        "odd_number",
     ],
 )
 def test_ascii_hex_decode_method(data, expected):


### PR DESCRIPTION
If the filter encounters the EOD marker after reading an odd number of hexadecimal digits, it shall behave as if a 0 (zero) followed the last digit [PDF 2.0, §7.4.2].