### PR TITLE
DEV: Modernize license specifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.9,<4"]
+requires = ["flit_core >=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
@@ -9,12 +9,12 @@ maintainers = [{ name = "stefan6419846" }, { name = "Martin Thoma", email = "inf
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 readme = "README.md"
 dynamic = ["version"]
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,9 +24,9 @@ exceptiongroup==1.2.2
     # via pytest
 filelock==3.16.1
     # via virtualenv
-flit==3.9.0
+flit==3.11.0
     # via -r requirements/dev.in
-flit-core==3.9.0
+flit-core==3.11.0
     # via flit
 identify==2.6.1
     # via pre-commit


### PR DESCRIPTION
Migrate to PEP 639 license expressions.

Requires flit>=3.11: https://flit.pypa.io/en/stable/history.html#version-3-11