### PR TITLE
DEV: Update pyupgrade in pre-commit configuration to 3.21.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ['--fix']
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py39-plus]


### PR DESCRIPTION
Otherwise, https://redirect.github.com/asottile/pyupgrade/issues/1038 is triggered for Python 3.14.2.