### PR TITLE
ENH: Extract the /FontFile and store it in the new FontDescriptor class

### DIFF
--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union, cast
 
-from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, StreamObject
+from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, PdfObject, StreamObject
 
 from ._cmap import get_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs
@@ -67,7 +67,7 @@ class FontDescriptor:
                 if "font_file" in font_kwargs:
                     raise PdfReadError(f"More than one /FontFile found in {font_descriptor_obj}")
 
-                file = font_descriptor_dict[source_key]
+                file = cast(PdfObject, font_descriptor_dict[source_key])
                 file = file.get_object() if isinstance(file, IndirectObject) else file
                 font_kwargs["font_file"] = file
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -65,7 +65,6 @@ class FontDescriptor:
         for source_key in ["/FontFile", "/FontFile2", "/FontFile3"]:
             if source_key in font_descriptor_dict:
                 if "font_file" in font_kwargs:
-                    import pdb;pdb.set_trace()
                     raise PdfReadError(f"More than one /FontFile found in {font_descriptor_obj}")
 
                 try:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -67,9 +67,8 @@ class FontDescriptor:
                 if "font_file" in font_kwargs:
                     raise PdfReadError(f"More than one /FontFile found in {font_descriptor_obj}")
 
-                file = cast(PdfObject, font_descriptor_dict[source_key])
-                file = file.get_object() if isinstance(file, IndirectObject) else file
-                font_kwargs["font_file"] = file
+                font_file = cast(PdfObject, font_descriptor_dict[source_key]).get_object()
+                font_kwargs["font_file"] = font_file
 
         return font_kwargs
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -65,10 +65,14 @@ class FontDescriptor:
         for source_key in ["/FontFile", "/FontFile2", "/FontFile3"]:
             if source_key in font_descriptor_dict:
                 if "font_file" in font_kwargs:
+                    import pdb;pdb.set_trace()
                     raise PdfReadError(f"More than one /FontFile found in {font_descriptor_obj}")
 
-                font_file = cast(PdfObject, font_descriptor_dict[source_key]).get_object()
-                font_kwargs["font_file"] = font_file
+                try:
+                    font_file = cast(PdfObject, font_descriptor_dict[source_key]).get_object()
+                    font_kwargs["font_file"] = font_file
+                except PdfReadError as e:
+                    logger_warning(f"Failed to get '{source_key}' in {font_descriptor_dict}", __name__)
 
         return font_kwargs
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -71,7 +71,7 @@ class FontDescriptor:
                     font_file = cast(PdfObject, font_descriptor_dict[source_key]).get_object()
                     font_kwargs["font_file"] = font_file
                 except PdfReadError as e:
-                    logger_warning(f"Failed to get '{source_key}' in {font_descriptor_dict}", __name__)
+                    logger_warning(f"Failed to get '{source_key}' in {font_descriptor_dict}: {e}", __name__)
 
         return font_kwargs
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -68,7 +68,7 @@ class FontDescriptor:
                     raise PdfReadError(f"More than one /FontFile found in {font_descriptor_obj}")
 
                 try:
-                    font_file = cast(PdfObject, font_descriptor_dict[source_key]).get_object()
+                    font_file = font_descriptor_dict[source_key].get_object()
                     font_kwargs["font_file"] = font_file
                 except PdfReadError as e:
                     logger_warning(f"Failed to get '{source_key}' in {font_descriptor_dict}: {e}", __name__)

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -33,7 +33,7 @@ class FontDescriptor:
     bbox: tuple[float, float, float, float] = field(default_factory=lambda: (-100.0, -200.0, 1000.0, 900.0))
 
     character_widths: dict[str, int] = field(default_factory=lambda: {"default": 500})
-    font_file: StreamObject | None = None
+    font_file: Union[StreamObject, None] = None
 
     @staticmethod
     def _parse_font_descriptor(font_kwargs: dict[str, Any], font_descriptor_obj: DictionaryObject) -> dict[str, Any]:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -2,7 +2,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union, cast
 
-from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject
+from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, StreamObject
+from pypdf.errors import PdfReadError
 
 from ._cmap import get_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs
@@ -32,6 +33,7 @@ class FontDescriptor:
     bbox: tuple[float, float, float, float] = field(default_factory=lambda: (-100.0, -200.0, 1000.0, 900.0))
 
     character_widths: dict[str, int] = field(default_factory=lambda: {"default": 500})
+    font_file: StreamObject | None = None
 
     @staticmethod
     def _parse_font_descriptor(font_kwargs: dict[str, Any], font_descriptor_obj: DictionaryObject) -> dict[str, Any]:
@@ -59,6 +61,16 @@ class FontDescriptor:
             bbox_tuple = tuple(map(float, font_kwargs["bbox"]))
             assert len(bbox_tuple) == 4, bbox_tuple
             font_kwargs["bbox"] = bbox_tuple
+        # Find the binary stream for this font if there is one
+        for source_key in ["/FontFile", "/FontFile2", "/FontFile3"]:
+            if source_key in font_descriptor_dict:
+                if "font_file" in font_kwargs:
+                    raise PdfReadError(f"More than one /FontFile found in {font_descriptor_obj}")
+
+                file = font_descriptor_dict[source_key]
+                file = file.get_object() if isinstance(file, IndirectObject) else file
+                font_kwargs["font_file"] = file
+
         return font_kwargs
 
     @staticmethod

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union, cast
 
-from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, PdfObject, StreamObject
+from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, StreamObject
 
 from ._cmap import get_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -3,11 +3,11 @@ from dataclasses import dataclass, field
 from typing import Any, Optional, Union, cast
 
 from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, StreamObject
