### PR TITLE
ENH: Add support for python in FIPS mode for document identifier

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -136,7 +136,7 @@ class ObjectDeletionFlag(enum.IntFlag):
 
 
 def _rolling_checksum(stream: BytesIO, blocksize: int = 65536) -> str:
-    hash = hashlib.md5()
+    hash = hashlib.md5(usedforsecurity=False)
     for block in iter(lambda: stream.read(blocksize), b""):
         hash.update(block)
     return hash.hexdigest()


### PR DESCRIPTION
In FIPS mode, md5 might be available and approved. It might also be
available, but only on opt-in basis for unapproved usage. And very
strict systems might not have md5 even on opt-in basis.

Python has API to expose this as "usedforsecurity=False" argument, see
python documentation.

The rolling document checksum is not used for cryptograpic protection,
but rather used out of convenience. Hence allow using MD5 on more FIPS
systems.

This is no effective change for regular non-fips python builds.
