### PR TITLE
MAINT: Move text extraction state to TextExtraction class

### DIFF
--- a/pypdf/__init__.py
+++ b/pypdf/__init__.py
@@ -11,8 +11,9 @@ from ._crypt_providers import crypt_provider
 from ._doc_common import DocumentInformation
 from ._encryption import PasswordType
 from ._merger import PdfMerger
-from ._page import PageObject, Transformation, mult
+from ._page import PageObject, Transformation
 from ._reader import PdfReader
+from ._text_extraction import mult
 from ._version import __version__
 from ._writer import ObjectDeletionFlag, PdfWriter
 from .constants import ImageType

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1653,7 +1653,7 @@ class PageObject(DictionaryObject):
             out += "No Font\n"
         return out
 
-    def _extract_text(  # noqa: C901, PLR0915  # Will be fixed soon.
+    def _extract_text(
         self,
         obj: Any,
         pdf: Any,
@@ -1700,14 +1700,6 @@ class PageObject(DictionaryObject):
                     cmaps[f] = build_char_map(f, space_width, obj)
                 except TypeError:
                     pass
-        cmap: Tuple[
-            Union[str, Dict[int, str]], Dict[str, str], str, Optional[DictionaryObject]
-        ] = (
-            "charmap",
-            {},
-            "NotInitialized",
-            None,
-        )  # (encoding, CMAP, font resource name, font)
 
         try:
             content = (

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -51,14 +51,10 @@ from typing import (
 
 from ._cmap import (
     build_char_map,
-    unknown_char_map,
 )
 from ._protocols import PdfCommonDocProtocol
 from ._text_extraction import (
-    OrientationNotFoundError,
     _layout_mode,
-    crlf_space_check,
-    mult,
 )
 from ._text_extraction._text_extractor import TextExtraction
 from ._utils import (
@@ -1659,7 +1655,6 @@ class PageObject(DictionaryObject):
 
 
 
-
     def _extract_text(
         self,
         obj: Any,
@@ -1681,9 +1676,6 @@ class PageObject(DictionaryObject):
 
         """
         extractor = TextExtraction()
-        text: str = ""
-        output: str = ""
-        rtl_dir: bool = False  # right-to-left
         cmaps: Dict[
             str,
             Tuple[
@@ -1707,14 +1699,6 @@ class PageObject(DictionaryObject):
         if "/Font" in resources_dict and (font := resources_dict["/Font"]):
             for f in cast(DictionaryObject, font):
                 cmaps[f] = build_char_map(f, space_width, obj)
-        cmap: Tuple[
-            Union[str, Dict[int, str]], Dict[str, str], str, Optional[DictionaryObject]
-        ] = (
-            "charmap",
-            {},
-            "NotInitialized",
-            None,
-        )  # (encoding, CMAP, font resource name, font)
 
         try:
             content = (
@@ -1728,245 +1712,57 @@ class PageObject(DictionaryObject):
         # are strings where the byte->string encoding was unknown, so adding
         # them to the text here would be gibberish.
 
-        cm_matrix: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-        tm_matrix: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-        cm_stack = []
-
-        # Store the last modified matrices; can be an intermediate position
-        cm_prev: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-        tm_prev: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-
-        # Store the position at the beginning of building the text
-        memo_cm: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-        memo_tm: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-
-        char_scale = 1.0
-        space_scale = 1.0
-        _space_width: float = 500.0  # will be set correctly at first Tf
-        _actual_str_size: Dict[str, float] = {
-            "str_widths": 0.0, "space_width": 0.0, "str_height": 0.0
-        }  # will be set to string length calculation result
-        TL = 0.0
-        font_size = 12.0  # init just in case of
-
-        def compute_str_widths(str_widths: float) -> float:
-            return str_widths / 1000
-
-        def process_operation(operator: bytes, operands: List[Any]) -> None:
-            nonlocal cm_matrix, tm_matrix, cm_stack, cm_prev, tm_prev, memo_cm, memo_tm
-            nonlocal char_scale, space_scale, _space_width, TL, font_size, cmap
-            nonlocal orientations, rtl_dir, visitor_text, output, text, _actual_str_size
-
-            str_widths: float = 0.0
-
-            # Table 5.4 page 405
-            if operator == b"BT":  # Begin Text
-                tm_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-                # Flush text:
-                output += text
-                if visitor_text is not None:
-                    visitor_text(text, memo_cm, memo_tm, cmap[3], font_size)
-                text = ""
-                memo_cm = cm_matrix.copy()
-                memo_tm = tm_matrix.copy()
-                return
-            if operator == b"ET":  # End Text
-                # Flush text:
-                output += text
-                if visitor_text is not None:
-                    visitor_text(text, memo_cm, memo_tm, cmap[3], font_size)
-                text = ""
-                memo_cm = cm_matrix.copy()
-                memo_tm = tm_matrix.copy()
-
-            # Table 4.7 "Graphics state operators", page 219
-            # cm_matrix calculation is reserved for later
-            elif operator == b"q":  # Save graphics state
-                cm_stack.append(
-                    (
-                        cm_matrix,
-                        cmap,
-                        font_size,
-                        char_scale,
-                        space_scale,
-                        _space_width,
-                        TL,
-                    )
-                )
-            elif operator == b"Q":  # Restore graphics state
-                try:
-                    (
-                        cm_matrix,
-                        cmap,
-                        font_size,
-                        char_scale,
-                        space_scale,
-                        _space_width,
-                        TL,
-                    ) = cm_stack.pop()
-                except Exception:
-                    cm_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-            elif operator == b"cm":  # Modify current matrix
-                output += text
-                if visitor_text is not None:
-                    visitor_text(text, memo_cm, memo_tm, cmap[3], font_size)
-                text = ""
-                try:
-                    cm_matrix = mult(
-                        [float(operand) for operand in operands[:6]],
-                        cm_matrix
-                    )
-                except Exception:
-                    cm_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
-                memo_cm = cm_matrix.copy()
-                memo_tm = tm_matrix.copy()
-
-            # Table 5.2 page 398
-            elif operator == b"Tz":  # Set horizontal text scaling
-                char_scale = float(operands[0]) / 100 if operands else 1.0
-            elif operator == b"Tw":  # Set word spacing
-                space_scale = 1.0 + float(operands[0] if operands else 0.0)
-            elif operator == b"TL":  # Set Text Leading
-                scale_x = math.sqrt(tm_matrix[0]**2 + tm_matrix[2]**2)
-                TL = float(operands[0] if operands else 0.0) * font_size * scale_x
-            elif operator == b"Tf":  # Set font size
-                if text != "":
-                    output += text  # .translate(cmap)
-                    if visitor_text is not None:
-                        visitor_text(text, memo_cm, memo_tm, cmap[3], font_size)
-                text = ""
-                memo_cm = cm_matrix.copy()
-                memo_tm = tm_matrix.copy()
-                try:
-                    # char_map_tuple: font_type,
-                    #                 float(sp_width / 2),
-                    #                 encoding,
-                    #                 map_dict,
-                    #                 font_dict (describes the font)
-                    char_map_tuple = cmaps[operands[0]]
-                    # current cmap: encoding,
-                    #               map_dict,
-                    #               font resource name (internal name, not the real font name),
-                    #               font_dict
-                    cmap = (
-                        char_map_tuple[2],
-                        char_map_tuple[3],
-                        operands[0],
-                        char_map_tuple[4],
-                    )
-                    _space_width = char_map_tuple[1]
-                except KeyError:  # font not found
-                    cmap = (
-                        unknown_char_map[2],
-                        unknown_char_map[3],
-                        f"???{operands[0]}",
-                        None,
-                    )
-                    _space_width = unknown_char_map[1]
-                try:
-                    font_size = float(operands[1])
-                except Exception:
-                    pass  # keep previous size
-            # Table 5.5 page 406
-            elif operator == b"Td":  # Move text position
-                # A special case is a translating only tm:
-                # tm = [1, 0, 0, 1, e, f]
-                # i.e. tm[4] += tx, tm[5] += ty.
-                tx, ty = float(operands[0]), float(operands[1])
-                tm_matrix[4] += tx * tm_matrix[0] + ty * tm_matrix[2]
-                tm_matrix[5] += tx * tm_matrix[1] + ty * tm_matrix[3]
-                str_widths = compute_str_widths(_actual_str_size["str_widths"])
-                _actual_str_size["str_widths"] = 0.0
-            elif operator == b"Tm":  # Set text matrix
-                tm_matrix = [float(operand) for operand in operands[:6]]
-                str_widths = compute_str_widths(_actual_str_size["str_widths"])
-                _actual_str_size["str_widths"] = 0.0
-            elif operator == b"T*":  # Move to next line
-                tm_matrix[4] -= TL * tm_matrix[2]
-                tm_matrix[5] -= TL * tm_matrix[3]
-                str_widths = compute_str_widths(_actual_str_size["str_widths"])
-                _actual_str_size["str_widths"] = 0.0
-            elif operator == b"Tj":  # Show text
-                text, rtl_dir, _actual_str_size = extractor._handle_tj(
-                    text,
-                    operands,
-                    cm_matrix,
-                    tm_matrix,
-                    cmap,
-                    orientations,
-                    font_size,
-                    rtl_dir,
-                    visitor_text,
-                    _space_width,
-                    _actual_str_size,
-                )
-            else:
-                return
-
-            if operator in {b"Td", b"Tm", b"T*", b"Tj"}:
-                try:
-                    text, output, cm_prev, tm_prev = crlf_space_check(
-                        text,
-                        (cm_prev, tm_prev),
-                        (cm_matrix, tm_matrix),
-                        (memo_cm, memo_tm),
-                        cmap,
-                        orientations,
-                        output,
-                        font_size,
-                        visitor_text,
-                        str_widths,
-                        compute_str_widths(_actual_str_size["space_width"]),
-                        _actual_str_size["str_height"]
-                    )
-                    if text == "":
-                        memo_cm = cm_matrix.copy()
-                        memo_tm = tm_matrix.copy()
-                except OrientationNotFoundError:
-                    return
+        # Initialize the extractor with the necessary parameters
+        extractor.initialize_extraction(orientations, visitor_text, cmaps)
 
         for operands, operator in content.operations:
             if visitor_operand_before is not None:
-                visitor_operand_before(operator, operands, cm_matrix, tm_matrix)
+                visitor_operand_before(operator, operands, extractor.cm_matrix, extractor.tm_matrix)
             # Multiple operators are handled here
             if operator == b"'":
-                process_operation(b"T*", [])
-                process_operation(b"Tj", operands)
+                extractor.process_operation(b"T*", [])
+                extractor.process_operation(b"Tj", operands)
             elif operator == b'"':
-                process_operation(b"Tw", [operands[0]])
-                process_operation(b"Tc", [operands[1]])
-                process_operation(b"T*", [])
-                process_operation(b"Tj", operands[2:])
+                extractor.process_operation(b"Tw", [operands[0]])
+                extractor.process_operation(b"Tc", [operands[1]])
+                extractor.process_operation(b"T*", [])
+                extractor.process_operation(b"Tj", operands[2:])
             elif operator == b"TJ":
                 # The space width may be smaller than the font width, so the width should be 95%.
-                _confirm_space_width = _space_width * 0.95
+                _confirm_space_width = extractor._space_width * 0.95
                 if operands:
                     for op in operands[0]:
                         if isinstance(op, (str, bytes)):
-                            process_operation(b"Tj", [op])
+                            extractor.process_operation(b"Tj", [op])
                         if isinstance(op, (int, float, NumberObject, FloatObject)) and (
                             abs(float(op)) >= _confirm_space_width
-                            and text
-                            and text[-1] != " "
+                            and extractor.text
+                            and extractor.text[-1] != " "
                         ):
-                            process_operation(b"Tj", [" "])
+                            extractor.process_operation(b"Tj", [" "])
             elif operator == b"TD":
-                process_operation(b"TL", [-operands[1]])
-                process_operation(b"Td", operands)
+                extractor.process_operation(b"TL", [-operands[1]])
+                extractor.process_operation(b"Td", operands)
             elif operator == b"Do":
-                output += text
+                extractor.output += extractor.text
                 if visitor_text is not None:
-                    visitor_text(text, memo_cm, memo_tm, cmap[3], font_size)
+                    visitor_text(
+                        extractor.text,
+                        extractor.memo_cm,
+                        extractor.memo_tm,
+                        extractor.cmap[3],
+                        extractor.font_size,
+                    )
                 try:
-                    if output[-1] != "\n":
-                        output += "\n"
+                    if extractor.output[-1] != "\n":
+                        extractor.output += "\n"
                         if visitor_text is not None:
                             visitor_text(
                                 "\n",
-                                memo_cm,
-                                memo_tm,
-                                cmap[3],
-                                font_size,
+                                extractor.memo_cm,
+                                extractor.memo_tm,
+                                extractor.cmap[3],
+                                extractor.font_size,
                             )
                 except IndexError:
                     pass
@@ -1981,14 +1777,14 @@ class PageObject(DictionaryObject):
                             visitor_operand_after,
                             visitor_text,
                         )
-                        output += text
+                        extractor.output += text
                         if visitor_text is not None:
                             visitor_text(
                                 text,
-                                memo_cm,
-                                memo_tm,
-                                cmap[3],
-                                font_size,
+                                extractor.memo_cm,
+                                extractor.memo_tm,
+                                extractor.cmap[3],
+                                extractor.font_size,
                             )
                 except Exception as exception:
                     logger_warning(
@@ -1996,17 +1792,23 @@ class PageObject(DictionaryObject):
                         __name__,
                     )
                 finally:
-                    text = ""
-                    memo_cm = cm_matrix.copy()
-                    memo_tm = tm_matrix.copy()
+                    extractor.text = ""
+                    extractor.memo_cm = extractor.cm_matrix.copy()
+                    extractor.memo_tm = extractor.tm_matrix.copy()
             else:
-                process_operation(operator, operands)
+                extractor.process_operation(operator, operands)
             if visitor_operand_after is not None:
-                visitor_operand_after(operator, operands, cm_matrix, tm_matrix)
-        output += text  # just in case
-        if text != "" and visitor_text is not None:
-            visitor_text(text, memo_cm, memo_tm, cmap[3], font_size)
-        return output
+                visitor_operand_after(operator, operands, extractor.cm_matrix, extractor.tm_matrix)
+        extractor.output += extractor.text  # just in case
+        if extractor.text != "" and visitor_text is not None:
+            visitor_text(
+                extractor.text,
+                extractor.memo_cm,
+                extractor.memo_tm,
+                extractor.cmap[3],
+                extractor.font_size,
+            )
+        return extractor.output
 
     def _layout_mode_fonts(self) -> Dict[str, _layout_mode.Font]:
         """

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -27,11 +27,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import math
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from .._cmap import build_font_width_map, compute_font_width, get_actual_str_key
 from ..generic import DictionaryObject, TextStringObject
-from . import get_display_str, get_text_operands
+from . import OrientationNotFoundError, crlf_space_check, get_display_str, get_text_operands, mult
 
 
 class TextExtraction:
@@ -46,6 +47,244 @@ class TextExtraction:
     def __init__(self) -> None:
         self._font_width_maps: Dict[str, Tuple[Dict[Any, float], str, float]] = {}
 
+        # Text extraction state variables
+        self.cm_matrix: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        self.tm_matrix: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        self.cm_stack: List[
+            Tuple[
+                List[float],
+                Tuple[Union[str, Dict[int, str]], Dict[str, str], str, Optional[DictionaryObject]],
+                float,
+                float,
+                float,
+                float,
+                float,
+            ]
+        ] = []
+
+        # Store the last modified matrices; can be an intermediate position
+        self.cm_prev: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        self.tm_prev: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+
+        # Store the position at the beginning of building the text
+        self.memo_cm: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        self.memo_tm: List[float] = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+
+        self.char_scale = 1.0
+        self.space_scale = 1.0
+        self._space_width: float = 500.0  # will be set correctly at first Tf
+        self._actual_str_size: Dict[str, float] = {
+            "str_widths": 0.0,
+            "space_width": 0.0,
+            "str_height": 0.0,
+        }  # will be set to string length calculation result
+        self.TL = 0.0
+        self.font_size = 12.0  # init just in case of
+
+        # Text extraction variables
+        self.text: str = ""
+        self.output: str = ""
+        self.rtl_dir: bool = False  # right-to-left
+        self.cmap: Tuple[Union[str, Dict[int, str]], Dict[str, str], str, Optional[DictionaryObject]] = (
+            "charmap",
+            {},
+            "NotInitialized",
+            None,
+        )  # (encoding, CMAP, font resource name, font)
+        self.orientations: Tuple[int, ...] = (0, 90, 180, 270)
+        self.visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]] = None
+        self.cmaps: Dict[str, Tuple[str, float, Union[str, Dict[int, str]], Dict[str, str], DictionaryObject]] = {}
+
+    def initialize_extraction(
+        self,
+        orientations: Tuple[int, ...] = (0, 90, 180, 270),
+        visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]] = None,
+        cmaps: Optional[
+            Dict[str, Tuple[str, float, Union[str, Dict[int, str]], Dict[str, str], DictionaryObject]]
+        ] = None,
+    ) -> None:
+        """Initialize the extractor with extraction parameters."""
+        self.orientations = orientations
+        self.visitor_text = visitor_text
+        self.cmaps = cmaps or {}
+
+        # Reset state
+        self.text = ""
+        self.output = ""
+        self.rtl_dir = False
+
+    def compute_str_widths(self, str_widths: float) -> float:
+        return str_widths / 1000
+
+    def process_operation(self, operator: bytes, operands: List[Any]) -> None:
+        str_widths: float = 0.0
+
+        # Table 5.4 page 405
+        if operator == b"BT":  # Begin Text
+            self.tm_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+            # Flush text:
+            self.output += self.text
+            if self.visitor_text is not None:
+                self.visitor_text(self.text, self.memo_cm, self.memo_tm, self.cmap[3], self.font_size)
+            self.text = ""
+            self.memo_cm = self.cm_matrix.copy()
+            self.memo_tm = self.tm_matrix.copy()
+            return
+        if operator == b"ET":  # End Text
+            # Flush text:
+            self.output += self.text
+            if self.visitor_text is not None:
+                self.visitor_text(self.text, self.memo_cm, self.memo_tm, self.cmap[3], self.font_size)
+            self.text = ""
+            self.memo_cm = self.cm_matrix.copy()
+            self.memo_tm = self.tm_matrix.copy()
+
+        # Table 4.7 "Graphics state operators", page 219
+        # cm_matrix calculation is reserved for later
+        elif operator == b"q":  # Save graphics state
+            self.cm_stack.append(
+                (
+                    self.cm_matrix,
+                    self.cmap,
+                    self.font_size,
+                    self.char_scale,
+                    self.space_scale,
+                    self._space_width,
+                    self.TL,
+                )
+            )
+        elif operator == b"Q":  # Restore graphics state
+            try:
+                (
+                    self.cm_matrix,
+                    self.cmap,
+                    self.font_size,
+                    self.char_scale,
+                    self.space_scale,
+                    self._space_width,
+                    self.TL,
+                ) = self.cm_stack.pop()
+            except Exception:
+                self.cm_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+        elif operator == b"cm":  # Modify current matrix
+            self.output += self.text
+            if self.visitor_text is not None:
+                self.visitor_text(self.text, self.memo_cm, self.memo_tm, self.cmap[3], self.font_size)
+            self.text = ""
+            try:
+                self.cm_matrix = mult([float(operand) for operand in operands[:6]], self.cm_matrix)
+            except Exception:
+                self.cm_matrix = [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
+            self.memo_cm = self.cm_matrix.copy()
+            self.memo_tm = self.tm_matrix.copy()
+
+        # Table 5.2 page 398
+        elif operator == b"Tz":  # Set horizontal text scaling
+            self.char_scale = float(operands[0]) / 100 if operands else 1.0
+        elif operator == b"Tw":  # Set word spacing
+            self.space_scale = 1.0 + float(operands[0] if operands else 0.0)
+        elif operator == b"TL":  # Set Text Leading
+            scale_x = math.sqrt(self.tm_matrix[0] ** 2 + self.tm_matrix[2] ** 2)
+            self.TL = float(operands[0] if operands else 0.0) * self.font_size * scale_x
+        elif operator == b"Tf":  # Set font size
+            if self.text != "":
+                self.output += self.text  # .translate(cmap)
+                if self.visitor_text is not None:
+                    self.visitor_text(self.text, self.memo_cm, self.memo_tm, self.cmap[3], self.font_size)
+            self.text = ""
+            self.memo_cm = self.cm_matrix.copy()
+            self.memo_tm = self.tm_matrix.copy()
+            try:
+                # Import here to avoid circular imports
+                from .._cmap import unknown_char_map  # noqa: PLC0415
+
+                # char_map_tuple: font_type,
+                #                 float(sp_width / 2),
+                #                 encoding,
+                #                 map_dict,
+                #                 font_dict (describes the font)
+                char_map_tuple = self.cmaps[operands[0]]
+                # current cmap: encoding,
+                #               map_dict,
+                #               font resource name (internal name, not the real font name),
+                #               font_dict
+                self.cmap = (
+                    char_map_tuple[2],
+                    char_map_tuple[3],
+                    operands[0],
+                    char_map_tuple[4],
+                )
+                self._space_width = char_map_tuple[1]
+            except KeyError:  # font not found
+                self.cmap = (
+                    unknown_char_map[2],
+                    unknown_char_map[3],
+                    f"???{operands[0]}",
+                    None,
+                )
+                self._space_width = unknown_char_map[1]
+            try:
+                self.font_size = float(operands[1])
+            except Exception:
+                pass  # keep previous size
+        # Table 5.5 page 406
+        elif operator == b"Td":  # Move text position
+            # A special case is a translating only tm:
+            # tm = [1, 0, 0, 1, e, f]
+            # i.e. tm[4] += tx, tm[5] += ty.
+            tx, ty = float(operands[0]), float(operands[1])
+            self.tm_matrix[4] += tx * self.tm_matrix[0] + ty * self.tm_matrix[2]
+            self.tm_matrix[5] += tx * self.tm_matrix[1] + ty * self.tm_matrix[3]
+            str_widths = self.compute_str_widths(self._actual_str_size["str_widths"])
+            self._actual_str_size["str_widths"] = 0.0
+        elif operator == b"Tm":  # Set text matrix
+            self.tm_matrix = [float(operand) for operand in operands[:6]]
+            str_widths = self.compute_str_widths(self._actual_str_size["str_widths"])
+            self._actual_str_size["str_widths"] = 0.0
+        elif operator == b"T*":  # Move to next line
+            self.tm_matrix[4] -= self.TL * self.tm_matrix[2]
+            self.tm_matrix[5] -= self.TL * self.tm_matrix[3]
+            str_widths = self.compute_str_widths(self._actual_str_size["str_widths"])
+            self._actual_str_size["str_widths"] = 0.0
+        elif operator == b"Tj":  # Show text
+            self.text, self.rtl_dir, self._actual_str_size = self._handle_tj(
+                self.text,
+                operands,
+                self.cm_matrix,
+                self.tm_matrix,
+                self.cmap,
+                self.orientations,
+                self.font_size,
+                self.rtl_dir,
+                self.visitor_text,
+                self._space_width,
+                self._actual_str_size,
+            )
+        else:
+            return
+
+        if operator in {b"Td", b"Tm", b"T*", b"Tj"}:
+            try:
+                self.text, self.output, self.cm_prev, self.tm_prev = crlf_space_check(
+                    self.text,
+                    (self.cm_prev, self.tm_prev),
+                    (self.cm_matrix, self.tm_matrix),
+                    (self.memo_cm, self.memo_tm),
+                    self.cmap,
+                    self.orientations,
+                    self.output,
+                    self.font_size,
+                    self.visitor_text,
+                    str_widths,
+                    self.compute_str_widths(self._actual_str_size["space_width"]),
+                    self._actual_str_size["str_height"],
+                )
+                if self.text == "":
+                    self.memo_cm = self.cm_matrix.copy()
+                    self.memo_tm = self.tm_matrix.copy()
+            except OrientationNotFoundError:
+                return
+
     def _get_actual_font_widths(
         self,
         cmap: Tuple[
@@ -53,7 +292,7 @@ class TextExtraction:
         ],
         text_operands: str,
         font_size: float,
-        space_width: float
+        space_width: float,
     ) -> Tuple[float, float, float]:
         font_widths: float = 0
         font_name: str = cmap[2]
@@ -96,7 +335,7 @@ class TextExtraction:
         rtl_dir: bool,
         visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]],
         space_width: float,
-        actual_str_size: Dict[str, float]
+        actual_str_size: Dict[str, float],
     ) -> Tuple[str, bool, Dict[str, float]]:
         text_operands, is_str_operands = get_text_operands(
             operands, cm_matrix, tm_matrix, cmap, orientations)
