### PR TITLE
ROB: Check for `self._info` being None in `compress_identical_objects`

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1638,7 +1638,8 @@ class PdfWriter(PdfDocCommon):
         # remove orphans (if applicable)
         orphans[self.root_object.indirect_reference.idnum - 1] = False  # type: ignore
 
-        orphans[self._info.indirect_reference.idnum - 1] = False  # type: ignore
+        if not is_null_or_none(self._info):
+            orphans[self._info.indirect_reference.idnum - 1] = False  # type: ignore
 
         try:
             orphans[self._ID.indirect_reference.idnum - 1] = False  # type: ignore

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2917,3 +2917,11 @@ def test_merge_with_null_acroform_does_not_raise_typeerror():
     target.merge(0, source)
 
     assert "/AcroForm" not in target.root_object
+
+
+def test_compress_identical_objects__info_is_none():
+    writer = PdfWriter(clone_from=RESOURCE_ROOT / "crazyones.pdf")
+    writer.compress_identical_objects()
+
+    writer.metadata = None
+    writer.compress_identical_objects()


### PR DESCRIPTION
Closes #3349.