### PR TITLE
Fix NoneType object is not subscriptable from _insert_filtered_annotations

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3052,7 +3052,14 @@ class PdfWriter(PdfDocCommon):
                         outlist.append(ano.clone(self).indirect_reference)
                 else:
                     d = cast("ArrayObject", d)
-                    p = self._get_cloned_page(d[0], pages, reader)
+                    try:
+                        p = self._get_cloned_page(d[0], pages, reader)
+                    except TypeError:
+                        # There are cases where the IndirectObject is not None, but d[0] will fail:
+                        # TypeError: 'NoneType' object is not subscriptable
+                        # in generic/_base.py, in __getitem__
+                        # at `return self._get_object_with_check()[key]`
+                        continue
                     if p is not None:
                         anc = ano.clone(self, ignore_fields=("/D",))
                         cast("DictionaryObject", anc["/A"])[


### PR DESCRIPTION
There are cases where the IndirectObject is not None, but `d[0]` will fail with `TypeError: 'NoneType' object is not subscriptable` in `generic/_base.py`, at `return self._get_object_with_check()[key]`.

I previously reported this issue in #3211, but the fix for that issue didn't fix this one. 

Unfortunately i still can't attach the PDF file that triggered this issue, because it contains personal information.
If someone has an idea how to create a PDF to test this with, i'd be happy to try. 
I fully understand that a maintainer would not be keen on including fixes for rare bugs without a test. 

## More details on the error

The script i used to reproduce the error:

```python
import glob

from pypdf import PdfWriter


def merge_pdfs():
    with PdfWriter() as merger:
        for pdf in glob.glob("*.pdf"):
            merger.append(pdf)
        merger.write("merged.pdf")

if __name__ == '__main__':

    merge_pdfs()
```

In the script directory i have a `broken.pdf` (the offending file i can't share here) and an `empty.pdf`. 

This fails as below:

```
Object 6 0 not defined.
Object 6 0 not defined.
Overwriting cache for 0 6
Traceback (most recent call last):
  File "/home/kees/Projects/pypdf/check_merge.py", line 21, in <module>
    merge_pdfs()
    ~~~~~~~~~~^^
  File "/home/kees/Projects/pypdf/check_merge.py", line 16, in merge_pdfs
    merger.append(pdf)
    ~~~~~~~~~~~~~^^^^^
  File "/home/kees/Projects/pypdf/pypdf/_writer.py", line 2693, in append
    self.merge(
    ~~~~~~~~~~^
        None,
        ^^^^^
    ...<4 lines>...
        excluded_fields,
        ^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/kees/Projects/pypdf/pypdf/_writer.py", line 2851, in merge
    lst = self._insert_filtered_annotations(
        pag.original_page.get("/Annots", []), pag, srcpages, reader
    )
  File "/home/kees/Projects/pypdf/pypdf/_writer.py", line 3055, in _insert_filtered_annotations
    p = self._get_cloned_page(d[0], pages, reader)
                              ~^^^
  File "/home/kees/Projects/pypdf/pypdf/generic/_base.py", line 402, in __getitem__
    return self._get_object_with_check()[key]  # type: ignore
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
TypeError: 'NoneType' object is not subscriptable

```

Setting a breakpoint before the error occurs gives:

```
(Pdb) d
IndirectObject(6, 0, 127177489623296)
(Pdb) d[0]
Object 6 0 not defined.
Overwriting cache for 0 6
*** TypeError: 'NoneType' object is not subscriptable
``` 

(To be fair, in this last example i cheated a bit because the variable name `d` clashes with the [pdb command](https://docs.python.org/3/library/pdb.html#pdbcommand-down). So i renamed that.)