### PR TITLE
Fix benchmark naming to align with historical data

### DIFF
--- a/dev/bench/data.js
+++ b/dev/bench/data.js
@@ -2,7 +2,7 @@ window.BENCHMARK_DATA = {
   "lastUpdate": 1767175349951,
   "repoUrl": "https://github.com/py-pdf/pypdf",
   "entries": {
-    "Python Benchmark with pytest-benchmark": [
+    "CPython Benchmark": [
       {
         "commit": {
           "author": {
@@ -86665,9 +86665,7 @@ window.BENCHMARK_DATA = {
             "extra": "mean: 635.0036485999908 msec\nrounds: 5"
           }
         ]
-      }
-    ],
-    "CPython Benchmark": [
+      },
       {
         "commit": {
           "author": {


### PR DESCRIPTION
In https://github.com/py-pdf/pypdf/pull/3574, the name/title of the CPython benchmark changed, leading to disconnecting new CPython benchmark results from historical results.

This data correction fixes that by merging the two sections under the new name. According to https://github.com/benchmark-action/github-action-benchmark/blob/2e6f4e33d6695578ee68981a04100aa77e0ac037/src/write.ts#L368-L390, the data will be first pulled before updating.