### PR TITLE
DOC: Add note about scanned PDFs and OCR suggestion in extract_text.md

### DIFF
--- a/docs/user/extract-text.md
+++ b/docs/user/extract-text.md
@@ -39,7 +39,9 @@ very often).
 
 To limit the size of the content streams to process (and avoid OOM errors in your application), consider
 checking `len(page.get_contents().get_data())` beforehand.
+```
 
+```{note}
 If a PDF page appears to contain only an image (e.g., a scanned document), the extracted text may be minimal or visually empty.
 In such cases, consider using OCR software such as [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) to extract text from images.
 ```


### PR DESCRIPTION
This documentation update enhances `docs/user/extract-text.md` by adding a useful `{tip}` block for users encountering `None` from `page.extract_text()`.

The new tip explains that if no text is extracted, the page might be a scanned image with no text layer. It also provides a short code snippet that checks for this case and suggests using OCR software like `pytesseract`.

This addresses a common pain point for users unfamiliar with the limitations of text extraction from image-based PDFs. No functional code changes are included, this is purely a doc improvement.
