### PR TITLE
BUG: PageObject.scale() scales media box incorrectly (#3487)

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1503,7 +1503,7 @@ class PageObject(DictionaryObject):
         Scale a page by the given factors by applying a transformation matrix
         to its content and updating the page size.
 
-        This updates the various page boundaries (mediabox, cropbox, etc.)
+        This updates the various page boundaries (artbox, cropbox, etc.)
         and the contents of the page.
 
         Args:
@@ -1512,11 +1512,11 @@ class PageObject(DictionaryObject):
 
         """
         self.add_transformation((sx, 0, 0, sy, 0, 0))
-        self.mediabox = self.mediabox.scale(sx, sy)
+        self.artbox = self.artbox.scale(sx, sy)
         self.cropbox = self.cropbox.scale(sx, sy)
         self.bleedbox = self.bleedbox.scale(sx, sy)
         self.trimbox = self.trimbox.scale(sx, sy)
-        self.artbox = self.artbox.scale(sx, sy)
+        self.mediabox = self.mediabox.scale(sx, sy)
 
         if PG.ANNOTS in self:
             annotations = self[PG.ANNOTS]


### PR DESCRIPTION
Partly undo https://github.com/py-pdf/pypdf/commit/d89fb787f9dfa161b86d7b67b6ed1f5547cee513#diff-153e5cee71ddf471246ff5c0e198345f005942a540a8f39297736f0b620d631dR1587-R1592 since the changed order of updates to the page boundaries results in wrongly scaled pdfs.