### PR TITLE
BUG: Guard empty input to prevent IndexError

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -77,7 +77,7 @@ StrByteType = Union[str, StreamType]
 
 def parse_iso8824_date(text: Optional[str]) -> Optional[datetime]:
     orgtext = text
-    if text is None:
+    if not text:
         return None
     if text[0].isdigit():
         text = "D:" + text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -360,6 +360,18 @@ def test_parse_datetime(text, expected):
     assert date_str == expected
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_datetime_edge_cases(text, expected):
+    date = parse_iso8824_date(text)
+    assert date == expected
+
+
 def test_parse_datetime_err():
     with pytest.raises(ValueError) as ex:
         parse_iso8824_date("D:20210408T054711Z")


### PR DESCRIPTION
Resolves #3446 

## How to check
As mentioned in #3446 you can test with [guwunmong.pdf](https://github.com/user-attachments/files/21969610/guwunmong.pdf).

```python
>>> import os
>>> from io import BytesIO
>>> from pypdf import PdfReader
>>> with open("guwunmong.pdf", "rb") as f:
...     pdf_bytes = f.read()
>>> reader = PdfReader(stream=BytesIO(pdf_bytes))
>>> metadata = reader.metadata
>>> creation_date = str(metadata.creation_date) if metadata.creation_date else None  # Used to raise IndexError here.
>>> creation_date
>>> print(creation_date)  # Prints None as expected.
None
```