-from pypdf.errors import PdfReadError
 
 from ._cmap import get_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs
 from ._utils import logger_warning
+from .errors import PdfReadError
 
 
 @dataclass(frozen=True)

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -8,7 +8,7 @@ from pypdf import PdfReader, PdfWriter
 from pypdf._cmap import get_encoding, parse_bfchar
 from pypdf._codecs import charset_encoding
 from pypdf._font import Font
-from pypdf.generic import ArrayObject, DictionaryObject, IndirectObject, NameObject, NullObject
+from pypdf.generic import ArrayObject, DictionaryObject, EncodedStreamObject, IndirectObject, NameObject, NullObject
 
 from . import get_data_from_url
 
@@ -139,6 +139,8 @@ def test_iss1533():
     reader.pages[0].extract_text()  # no error
     font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F"])
     assert font.character_map["\x01"] == "Ü"
+    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert font.font_descriptor.font_file["/Subtype"] == "/CIDFontType0C"
 
 
 @pytest.mark.enable_socket

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -139,7 +139,7 @@ def test_iss1533():
     reader.pages[0].extract_text()  # no error
     font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F"])
     assert font.character_map["\x01"] == "Ü"
-    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert type(font.font_descriptor.font_file) is EncodedStreamObject
     assert font.font_descriptor.font_file["/Subtype"] == "/CIDFontType0C"
 
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -44,16 +44,16 @@ def test_font_file():
 
     # /FontFile
     font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F2"])
-    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert type(font.font_descriptor.font_file) is EncodedStreamObject
     assert len(font.font_descriptor.font_file.get_data()) == 5116
 
     # /FontFile2
     font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F1"])
-    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert type(font.font_descriptor.font_file) is EncodedStreamObject
     assert len(font.font_descriptor.font_file.get_data()) == 28464
 
     # /FontFile3
     reader = PdfReader(RESOURCE_ROOT / "attachment.pdf")
     font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F1"])
-    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert type(font.font_descriptor.font_file) is EncodedStreamObject
     assert len(font.font_descriptor.font_file.get_data()) == 2168

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -38,7 +38,6 @@ def test_font_descriptor():
     assert my_font.bbox == (-113.0, -250.0, 749.0, 801.0)
 
 
-@pytest.mark.enable_socket
 def test_font_file():
     reader = PdfReader(RESOURCE_ROOT / "multilang.pdf")
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,7 +1,15 @@
 """Test font-related functionality."""
+from pathlib import Path
 
-from pypdf._font import FontDescriptor
-from pypdf.generic import DictionaryObject, NameObject
+import pytest
+
+from pypdf import PdfReader
+from pypdf._font import Font, FontDescriptor
+from pypdf.generic import DictionaryObject, EncodedStreamObject, NameObject
+
+TESTS_ROOT = Path(__file__).parent.resolve()
+PROJECT_ROOT = TESTS_ROOT.parent
+RESOURCE_ROOT = PROJECT_ROOT / "resources"
 
 
 def test_font_descriptor():
@@ -28,3 +36,24 @@ def test_font_descriptor():
     assert my_font.italic_angle == 0
     assert my_font.flags == 33
     assert my_font.bbox == (-113.0, -250.0, 749.0, 801.0)
+
+
+@pytest.mark.enable_socket
+def test_font_file():
+    reader = PdfReader(RESOURCE_ROOT / "multilang.pdf")
+
+    # /FontFile
+    font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F2"])
+    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert len(font.font_descriptor.font_file.get_data()) == 5116
+
+    # /FontFile2
+    font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F1"])
+    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert len(font.font_descriptor.font_file.get_data()) == 28464
+
+    # /FontFile3
+    reader = PdfReader(RESOURCE_ROOT / "attachment.pdf")
+    font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F1"])
+    assert type(font.font_descriptor.font_file) == EncodedStreamObject
+    assert len(font.font_descriptor.font_file.get_data()) == 2168

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -54,7 +54,7 @@ def test_font_file():
     assert len(font.font_descriptor.font_file.get_data()) == 28464
 
     with pytest.raises(PdfReadError) as exception:
-        font_resource[NameObject("/FontDescriptor")][NameObject("/FontFile")] = NameObject('xyz')
+        font_resource[NameObject("/FontDescriptor")][NameObject("/FontFile")] = NameObject("xyz")
         font = Font.from_font_resource(font_resource)
     assert "More than one /FontFile" in exception.value.args[0]
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,8 +1,6 @@
 """Test font-related functionality."""
 from pathlib import Path
 
-import pytest
-
 from pypdf import PdfReader
 from pypdf._font import Font, FontDescriptor
 from pypdf.generic import DictionaryObject, EncodedStreamObject, NameObject

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -143,6 +143,7 @@ def test_font_class_to_dict():
             "x_height": 500.0,
             "italic_angle": 0.0,
             "flags": 32,
+            "font_file": None,
             "bbox": (
                 -100.0,
                 -200.0,


### PR DESCRIPTION
Apologies for not opening an issue first but this is a small change w/theoretically no impact.

I appreciated the new `Font` / `FontDescriptor` refactor in 6.6.0 but when I went to use it in [pdfalyzer](https://github.com/michelcrypt4d4mus/pdfalyzer) i noticed that the `/FontFile` is not extracted into the new `FontDescriptor` class so I made a small change to do that.

lmk if this isn't up to snuff. also happy to add unit tests if people can point me in the direction of sample files that might be hairy around this kind of thing.