### PR TITLE
MAINT: Change name of class attribute

### DIFF
--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -780,10 +780,6 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
-    @classproperty
-    def surfix(cls) -> bytes:  # noqa: N805
-        deprecate_with_replacement("surfix", "prefix", "6.0.0")
-        return b"/"
     prefix = b"/"
     renumber_table: ClassVar[Dict[str, bytes]] = {
         "#": b"#23",
@@ -842,6 +838,11 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
                 except KeyError:
                     out += c.encode("utf-8")
         return out
+
+    @classproperty
+    def surfix(cls) -> bytes:  # noqa: N805
+        deprecate_with_replacement("surfix", "prefix", "6.0.0")
+        return b"/"
 
     @staticmethod
     def unnumber(sin: bytes) -> bytes:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -778,7 +778,7 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
-    surfix = b"/"
+    prefix = b"/"
     renumber_table: ClassVar[Dict[str, bytes]] = {
         "#": b"#23",
         "(": b"#28",
@@ -855,7 +855,7 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
     @staticmethod
     def read_from_stream(stream: StreamType, pdf: Any) -> "NameObject":  # PdfReader
         name = stream.read(1)
-        if name != NameObject.surfix:
+        if name != NameObject.prefix:
             raise PdfReadError("Name read error")
         name += read_until_regex(stream, NameObject.delimiter_pattern)
         try:

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -43,6 +43,7 @@ from .._codecs import _pdfdoc_encoding_rev
 from .._protocols import PdfObjectProtocol, PdfWriterProtocol
 from .._utils import (
     StreamType,
+    classproperty,
     deprecate_no_replacement,
     deprecate_with_replacement,
     logger_warning,
@@ -779,6 +780,7 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
+    @classproperty
     deprecate_with_replacement("surfix", "prefix", "6.0.0")
     surfix = b"/"
     prefix = b"/"

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -781,8 +781,9 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
     @classproperty
-    deprecate_with_replacement("surfix", "prefix", "6.0.0")
-    surfix = b"/"
+    def surfix(cls) -> bytes:
+        deprecate_with_replacement("surfix", "prefix", "6.0.0")
+        return b"/"
     prefix = b"/"
     renumber_table: ClassVar[Dict[str, bytes]] = {
         "#": b"#23",

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -781,7 +781,7 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
     @classproperty
-    def surfix(cls) -> bytes:
+    def surfix(cls) -> bytes:  # noqa: N805
         deprecate_with_replacement("surfix", "prefix", "6.0.0")
         return b"/"
     prefix = b"/"

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -44,6 +44,7 @@ from .._protocols import PdfObjectProtocol, PdfWriterProtocol
 from .._utils import (
     StreamType,
     deprecate_no_replacement,
+    deprecate_with_replacement,
     logger_warning,
     read_non_whitespace,
     read_until_regex,
@@ -778,6 +779,8 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
 
 class NameObject(str, PdfObject):  # noqa: SLOT000
     delimiter_pattern = re.compile(rb"\s+|[\(\)<>\[\]{}/%]")
+    deprecate_with_replacement("surfix", "prefix", "6.0.0")
+    surfix = b"/"
     prefix = b"/"
     renumber_table: ClassVar[Dict[str, bytes]] = {
         "#": b"#23",

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -194,16 +194,24 @@ def test_name_object(caplog):
     with pytest.raises(PdfReadError) as exc:
         NameObject.read_from_stream(stream, None)
     assert exc.value.args[0] == "Name read error"
+
+    assert (
+        NameObject.read_from_stream(BytesIO(b"without_solidus_prefix"), None)
+        == "surfix is deprecated and will be removed in pypdf 6.0.0. Use prefix instead."
+    )
+    
     assert (
         NameObject.read_from_stream(
             BytesIO(b"/A;Name_With-Various***Characters?"), None
         )
         == "/A;Name_With-Various***Characters?"
     )
+
     assert (
         NameObject.read_from_stream(BytesIO(b"/paired#28#29parentheses"), None)
         == "/paired()parentheses"
     )
+
     assert NameObject.read_from_stream(BytesIO(b"/A#42"), None) == "/AB"
 
     assert (
@@ -222,7 +230,7 @@ def test_name_object(caplog):
         )
     ) == "/你好世界"
 
-    # to test PDFDocEncoding (latin-1)
+    # test PDFDocEncoding (latin-1)
     assert (
         NameObject.read_from_stream(BytesIO(b"/DocuSign\xae"), None)
     ) == "/DocuSign®"

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -199,7 +199,7 @@ def test_name_object(caplog):
         DeprecationWarning,
         match="surfix is deprecated and will be removed in pypdf 6.0.0. Use prefix instead.",
     ):
-        NameObject.surfix = 42
+        _ = NameObject.surfix
 
     assert (
         NameObject.read_from_stream(

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -196,10 +196,10 @@ def test_name_object(caplog):
     assert exc.value.args[0] == "Name read error"
 
     assert (
-        NameObject.read_from_stream(BytesIO(b"without_solidus_prefix"), None)
+        (NameObject.surfix = 42)
         == "surfix is deprecated and will be removed in pypdf 6.0.0. Use prefix instead."
     )
-    
+
     assert (
         NameObject.read_from_stream(
             BytesIO(b"/A;Name_With-Various***Characters?"), None

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -195,10 +195,11 @@ def test_name_object(caplog):
         NameObject.read_from_stream(stream, None)
     assert exc.value.args[0] == "Name read error"
 
-    assert (
-        (NameObject.surfix = 42)
-        == "surfix is deprecated and will be removed in pypdf 6.0.0. Use prefix instead."
-    )
+    with pytest.warns(
+        DeprecationWarning,
+        match="surfix is deprecated and will be removed in pypdf 6.0.0. Use prefix instead.",
+    ):
+        NameObject.surfix = 42
 
     assert (
         NameObject.read_from_stream(


### PR DESCRIPTION
The SOLIDUS is a prefix, so use this as the name.