### PR TITLE
ENH: Preserve links in added pages also when links come from merged-in pages

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -517,6 +517,7 @@ class PageObject(DictionaryObject):
         if not is_null_or_none(indirect_reference):
             assert indirect_reference is not None, "mypy"
             self.update(cast(DictionaryObject, indirect_reference.get_object()))
+        self._merged_in_pages: list[IndirectObject] = []
 
     def hash_bin(self) -> int:
         """
@@ -1093,6 +1094,10 @@ class PageObject(DictionaryObject):
         over: bool = True,
         expand: bool = False,
     ) -> None:
+        # Track merged-in pages so we can do link rewriting correctly
+        if page2.indirect_reference:
+            self._merged_in_pages.append(page2.indirect_reference)
+
         # First we work on merging the resource dictionaries. This allows us
         # to find out what symbols in the content streams we might need to
         # rename.

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -102,17 +102,16 @@ from .generic import (
     NumberObject,
     PdfObject,
     RectangleObject,
-    ReferenceLink,
     StreamObject,
     TextStringObject,
     TreeObject,
     ViewerPreferences,
     create_string_object,
-    extract_links,
     hex_to_rgb,
     is_null_or_none,
 )
 from .generic._appearance_stream import TextStreamAppearance
+from .generic._link import ReferenceLink, extract_links
 from .pagerange import PageRange, PageRangeSpec
 from .types import (
     AnnotationSubtype,
@@ -559,6 +558,11 @@ class PdfWriter(PdfDocCommon):
             # later.
             self._unresolved_links.extend(extract_links(page, page_org))
             self._merged_in_pages[page_org.indirect_reference] = page.indirect_reference
+            # the original page may have been created by merging the link
+            # target page into it, so we need to also track the merged-in
+            # pages that formed this page
+            for merged_in in page_org._merged_in_pages:
+                self._merged_in_pages[merged_in] = page.indirect_reference
 
         return page
 

--- a/pypdf/generic/__init__.py
+++ b/pypdf/generic/__init__.py
@@ -57,7 +57,6 @@ from ._data_structures import (
 )
 from ._files import EmbeddedFile
 from ._fit import Fit
-from ._link import DirectReferenceLink, NamedReferenceLink, ReferenceLink, extract_links
 from ._outline import OutlineItem
 from ._rectangle import RectangleObject
 from ._utils import (
@@ -81,7 +80,6 @@ __all__ = [
     "DecodedStreamObject",
     "Destination",
     "DictionaryObject",
-    "DirectReferenceLink",
     "EmbeddedFile",
     "EncodedStreamObject",
     "Field",
@@ -89,14 +87,12 @@ __all__ = [
     "FloatObject",
     "IndirectObject",
     "NameObject",
-    "NamedReferenceLink",
     "NullObject",
     "NumberObject",
     "OutlineFontFlag",
     "OutlineItem",
     "PdfObject",
     "RectangleObject",
-    "ReferenceLink",
     "StreamObject",
     "TextStringObject",
     "TreeObject",
@@ -105,7 +101,6 @@ __all__ = [
     "create_string_object",
     "decode_pdfdocencoding",
     "encode_pdfdocencoding",
-    "extract_links",
     "hex_to_rgb",
     "is_null_or_none",
     "read_hex_string_from_stream",

--- a/pypdf/generic/_link.py
+++ b/pypdf/generic/_link.py
@@ -31,25 +31,50 @@
 from typing import TYPE_CHECKING, Optional, Union, cast
 
 from .._utils import logger_warning
-from . import ArrayObject, DictionaryObject, IndirectObject, PdfObject, TextStringObject, is_null_or_none
+from . import ArrayObject, DictionaryObject, IndirectObject, NullObject, PdfObject, TextStringObject, is_null_or_none
 
 if TYPE_CHECKING:
     from .._page import PageObject
+    from .._protocols import PdfCommonDocProtocol
     from .._reader import PdfReader
     from .._writer import PdfWriter
+    from ..generic import Destination
 
 
 class NamedReferenceLink:
     """Named reference link being preserved until we can resolve it correctly."""
 
-    def __init__(self, reference: TextStringObject, source_pdf: "PdfReader") -> None:
+    def __init__(self, reference: TextStringObject, page: "PageObject") -> None:
         """reference: TextStringObject with named reference"""
         self._reference = reference
-        self._source_pdf = source_pdf
+
+        # to work out where the reference points to we need to find the
+        # source PDF which the reference is pointing to.  this *can*
+        # be the PDF the page containing the link comes from, but it
+        # may also be some other PDF merged into this page, so we need
+        # to do a little search
+        destination = self._find_referenced_page_in(page.pdf)
+
+        if not destination:
+            for src_page in page._merged_in_pages:
+                destination = self._find_referenced_page_in(src_page.pdf)
+                break
+
+        if destination and not isinstance(destination.dest_array[0], NullObject):
+            self._referenced_page = destination.dest_array[0]
+        else:
+            self._referenced_page = None
+
+    def _find_referenced_page_in(self, pdf: "Optional[PdfCommonDocProtocol]") -> "Optional[Destination]":
+        if not pdf or not hasattr(pdf, "named_destinations"):
+            return None
+        reader: PdfReader = cast("PdfReader", pdf)
+        return reader.named_destinations.get(str(self._reference))
 
     def find_referenced_page(self) -> Union[IndirectObject, None]:
-        destination = self._source_pdf.named_destinations.get(str(self._reference))
-        return destination.page if destination else None
+        if self._referenced_page:
+            return cast(IndirectObject, self._referenced_page.indirect_reference)
+        return None
 
     def patch_reference(self, target_pdf: "PdfWriter", new_page: IndirectObject) -> None:
         """target_pdf: PdfWriter which the new link went into"""
@@ -120,29 +145,28 @@ def extract_links(new_page: "PageObject", old_page: "PageObject") -> list[tuple[
 
 
 def _build_link(indirect_object: IndirectObject, page: "PageObject") -> Optional[ReferenceLink]:
-    src = cast("PdfReader", page.pdf)
     link = cast(DictionaryObject, indirect_object.get_object())
     if (not isinstance(link, DictionaryObject)) or link.get("/Subtype") != "/Link":
         return None
 
-    if "/A" in link:
-        action = cast(DictionaryObject, link["/A"])
+    if "/A" in link and isinstance(link["/A"], DictionaryObject):
+        action = link["/A"]
         if action.get("/S") != "/GoTo":
             return None
 
         if "/D" not in action:
             return None
-        return _create_link(action["/D"], src)
+        return _create_link(action["/D"], page)
 
     if "/Dest" in link:
-        return _create_link(link["/Dest"], src)
+        return _create_link(link["/Dest"], page)
 
     return None  # Nothing to do here
 
 
-def _create_link(reference: PdfObject, source_pdf: "PdfReader") -> Optional[ReferenceLink]:
+def _create_link(reference: PdfObject, page: "PageObject") -> Optional[ReferenceLink]:
     if isinstance(reference, TextStringObject):
-        return NamedReferenceLink(reference, source_pdf)
+        return NamedReferenceLink(reference, page)
     if isinstance(reference, ArrayObject):
         return DirectReferenceLink(reference)
     return None

--- a/tests/generic/test_link.py
+++ b/tests/generic/test_link.py
@@ -7,12 +7,11 @@ from pypdf import PageObject, PdfReader, PdfWriter
 from pypdf.generic import (
     ArrayObject,
     DictionaryObject,
-    DirectReferenceLink,
     NameObject,
     NullObject,
     NumberObject,
-    extract_links,
 )
+from pypdf.generic._link import DirectReferenceLink, extract_links
 from tests import get_data_from_url
 
 

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -534,3 +534,80 @@ def test_merge__null_destination():
 
     writer.merge(position=1, fileobj=data)
     assert writer.pages[0].annotations is None
+
+
+@pytest.mark.enable_socket
+def test_merge_direct_link_preserved(pdf_file_path):
+    # this could be any PDF -- we don't care which
+    reader = PdfReader(BytesIO(get_data_from_url(name="iss3268.pdf")))
+    writer = PdfWriter(clone_from=reader)
+
+    # this PDF has a direct link from p1 to p2
+    merger = PdfReader(BytesIO(get_data_from_url(name="direct-link.pdf")))
+    for page in merger.pages:
+        # we are deliberately merging into a blank page first, to
+        # verify that links are preserved even when we are not adding
+        # the source page directly
+        new_page = page.create_blank_page(
+            writer, width = page.mediabox.width, height = page.mediabox.height
+        )
+        new_page.merge_page(page)
+        writer.add_page(new_page)
+
+    writer.write(pdf_file_path)
+
+    check = PdfReader(pdf_file_path)
+    page3 = check.pages[2]
+    link = page3["/Annots"][0].get_object()
+    assert link["/Subtype"] == "/Link"
+    destination = link["/Dest"][0]  # indirect reference of page referred to
+
+    page4 = check.flattened_pages[3]
+    assert destination == page4.indirect_reference, "Link from page 3 to page 4 is broken"
+
+
+@pytest.mark.enable_socket
+def test_merged_named_reference_preserved(pdf_file_path):
+    # this could be any PDF -- we don't care which
+    reader = PdfReader(BytesIO(get_data_from_url(name="iss3268.pdf")))
+    writer = PdfWriter(clone_from=reader)
+
+    # this PDF has a named reference from from p3 to p5
+    merger = PdfReader(BytesIO(get_data_from_url(name="named-reference.pdf")))
+    for page in merger.pages:
+        # we are deliberately merging into a blank page first, to
+        # verify that links are preserved even when we are not adding
+        # the source page directly
+        new_page = page.create_blank_page(
+            writer, width = page.mediabox.width, height = page.mediabox.height
+        )
+        new_page.merge_page(page)
+        writer.add_page(new_page)
+
+    writer.write(pdf_file_path)
+
+    check = PdfReader(pdf_file_path)
+    page5 = check.pages[4]
+    page7 = check.flattened_pages[6]
+    for link in page5["/Annots"]:
+        action = link["/A"]
+        assert action.get("/S") == "/GoTo"
+        destination = str(action["/D"])
+        assert destination in check.named_destinations
+        referenced_page = check.named_destinations[destination].page
+
+        assert referenced_page == page7.indirect_reference, "Link from page 5 to page 7 is broken"
+
+
+@pytest.mark.enable_socket
+def test_copy_to_writer():
+    # this PDF has a named reference from from p3 to p5. test verifies
+    # that merging in the pages of a file with a named reference doesn't
+    # crash
+    reader = PdfReader(BytesIO(get_data_from_url(name="named-reference.pdf")))
+
+    writer = PdfWriter()
+    for page in reader.pages:
+        writer.add_page(page)
+
+    assert len(writer.pages) == len(reader.pages)


### PR DESCRIPTION
This is the last part of the implementation of issue 3290.

It causes the tests to be slow because `named_destinations` is not cached, but I'm leaving that as a separate task.