### PR TITLE
STY: Remove test_rectangle_annotation

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -210,7 +210,7 @@ def test_line(pdf_file_path):
         writer.write(fp)
 
 
-def test_square(pdf_file_path):
+def test_rectangle(pdf_file_path):
     # Arrange
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     reader = PdfReader(pdf_path)


### PR DESCRIPTION
The test of test_rectangle_annotation is duplicated in test_square: having two names for the same test is confusing. Also rename some annotation tests to have consistent naming.