### PR TITLE
MAINT: Remove ignoring of Ruff rule UP035

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -43,7 +43,6 @@ from typing import (
     IO,
     Any,
     Callable,
-    List,
     Optional,
     Union,
     cast,

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3087,7 +3087,7 @@ class PdfWriter(PdfDocCommon):
     ) -> list[Destination]:
         outlist = ArrayObject()
         if isinstance(annots, IndirectObject):
-            annots = cast("List[Any]", annots.get_object())
+            annots = cast("list[Any]", annots.get_object())
         if annots is None:
             return outlist
         if not isinstance(annots, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,6 @@ ignore = [
     "TRY301",  # Abstract `raise` to an inner function
     "UP006",   # Non-PEP 585 annotation. As long as we are not on Python 3.11+
     "UP007",   # Non-PEP 604 annotation. As long as we are not on Python 3.11+
-    "UP035",   # PEP 585. As long as we are not on Python 3.9+
     "UP038",   # Use `X | Y` in `isinstance` call instead of `(X, Y)` - PEP 604. While not on Python 3.10+
 ]
 


### PR DESCRIPTION
UP035: checks for uses of deprecated imports based on the minimum supported Python version.