### PR TITLE
BUG: Fix wrong LUT size error

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -408,13 +408,10 @@ def test_rgba():
 
 
 @pytest.mark.enable_socket
+@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_cmyk():
     """Decode CMYK"""
     # JPEG compression
-    try:
-        from Crypto.Cipher import AES  # noqa: F401, PLC0415
-    except ImportError:
-        return  # the file is encrypted
     reader = PdfReader(BytesIO(get_data_from_url(name="Vitocal.pdf")))
     refimg = BytesIO(get_data_from_url(name="VitocalImage.png"))
     data = reader.pages[1].images[0]

--- a/tests/test_xobject_image_helpers.py
+++ b/tests/test_xobject_image_helpers.py
@@ -5,6 +5,7 @@ import pytest
 from PIL import Image
 
 from pypdf import PdfReader
+from pypdf._utils import Version
 from pypdf._xobj_image_helpers import _extended_image_from_bytes, _handle_flate, _xobj_to_image
 from pypdf.constants import FilterTypes, ImageAttributes, StreamAttributes
 from pypdf.errors import EmptyImageDataError, PdfReadError
@@ -233,6 +234,10 @@ def test_handle_flate__icc_based__image_mode_1():
             assert image.getpixel((x, y)) == 255 * int(not is_black_square)
 
 
+@pytest.mark.skipif(
+    condition=Version(Image.__version__) < Version("12.1.0"),
+    reason="Unsuitable Pillow version."
+)
 def test_handle_jpx__explicit_decode():
     stream = StreamObject()
     stream[NameObject("/BitsPerComponent")] = NumberObject(8)


### PR DESCRIPTION
Running the image extraction on an image with DeviceCMYK and JPXDecode using a custom /Decode entry would previously fail when applying the LUT to the image in `_apply_decode`. This was due to converting the image to RGB, but the custom LUT having a size of 8 entries.

For my specific (non-disclosable) example everything works correctly now, while all existing tests still pass. Honestly, I am not sure whether all cases are handled correctly now, but at least the error is gone ...