### PR TITLE
DEV: Add PyPy 3.11 to test matrix and benchmarks

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -10,11 +10,16 @@ permissions:
 
 jobs:
   benchmark:
-    name: Run pytest-benchmark
+    name: "Benchmark ${{ matrix.name }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.x']
+        include:
+          - python-version: '3.x'
+            name: 'CPython'
+          - python-version: 'pypy3.11'
+            name: 'PyPy 3.11'
     steps:
     - name: Checkout Code
       uses: actions/checkout@v6
@@ -36,7 +41,7 @@ jobs:
     - name: Store benchmark result
       uses: benchmark-action/github-action-benchmark@v1
       with:
-        name: Python Benchmark with pytest-benchmark
+        name: "${{ matrix.name }} Benchmark"
         tool: 'pytest'
         output-file-path: output.json
         # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t/github-action-not-triggering-gh-pages-upon-push/16096

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.11']
         use-crypto-lib: ['cryptography']
         include:
           - python-version: '3.9'
@@ -180,10 +180,19 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest tests --cov=pypdf --cov-append -n auto -vv -p no:benchmark
+      if: ${{ !startsWith(matrix.python-version, 'pypy') }}
+    - name: Test with pytest (PyPy, no coverage)
+      # Coverage on PyPy is skipped because running coverage with PyPy is slow and CPython test already provides
+      # complete coverage data for the same code
+      run: |
+        python -m pytest tests -n auto -vv -p no:benchmark
+      if: ${{ startsWith(matrix.python-version, 'pypy') }}
     - name: Rename coverage data file
       run: mv .coverage ".coverage.$RANDOM"
+      if: ${{ !startsWith(matrix.python-version, 'pypy') }}
     - name: Upload coverage data
       uses: actions/upload-artifact@v6
+      if: ${{ !startsWith(matrix.python-version, 'pypy') }}
       with:
         name: coverage-data.${{ matrix.python-version }}-${{ matrix.use-crypto-lib }}
         path: .coverage.*

--- a/requirements/ci-3.11.txt
+++ b/requirements/ci-3.11.txt
@@ -10,7 +10,7 @@ coverage[toml]==7.13.0
     # via
     #   -r requirements/ci.in
     #   pytest-cov
-cryptography==44.0.1
+cryptography==44.0.2
     # via -r requirements/ci.in
 defusedxml==0.7.1
     # via fpdf2

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,7 +10,7 @@ coverage[toml]==7.10.7
     # via
     #   -r requirements/ci.in
     #   pytest-cov
-cryptography==44.0.1
+cryptography==44.0.2
     # via -r requirements/ci.in
 exceptiongroup==1.2.2
     # via pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -334,7 +334,8 @@ def test_file_class():
     """File class can be instantiated and string representation is ok."""
     f = File(name="image.png", data=b"")
     assert str(f) == "File(name=image.png, data: 0 Byte)"
-    assert repr(f) == "File(name=image.png, data: 0 Byte, hash: 0)"
+    # hash(b"") varies between CPython and PyPy
+    assert repr(f) == f"File(name=image.png, data: 0 Byte, hash: {hash(b'')})"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Encouraged by https://github.com/py-pdf/pypdf/discussions/3570, I've tried adding PyPy support to the build pipeline and benchmarks. This PR adds a data point about pypdf's compatibility and performance with PyPy, but this does not make PyPy support official (yet). 

The test suite passed locally, except for a small problem with hash values (fix included). It probably makes sense to discuss further based on CI results.

Important points:
* `cryptography` upgraded to 44.0.2, the only change from 44.0.1 is that they've added wheels for PyPy 3.11, which is exactly what we needed
* coverage is disabled for PyPy, it increases the run to break timeouts and it's actually already provided by CPython 3.11 tests. Could re-enable if we increase the timeouts.