### PR TITLE
PI: Optimize retrieval of named destinations in reader

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -74,6 +74,7 @@ from .generic import (
     ArrayObject,
     ContentStream,
     DecodedStreamObject,
+    Destination,
     DictionaryObject,
     EncodedStreamObject,
     IndirectObject,
@@ -83,6 +84,7 @@ from .generic import (
     PdfObject,
     StreamObject,
     TextStringObject,
+    TreeObject,
     is_null_or_none,
     read_object,
 )
@@ -155,6 +157,8 @@ class PdfReader(PdfDocCommon):
             self._handle_encryption(password)
         elif password is not None:
             raise PdfReadError("Not an encrypted file")
+
+        self._named_destinations_cache: Optional[dict[str, Destination]] = None
 
     def _initialize_stream(self, stream: Union[StrByteType, Path]) -> None:
         if hasattr(stream, "mode") and "b" not in stream.mode:
@@ -1505,3 +1509,18 @@ class PdfReader(PdfDocCommon):
             data = {k: v for k, v in data.items() if k not in exclude}
 
         return data
+
+    def _get_named_destinations(
+        self,
+        tree: Union[TreeObject, None] = None,
+        retval: Optional[dict[str, Destination]] = None,
+    ) -> dict[str, Destination]:
+        """Override from PdfDocCommon. In the reader we can assume this is
+        static, but not in the writer.
+        """
+        if tree or retval:
+            return super()._get_named_destinations(tree, retval)
+
+        if self._named_destinations_cache is None:
+            self._named_destinations_cache = super()._get_named_destinations()
+        return self._named_destinations_cache

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -6,6 +6,7 @@ import time
 from io import BytesIO
 from pathlib import Path
 from typing import Union
+from unittest import mock
 
 import pytest
 
@@ -2273,3 +2274,13 @@ def test_get_object_from_stream__size_limit(caplog):
         "NumberObject(b'') invalid; use 0 instead",
         "NumberObject(b'') invalid; use 0 instead",
     ]
+
+
+def test_named_destinations_cache():
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+
+    with mock.patch("pypdf._doc_common.PdfDocCommon._get_named_destinations") as get_mock:
+        for _ix in range(20):
+            reader.named_destinations.get("foo")
+
+        get_mock.assert_called_once()


### PR DESCRIPTION
This optimization solves the performance issue introduced by PR #3400.

Without this optimization `test_merger.py` takes 124 seconds on my laptop after PR 3400. With this optimization it takes 6.6 seconds.

Very likely this optimization will benefit other code as well.