### PR TITLE
BUG: properly clean up orphan objects when removing pages

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1430,8 +1430,8 @@ class PdfWriter(PdfDocCommon):
         if clean and getattr(self, "_has_written", False):
             try:
                 self._rebuild_via_io()
-            except Exception as e:
-                logger_warning(f"Failed to rebuild PdfWriter after remove_page with clean=True: {e}", __name__)
+            except Exception as exc:
+                logger_warning(f"Failed to rebuild PdfWriter after remove_page with clean=True: {exc}", __name__)
                 # No re-raise: keep remove_page robust, tests/CI should catch the error
 
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -59,8 +59,8 @@ from ._utils import (
     StreamType,
     _get_max_pdf_version_header,
     deprecation_no_replacement,
-    logger_warning,
     logger_error,
+    logger_warning,
 )
 from .constants import AnnotationDictionaryAttributes as AA
 from .constants import CatalogAttributes as CA
@@ -1441,9 +1441,6 @@ class PdfWriter(PdfDocCommon):
 
         This removes orphan objects that persist after intermediate writes.
         """
-        from io import BytesIO
-        from pypdf import PdfReader
-
         buf = BytesIO()
         self.write(buf)
         buf.seek(0)


### PR DESCRIPTION
This fixes an issue where removing pages after writing left orphan objects in the PDF writer.

The fix forces a rebuild of the internal structure to clean orphaned objects, improving stability and avoiding potential PDF corruption.

Closes #3418