### PR TITLE
fix: Type hints for ArrayObject

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -35,7 +35,6 @@ from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Literal,
@@ -80,9 +79,6 @@ from .generic import (
     StreamObject,
     is_null_or_none,
 )
-
-# if TYPE_CHECKING:
-#     from PIL.Image import Image as PILImage
 
 try:
     from PIL.Image import Image

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -35,6 +35,7 @@ from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Literal,
@@ -79,6 +80,9 @@ from .generic import (
     StreamObject,
     is_null_or_none,
 )
+
+# if TYPE_CHECKING:
+#     from PIL.Image import Image as PILImage
 
 try:
     from PIL.Image import Image

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -35,15 +35,13 @@ import sys
 from collections.abc import Iterable, Sequence
 from io import BytesIO
 from math import ceil
-from typing import (
-    Any,
-    Callable,
-    Optional,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Optional, Union, cast
 
-from .._protocols import PdfReaderProtocol, PdfWriterProtocol, XmpInformationProtocol
+from .._protocols import (
+    PdfReaderProtocol,
+    PdfWriterProtocol,
+    XmpInformationProtocol,
+)
 from .._utils import (
     WHITESPACES,
     StreamType,
@@ -57,9 +55,9 @@ from .._utils import (
 from ..constants import (
     CheckboxRadioButtonAttributes,
     FieldDictionaryAttributes,
-    OutlineFontFlag,
 )
 from ..constants import FilterTypes as FT
+from ..constants import OutlineFontFlag
 from ..constants import StreamAttributes as SA
 from ..constants import TypArguments as TA
 from ..constants import TypFitArguments as TF
@@ -1000,7 +998,7 @@ class StreamObject(DictionaryObject):
 
     @staticmethod
     def initialize_from_dictionary(
-        data: dict[str, Any]
+        data: dict[str, Any],
     ) -> Union["EncodedStreamObject", "DecodedStreamObject"]:
         retval: Union[EncodedStreamObject, DecodedStreamObject]
         if SA.FILTER in data:
@@ -1046,7 +1044,9 @@ class StreamObject(DictionaryObject):
         retval._data = FlateDecode.encode(self._data, level)
         return retval
 
-    def decode_as_image(self, pillow_parameters: Union[dict[str, Any], None] = None) -> Any:
+    def decode_as_image(
+        self, pillow_parameters: Union[dict[str, Any], None] = None
+    ) -> Any:
         """
         Try to decode the stream object as an image
 
@@ -1166,7 +1166,7 @@ class ContentStream(DecodedStreamObject):
                         # seems to already be broken beforehand in these cases.
                         logger_warning(
                             f"Expected StreamObject, got {type(s_resolved).__name__} instead. Data might be wrong.",
-                            __name__
+                            __name__,
                         )
                     else:
                         data += s_resolved.get_data()
@@ -1598,9 +1598,9 @@ class Destination(TreeObject):
 
     """
 
-    node: Optional[
-        DictionaryObject
-    ] = None  # node provide access to the original Object
+    node: Optional[DictionaryObject] = (
+        None  # node provide access to the original Object
+    )
 
     def __init__(
         self,

--- a/tests/test_xobject_image_helpers.py
+++ b/tests/test_xobject_image_helpers.py
@@ -161,10 +161,8 @@ def test_handle_flate__autodesk_indexed():
         else:
             assert name[0].startswith("/")
 
-        if image.image is not None:
+        if image.image:
             image.image.load()
-        else:
-            print(f"Warning: Could not load image data for {name}")
 
     data = RESOURCE_ROOT.joinpath("AutoCad_Diagram.pdf").read_bytes()
     data = data.replace(b"/DeviceRGB\x00255", b"/DeviceRGB")
@@ -175,7 +173,10 @@ def test_handle_flate__autodesk_indexed():
         match=r"^Expected color space with 4 values, got 3: \['/Indexed', '/DeviceRGB', '\\x00\\x80\\x00\\x80\\x80耀",  # noqa: E501
     ):
         for name, _image in page.images.items():  # noqa: PERF102
-            assert name.startswith("/")
+            if isinstance(name, str):
+                assert name.startswith("/")
+            else:
+                assert name[0].startswith("/")
 
 
 @pytest.mark.enable_socket
@@ -185,7 +186,8 @@ def test_get_mode_and_invert_color():
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     page = reader.pages[12]
     for _name, image in page.images.items():  # noqa: PERF102
-        image.image.load()
+        if image.image:
+            image.image.load()
 
 
 @pytest.mark.enable_socket
@@ -198,7 +200,8 @@ def test_get_imagemode__empty_array():
     with pytest.raises(
         expected_exception=PdfReadError, match=r"^ColorSpace field not found in .+"
     ):
-        page.images[0].image.load()
+        if page.images[0].image:
+            page.images[0].image.load()
 
 
 def test_p_image_with_alpha_mask():


### PR DESCRIPTION
Added  correct type for the **color_space** to be **ArrayObject**

For the test file test_xobject_image_helpers, all type hinting errors have been resolved