### PR TITLE
ROB: ignore faulty trailing newline during RLE decoding

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -386,6 +386,14 @@ class RunLengthDecode:
             index += 1
             if length == 128:
                 if index < len(data):
+                    # We should first check, if we have an inner stream from a multi-encoded
+                    # stream with a faulty trailing newline that we can decode properly.
+                    # We will just ignore the last byte and raise a warning ...
+                    if (index == len(data) - 1) and (data[index] == ord("\n")):
+                        logger_warning(
+                            "Found trailing newline in stream data, check if output is OK", __name__
+                        )
+                        break
                     raise PdfStreamError("Early EOD in RunLengthDecode")
                 break
             if length < 128:


### PR DESCRIPTION
Found PDFs from Dalim software with multi-encoded streams: inner stream is RLE, outer stream is FLATE. The inner stream contains a trailing newline char that breaks the RLE decoding. It seems that there was in some Dalim version a systematíc error that included the bytes of the inner stream just from raw PDF bytes with the trailing newline before "endsrteam". This is fixed with the changes by ignoring the trailing newline and raising a warning instead of an exception.

Test data: 
[Uploading multi_decoding_example_with_faulty_tail_byte.pdf…]()
