### PR TITLE
ROB: Avoid empty FlateDecode outputs without warning

### DIFF
--- a/docs/user/extract-images.md
+++ b/docs/user/extract-images.md
@@ -26,7 +26,7 @@ for i, image_file_object in enumerate(page.images):
     image_file_object.image.save(file_name)
 ```
 
-# Other images
+## Other images
 
 Some other objects can contain images, such as stamp annotations.
 
@@ -43,4 +43,25 @@ im = (
 )
 
 im.save("out-annotation-image.png")
+```
+
+## Error handling
+
+Iterating over `page.images` directly will raise an exception on the first issue.
+If you expect some more or less broken PDF files, but still want to retrieve as many images as possible,
+consider making this a multistep process:
+
+```{testcode}
+from pypdf import PdfReader
+
+reader = PdfReader("example.pdf")
+
+for page in reader.pages:
+    for name in page.images.keys():
+        try:
+            # Try to retrieve actual image.
+            image = page.images[name]
+        except Exception as exception:
+            # Handle exceptions.
+            pass
 ```

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -132,6 +132,7 @@ def decompress(data: bytes) -> bytes:
         result_str = b""
         remaining_limit = ZLIB_MAX_OUTPUT_LENGTH
         data_single_bytes = [data[i : i + 1] for i in range(len(data))]
+        known_errors = set()
         for index, b in enumerate(data_single_bytes):
             try:
                 decompressed = decompressor.decompress(b, max_length=remaining_limit)
@@ -141,8 +142,12 @@ def decompress(data: bytes) -> bytes:
                     raise LimitReachedError(
                         f"Limit reached while decompressing. {len(data_single_bytes) - index} bytes remaining."
                     )
-            except zlib.error:
-                pass
+            except zlib.error as error:
+                error_str = str(error)
+                if error_str in known_errors:
+                    continue
+                logger_warning(error_str, __name__)
+                known_errors.add(error_str)
         return result_str
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -893,3 +893,12 @@ def test_decompress():
                 LimitReachedError, match=r"^Limit reached while decompressing\. 12 bytes remaining\."
             ):
         decompress(compressed)
+
+
+def test_decompress__logging_on_invalid_data(caplog):
+    """We do not like suddenly getting empty outputs for non-empty inputs without a warning."""
+    codec = FlateDecode()
+    encoded = codec.encode(b"My test string")
+    assert len(encoded) > 5
+    assert codec.decode(encoded[5:]) == b""
+    assert caplog.messages == ["Error -3 while decompressing data: incorrect header check"]


### PR DESCRIPTION
It took me rather long to debug

> pypdf.errors.EmptyImageDataError: Data is 0 bytes, cannot process an image from empty data.

for a stream which looked completely fine. It turned out to be an invalid FlateDecode stream which we could not decode, thus converting an non-empty content stream into an empty one. With this PR, we at least forward the corresponding warning, although only once per warning type to not flood the application logs.