### PR TITLE
DOC: Update metadata.md to add example for custom field access 

### DIFF
--- a/docs/user/metadata.md
+++ b/docs/user/metadata.md
@@ -60,6 +60,10 @@ writer.add_metadata(
 # Save the new PDF to a file
 with open("meta-pdf.pdf", "wb") as f:
     writer.write(f)
+
+#Access new custom field (while standard fields like Author have primitive analogs and can be accessed like reader.metadata.author, custom fields do not)
+metareader = PdfReader("meta-pdf.pdf")
+print(metareader.metadata['/CustomField'])
 ```
 
 ## Updating metadata


### PR DESCRIPTION
Adding a part to **Writing Metadata** section to explain that custom metadata fields added this way need to be accessed using their string literal name because they do not have primitive names.  

works: reader.metadata['/CustomField']
not works: reader.metadata.CustomField  or  reader.metadata.customfield
