### PR TITLE
BUG: Fix handling of zero-length streams in StreamObject

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -636,7 +636,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             pstart = stream.tell()
             if length > 0:
                 data["__streamdata__"] = stream.read(length)
-            else:
+            elif length < 0:
                 data["__streamdata__"] = read_until_regex(
                     stream, re.compile(b"endstream")
                 )

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -634,9 +634,9 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             if length is None:  # if the PDF is damaged
                 length = -1
             pstart = stream.tell()
-            if length > 0:
+            if length >= 0:
                 data["__streamdata__"] = stream.read(length)
-            elif length < 0:
+            else:
                 data["__streamdata__"] = read_until_regex(
                     stream, re.compile(b"endstream")
                 )

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1275,4 +1275,4 @@ def test_dictionaryobject__length_0_stream():
     writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
     output = BytesIO()
     writer.write(output)
-    assert b"\n8 0 obj\n<<\n/Length 0\n>>\nendobj\n" in output.getvalue()
+    assert b"\n8 0 obj\n<<\n/Length 0\n>>\nstream\n\nendstream\nendobj\n" in output.getvalue()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1265,3 +1265,14 @@ def test_build_link__go_to_action_without_destination():
     for page in reader.pages:
         writer.add_page(page)
     assert len(writer.pages) == len(reader.pages)
+
+
+@pytest.mark.enable_socket
+def test_dictionaryobject__length_0_stream():
+    """Test for issue #3052."""
+    url = "https://github.com/user-attachments/files/18734105/correct.pdf"
+    name = "issue3052.pdf"
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    output = BytesIO()
+    writer.write(output)
+    assert b"\n8 0 obj\n<<\n/Length 0\n>>\nendobj\n" in output.getvalue()


### PR DESCRIPTION
A solution to #3052 continue from pr #3114.