@@ -111,7 +350,8 @@ class TextExtraction:
                 text_operands,
                 font_size,
                 rtl_dir,
-                visitor_text)
+                visitor_text,
+            )
         font_widths, actual_str_size["space_width"], actual_str_size["str_height"] = (
             self._get_actual_font_widths(cmap, text_operands, font_size, space_width))
         actual_str_size["str_widths"] += font_widths

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -441,4 +441,18 @@ def test_extract_text__with_visitor_text():
 
     reader = PdfReader(BytesIO(get_data_from_url(name="TextAttack_paper.pdf")))
     page = reader.pages[0]
-    page.extract_text()
+    page.extract_text(visitor_text=visitor_text)
+
+
+@pytest.mark.enable_socket
+def test_extract_text__restore_cm_stack_pop_error():
+    url = "https://github.com/user-attachments/files/18381737/tika-966635.pdf"
+    name = "tika-966635.pdf"
+    stream = BytesIO(get_data_from_url(url, name=name))
+    reader = PdfReader(stream)
+    page = reader.pages[10]
+
+    # There is a previous error we already omit ("pop from empty list"), thus
+    # check for the message explicitly here.
+    with pytest.raises(IndexError, match="list index out of range"):
+        page.extract_text()


### PR DESCRIPTION


Move all non-local variables and nested functions from PageObject._extract_text()
to the TextExtraction class to improve code organization and maintainability.

Changes:
- Moved state variables (cm_matrix, tm_matrix, text, output, etc.) to TextExtraction instance variables
- Moved compute_str_widths() and process_operation() functions to TextExtraction methods
- Added initialize_extraction() method to set up extraction parameters
- Simplified _extract_text() to use TextExtraction instance instead of local state
- Maintains existing API and functionality while improving code structure

This refactoring eliminates the need for nonlocal variables and nested functions,
making the text extraction code more modular and easier to understand.