### PR TITLE
ROB: `/AcroForm` might be NullObject

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2749,7 +2749,7 @@ class PdfWriter(PdfDocCommon):
                     pag[NameObject("/Annots")] = lst
                 self.clean_page(pag)
 
-        if "/AcroForm" in _ro and _ro["/AcroForm"] is not None:
+        if "/AcroForm" in _ro and not is_null_or_none(_ro["/AcroForm"]):
             if "/AcroForm" not in self._root_object:
                 self._root_object[NameObject("/AcroForm")] = self._add_object(
                     cast(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2895,3 +2895,25 @@ def test_flatten_form_field_without_font_in_resources():
     reader = PdfReader(b)
     form_text_fields = reader.get_form_text_fields()
     assert form_text_fields["Unique reference numberRow1"] == "test"
+
+
+def test_merge_with_null_acroform_does_not_raise_typeerror():
+    """
+    Source PDFs may contain '/AcroForm null'.
+
+    Test for issue #3598.
+    """
+    src_writer = PdfWriter()
+    src_writer.add_blank_page(72, 72)
+    src_writer.root_object[NameObject("/AcroForm")] = NullObject()
+
+    src_bytes = BytesIO()
+    src_writer.write(src_bytes)
+    src_bytes.seek(0)
+
+    source = PdfReader(src_bytes)
+
+    target = PdfWriter()
+    target.merge(0, source)
+
+    assert "/AcroForm" not in target.root_object


### PR DESCRIPTION
This PR prevents `PdfWriter.merge()`/`append()` from crashing when a source PDF’s catalog contains an `/AcroForm` entry that is present but `null` (or resolves to `null`). A regression test is included.

Closes #3598 