### PR TITLE
BUG: Add delimiters to NameObject.renumber_table

### DIFF
--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -780,11 +780,7 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
     surfix = b"/"
     renumber_table: ClassVar[Dict[str, bytes]] = {
-        "#": b"#23",
-        "(": b"#28",
-        ")": b"#29",
-        "/": b"#2F",
-        "%": b"#25",
+        **{chr(i): f"#{i:02X}".encode() for i in b"#()<>[]{}/%"},
         **{chr(i): f"#{i:02X}".encode() for i in range(33)},
     }
 

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -243,9 +243,16 @@ def test_name_object(caplog):
     assert bytes(b.getbuffer()) == b"/DIJMAC+Arial#20Black#231"
     assert caplog.text == ""
 
+    caplog.clear()
     b = BytesIO()
     NameObject("/你好世界 (%)").write_to_stream(b)
     assert bytes(b.getbuffer()) == b"/#E4#BD#A0#E5#A5#BD#E4#B8#96#E7#95#8C#20#28#25#29"
+    assert caplog.text == ""
+
+    caplog.clear()
+    b = BytesIO()
+    NameObject("/{foo}<bar>(baz)[qux]#/%").write_to_stream(b)
+    assert bytes(b.getbuffer()) == b"/#7Bfoo#7D#3Cbar#3E#28baz#29#5Bqux#5D#23#2F#25"
     assert caplog.text == ""
 
 


### PR DESCRIPTION
Per the spec, name objects cannot contain unescaped delimiters, which include angle, curly and square brackets (currently missing).

I've attached a sample input PDF with a valid, correctly escaped name object. When appending this to a new PdfWriter the output is invalid (incorrectly escaped):

```
>>> w = PdfWriter()
>>> w.append('nameobj.pdf')
>>> w.write('out.pdf')
```
[out.pdf](https://github.com/user-attachments/files/20173760/out.pdf)
[nameobj.pdf](https://github.com/user-attachments/files/20173761/nameobj.pdf)
