### PR TITLE
ROB: Gracefully handle odd-length strings in parse_bfchar

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -1,4 +1,5 @@
 import binascii
+from binascii import Error as BinasciiError
 from binascii import unhexlify
 from math import ceil
 from typing import Any, Dict, List, Tuple, Union, cast
@@ -383,9 +384,12 @@ def parse_bfchar(line: bytes, map_dict: Dict[Any, Any], int_entry: List[int]) ->
         map_to = ""
         # placeholder (see above) means empty string
         if lst[1] != b".":
-            map_to = unhexlify(lst[1]).decode(
-                "charmap" if len(lst[1]) < 4 else "utf-16-be", "surrogatepass"
-            )  # join is here as some cases where the code was split
+            try:
+                map_to = unhexlify(lst[1]).decode(
+                    "charmap" if len(lst[1]) < 4 else "utf-16-be", "surrogatepass"
+                )  # join is here as some cases where the code was split
+            except BinasciiError as exception:
+                logger_warning(f"Got invalid hex string: {exception!s} ({lst[1]!r})", __name__)
         map_dict[
             unhexlify(lst[0]).decode(
                 "charmap" if map_dict[-1] == 1 else "utf-16-be", "surrogatepass"

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from pypdf import PdfReader, PdfWriter
-from pypdf._cmap import build_char_map, get_encoding
+from pypdf._cmap import build_char_map, get_encoding, parse_bfchar
 from pypdf._codecs import charset_encoding
 from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, NameObject, NullObject
 
@@ -327,3 +327,14 @@ def test_get_encoding__encoding_value_is_none():
         dict(zip(range(256), charset_encoding["/StandardEncoding"])),
         {}
     )
+
+
+def test_parse_bfchar(caplog):
+    map_dict = {}
+    int_entry = []
+    parse_bfchar(line=b"057e   1337", map_dict=map_dict, int_entry=int_entry)
+    parse_bfchar(line=b"056e   1f310", map_dict=map_dict, int_entry=int_entry)
+
+    assert map_dict == {-1: 2, "ծ": "", "վ": "ጷ"}
+    assert int_entry == [1406, 1390]
+    assert caplog.messages == ["Got invalid hex string: Odd-length string (b'1f310')"]


### PR DESCRIPTION
Closes #3347.