### PR TITLE
STY: Standardize mypy assert statements

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -436,7 +436,7 @@ class PdfWriter(PdfDocCommon):
             raise ValueError("PDF must be self")
         else:
             obj = self._objects[indirect_reference.idnum - 1]
-        assert obj is not None  # clarification for mypy
+        assert obj is not None, "mypy"
         return obj
 
     def _replace_object(
@@ -457,7 +457,7 @@ class PdfWriter(PdfDocCommon):
         self._objects[indirect_reference - 1] = obj
         obj.indirect_reference = IndirectObject(indirect_reference, gen, self)
 
-        assert isinstance(obj, PdfObject)  # clarification for mypy
+        assert isinstance(obj, PdfObject), "mypy"
         return obj
 
     def _add_page(
@@ -1441,7 +1441,7 @@ class PdfWriter(PdfDocCommon):
                 or obj.hash_bin() != self._original_hash[i]
             ):
                 idnum = i + 1
-                assert isinstance(obj, PdfObject)  # mypy
+                assert isinstance(obj, PdfObject), "mypy"
                 # first write new/modified object
                 object_positions[idnum] = stream.tell()
                 stream.write(f"{idnum} 0 obj\n".encode())
@@ -1651,7 +1651,7 @@ class PdfWriter(PdfDocCommon):
         for idx, obj in enumerate(self._objects):
             if is_null_or_none(obj):
                 continue
-            assert obj is not None  # mypy: TypeGuard of `is_null_or_none` does not help here.
+            assert obj is not None, "mypy"  # mypy: TypeGuard of `is_null_or_none` does not help here.
             assert isinstance(obj.indirect_reference, IndirectObject)
             h = obj.hash_value()
             if remove_identicals and h in self._idnum_hash:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -353,10 +353,9 @@ class IndirectObject(PdfObject):
             dup = pdf_dest._add_object(
                 obj.clone(pdf_dest, force_duplicate, ignore_fields)
             )
-        # asserts added to prevent errors in mypy
-        assert dup is not None
-        assert dup.indirect_reference is not None
-        return dup.indirect_reference
+        assert dup is not None, "mypy"
+        assert dup.indirect_reference is not None, "mypy"
+        return dup.indirect_reference, "mypy"
 
     @property
     def indirect_reference(self) -> "IndirectObject":  # type: ignore[override]
@@ -658,7 +657,7 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
         o.autodetect_pdfdocencoding = False
         o.utf16_bom = b""
         if o.startswith(("\xfe\xff", "\xff\xfe")):
-            assert org is not None  # for mypy
+            assert org is not None, "mypy"
             try:
                 o = str.__new__(cls, org.decode("utf-16"))
             except UnicodeDecodeError as exc:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -355,7 +355,7 @@ class IndirectObject(PdfObject):
             )
         assert dup is not None, "mypy"
         assert dup.indirect_reference is not None, "mypy"
-        return dup.indirect_reference, "mypy"
+        return dup.indirect_reference
 
     @property
     def indirect_reference(self) -> "IndirectObject":  # type: ignore[override]

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -636,7 +636,7 @@ class DictionaryObject(Dict[Any, Any], PdfObject):
             length = data[SA.LENGTH]
             if isinstance(length, IndirectObject):
                 t = stream.tell()
-                assert pdf is not None  # hint for mypy
+                assert pdf is not None, "mypy"
                 length = pdf.get_object(length)
                 stream.seek(t, 0)
             if length is None:  # if the PDF is damaged
@@ -1480,7 +1480,7 @@ def read_object(
         peek = stream.read(20)
         stream.seek(-len(peek), 1)  # reset to start
         if IndirectPattern.match(peek) is not None:
-            assert pdf is not None  # hint for mypy
+            assert pdf is not None, "mypy"
             return IndirectObject.read_from_stream(stream, pdf)
         return NumberObject.read_from_stream(stream)
     pos = stream.tell()


### PR DESCRIPTION
Use "mypy" in the second expression of the assert statement, instead of a comment explaining the assert statement is for mypy.