### PR TITLE
ENH: CID font resource from font file to encode more characters

### DIFF
--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -8,6 +8,7 @@ from pypdf.generic import (
     ArrayObject,
     DictionaryObject,
     FloatObject,
+    IndirectObject,
     NameObject,
     NumberObject,
     PdfObject,
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
     from fontTools.ttLib.tables._h_e_a_d import table__h_e_a_d
     from fontTools.ttLib.tables._p_o_s_t import table__p_o_s_t
     from fontTools.ttLib.tables.O_S_2f_2 import table_O_S_2f_2
+
+    from ._writer import PdfWriter
 
 try:
     from fontTools.ttLib import TTFont
@@ -617,6 +620,34 @@ class Font:
             NameObject("/BaseFont"): NameObject(f"/{self.name}"),
             NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
         })
+
+    def add_to_writer(
+        self,
+        writer: PdfWriter,
+        target_resource_dict: DictionaryObject,
+        font_resource_name: NameObject
+    ) -> IndirectObject:
+        font_resource = self.as_font_resource()
+        if "/ToUnicode" in font_resource:
+            font_resource[NameObject("/ToUnicode")] = writer._add_object(font_resource["/ToUnicode"])
+
+        if "/DescendantFonts" in font_resource:
+            descendant_fonts = cast(ArrayObject, font_resource["/DescendantFonts"])
+            font_resource_dict = cast(DictionaryObject, descendant_fonts[0])
+        else:
+            font_resource_dict = font_resource
+
+        if "/FontDescriptor" in font_resource_dict:
+            font_descriptor_obj = cast(DictionaryObject, font_resource_dict["/FontDescriptor"])
+            for key in ["/FontFile", "/FontFile2", "/FontFile3"]:
+                if key in font_descriptor_obj:
+                    font_descriptor_obj[NameObject(key)] = writer._add_object(font_descriptor_obj[key])
+            font_resource_dict[NameObject("/FontDescriptor")] = writer._add_object(
+                font_resource_dict["/FontDescriptor"]
+            )
+        font_resource_ref = writer._add_object(font_resource)
+        target_resource_dict[font_resource_name] = font_resource_ref
+        return font_resource_ref
 
     def text_width(self, text: str = "") -> float:
         """Sum of character widths specified in PDF font for the supplied text."""

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -4,7 +4,15 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
-from pypdf.generic import ArrayObject, DictionaryObject, NameObject, NumberObject, StreamObject
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    FloatObject,
+    NameObject,
+    NumberObject,
+    StreamObject,
+    TextStringObject,
+)
 
 from ._cmap import get_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs
@@ -506,16 +514,50 @@ class Font:
         )
 
     def as_font_resource(self) -> DictionaryObject:
-        # For now, this returns a font resource that only works with the 14 Adobe Core fonts.
-        return (
-            DictionaryObject({
-                NameObject("/Subtype"): NameObject("/Type1"),
-                NameObject("/Name"): NameObject(f"/{self.name}"),
+        # If we have an embedded Truetype font, we assume that we need to produce a Type 2 CID font resource.
+        if self.font_descriptor.font_file and self.sub_type == "TrueType":
+            # Create the descendant font, using Identity mapping
+            cid_font = DictionaryObject({
                 NameObject("/Type"): NameObject("/Font"),
+                NameObject("/Subtype"): NameObject("/CIDFontType2"),
                 NameObject("/BaseFont"): NameObject(f"/{self.name}"),
-                NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
+                NameObject("/CIDSystemInfo"): DictionaryObject({
+                    NameObject("/Registry"): TextStringObject("Adobe"),
+                    NameObject("/Ordering"): TextStringObject("Identity"),
+                    NameObject("/Supplement"): NumberObject(0)
+                }),
             })
-        )
+
+            # Build the widths (/W) array. This can have two formats:
+            # [first_cid [w1 w2 w3]] or [first last width]
+            # Here we choose the first format and simply provide one array with one width for every cid.
+            widths_list = []
+            for char, width in self.character_widths.items():
+                if char != "default":
+                    cid = ord(char)
+                    widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
+
+            cid_font[NameObject("/W")] = ArrayObject(widths_list)
+            cid_font[NameObject("/DW")] = NumberObject(self.character_widths["default"])
+            cid_font[NameObject("/CIDToGIDMap")] = NameObject("/Identity")
+
+            # Create the Type 0 font object)
+            return DictionaryObject({
+                NameObject("/Type"): NameObject("/Font"),
+                NameObject("/Subtype"): NameObject("/Type0"),
+                NameObject("/BaseFont"): NameObject(f"/{self.name}"),
+                NameObject("/Encoding"): NameObject("/Identity-H"),
+                NameObject("/DescendantFonts"): ArrayObject([cid_font]),
+            })
+
+        # Fallback: Return a font resource for the 14 Adobe Core fonts.
+        return DictionaryObject({
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Subtype"): NameObject("/Type1"),
+            NameObject("/Name"): NameObject(f"/{self.name}"),
+            NameObject("/BaseFont"): NameObject(f"/{self.name}"),
+            NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
+        })
 
     def text_width(self, text: str = "") -> float:
         """Sum of character widths specified in PDF font for the supplied text."""

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -532,14 +532,42 @@ class Font:
             # [first_cid [w1 w2 w3]] or [first last width]
             # Here we choose the first format and simply provide one array with one width for every cid.
             widths_list = []
-            for char, width in self.character_widths.items():
-                if char != "default":
-                    cid = ord(char)
-                    widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
+            unicode_map = []
+            # In the loop, char is the decoded GID string (the reverse unicode hack)
+            # and character_map[char] is the actual character.
+            for gid_str, actual_char in self.character_map.items():
+                cid = ord(gid_str)
+                cid_hex = f"{cid:04X}"
+                uni_point = ord(actual_char)
+                uni_hex = f"{uni_point:04X}"
+                unicode_map.append(f"<{cid_hex}> <{uni_hex}>")
+
+                width = self.character_widths.get(gid_str, self.character_widths["default"])
+                widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
 
             cid_font[NameObject("/W")] = ArrayObject(widths_list)
             cid_font[NameObject("/DW")] = NumberObject(self.character_widths["default"])
             cid_font[NameObject("/CIDToGIDMap")] = NameObject("/Identity")
+
+            # Create the /ToUnicode CMap Stream
+            cmap_body = (
+                "/CIDInit /ProcSet findresource begin\n"
+                "12 dict begin\n"
+                "begincmap\n"
+                "/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n"
+                "/CMapName /Adobe-Identity-UCS def\n"
+                "/CMapType 2 def\n"
+                "1 begincodespacerange <0000> <FFFF> endcodespacerange\n"
+                f"{len(unicode_map)} beginbfchar\n"
+                + "\n".join(unicode_map) + "\n"
+                "endbfchar\n"
+                "endcmap\n"
+                "CMapName currentdict /CMap defineresource pop\n"
+                "end end"
+            )
+
+            to_unicode_stream = StreamObject()
+            to_unicode_stream.set_data(cmap_body.encode("ascii"))
 
             # Create the Type 0 font object)
             return DictionaryObject({
@@ -548,6 +576,7 @@ class Font:
                 NameObject("/BaseFont"): NameObject(f"/{self.name}"),
                 NameObject("/Encoding"): NameObject("/Identity-H"),
                 NameObject("/DescendantFonts"): ArrayObject([cid_font]),
+                NameObject("/ToUnicode"): to_unicode_stream,
             })
 
         # Fallback: Return a font resource for the 14 Adobe Core fonts.

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -613,3 +613,20 @@ class Font:
         return sum(
             [self.character_widths.get(char, self.character_widths["default"]) for char in text], 0.0
         )
+
+    def can_encode(self, text: str) -> bool:
+        """Check whether the font is able to encode a text string."""
+        try:
+            if self.character_map:
+                supported_chars = set(self.character_map.values())
+                return all(char in supported_chars for char in text)
+            if isinstance(self.encoding, str):
+                text.encode(self.encoding, "surrogatepass")
+            else:
+                supported_chars = set(self.encoding.values())
+                return all(char in supported_chars for char in text)
+
+        except UnicodeEncodeError:
+            return False
+
+        return True

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -68,6 +68,25 @@ class FontDescriptor:
     bbox: tuple[float, float, float, float] = field(default_factory=lambda: (-100.0, -200.0, 1000.0, 900.0))
     font_file: StreamObject | None = None
 
+    def as_font_descriptor_resource(self) -> DictionaryObject:
+        font_descriptor_resource = DictionaryObject({
+            NameObject("/Type"): NameObject("/FontDescriptor"),
+            NameObject("/FontName"): NameObject(f"/{self.name}"),
+            NameObject("/Flags"): NumberObject(self.flags),
+            NameObject("/FontBBox"): ArrayObject([FloatObject(n) for n in self.bbox]),
+            NameObject("/ItalicAngle"): FloatObject(self.italic_angle),
+            NameObject("/Ascent"): FloatObject(self.ascent),
+            NameObject("/Descent"): FloatObject(self.descent),
+            NameObject("/CapHeight"): FloatObject(self.cap_height),
+            NameObject("/XHeight"): FloatObject(self.x_height),
+        })
+
+        if self.font_file:
+            # Add the stream. For now, we assume a TrueType font (FontFile2)
+            font_descriptor_resource[NameObject("/FontFile2")] = self.font_file
+
+        return font_descriptor_resource
+
 
 @dataclass(frozen=True)
 class CoreFontMetrics:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -10,6 +10,7 @@ from pypdf.generic import (
     FloatObject,
     NameObject,
     NumberObject,
+    PdfObject,
     StreamObject,
     TextStringObject,
 )
@@ -532,45 +533,31 @@ class Font:
             interpretable=True
         )
 
-    def as_font_resource(self) -> DictionaryObject:
-        # If we have an embedded Truetype font, we assume that we need to produce a Type 2 CID font resource.
-        if self.font_descriptor.font_file and self.sub_type == "TrueType":
-            # Create the descendant font, using Identity mapping
-            cid_font = DictionaryObject({
-                NameObject("/Type"): NameObject("/Font"),
-                NameObject("/Subtype"): NameObject("/CIDFontType2"),
-                NameObject("/BaseFont"): NameObject(f"/{self.name}"),
-                NameObject("/CIDSystemInfo"): DictionaryObject({
-                    NameObject("/Registry"): TextStringObject("Adobe"),
-                    NameObject("/Ordering"): TextStringObject("Identity"),
-                    NameObject("/Supplement"): NumberObject(0)
-                }),
-                NameObject("/FontDescriptor"): self.font_descriptor.as_font_descriptor_resource()
-            })
-
-            # Build the widths (/W) array. This can have two formats:
-            # [first_cid [w1 w2 w3]] or [first last width]
-            # Here we choose the first format and simply provide one array with one width for every cid.
-            widths_list = []
-            unicode_map = []
-            # In the loop, char is the decoded GID string (the reverse unicode hack)
-            # and character_map[char] is the actual character.
-            for gid_str, actual_char in self.character_map.items():
+    def _create_widths_list_and_unicode_stream(self) -> tuple[list[PdfObject], StreamObject]:
+        widths_list = []
+        unicode_map = []
+        # In the loop, char is the decoded GID string (the reverse unicode hack)
+        # and character_map[char] is the actual character.
+        # The widths (/W) array can have two formats:
+        # [first_cid [w1 w2 w3]] or [first last width]
+        # Here we choose the first format and simply provide one array with one width for every cid.
+        for gid_str, actual_char in self.character_map.items():
+            uni_point = ord(actual_char)
+            # Only deal with Basic Multilingual Plane characters.
+            # TODO: Add all characters. However, this requires widths reworking first.
+            if uni_point <= 0xFFFF:
                 cid = ord(gid_str)
                 cid_hex = f"{cid:04X}"
-                uni_point = ord(actual_char)
                 uni_hex = f"{uni_point:04X}"
                 unicode_map.append(f"<{cid_hex}> <{uni_hex}>")
 
                 width = self.character_widths.get(gid_str, self.character_widths["default"])
                 widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
 
-            cid_font[NameObject("/W")] = ArrayObject(widths_list)
-            cid_font[NameObject("/DW")] = NumberObject(self.character_widths["default"])
-            cid_font[NameObject("/CIDToGIDMap")] = NameObject("/Identity")
-
-            # Create the /ToUnicode CMap Stream
-            cmap_body = (
+        # Create the /ToUnicode CMap Stream
+        to_unicode_stream = StreamObject()
+        to_unicode_stream.set_data(
+            (
                 "/CIDInit /ProcSet findresource begin\n"
                 "12 dict begin\n"
                 "begincmap\n"
@@ -584,12 +571,35 @@ class Font:
                 "endcmap\n"
                 "CMapName currentdict /CMap defineresource pop\n"
                 "end end"
-            )
+            ).encode("ascii")
+        )
 
-            to_unicode_stream = StreamObject()
-            to_unicode_stream.set_data(cmap_body.encode("ascii"))
+        return widths_list, to_unicode_stream
 
-            # Create the Type 0 font object)
+    def as_font_resource(self) -> DictionaryObject:
+        # If we have an embedded Truetype font, we assume that we need to produce a Type 2 CID font resource.
+        if self.font_descriptor.font_file and self.sub_type == "TrueType":
+            # Begin with creating the widths array (part of the descendant font) and the unicode cmap (part
+            # of the Type 0 font obect).
+            widths_list, to_unicode_stream = self._create_widths_list_and_unicode_stream()
+
+            # Create the descendant font object
+            cid_font = DictionaryObject({
+                NameObject("/Type"): NameObject("/Font"),
+                NameObject("/Subtype"): NameObject("/CIDFontType2"),
+                NameObject("/BaseFont"): NameObject(f"/{self.name}"),
+                NameObject("/CIDSystemInfo"): DictionaryObject({
+                    NameObject("/Registry"): TextStringObject("Adobe"),
+                    NameObject("/Ordering"): TextStringObject("Identity"),
+                    NameObject("/Supplement"): NumberObject(0)
+                }),
+                NameObject("/FontDescriptor"): self.font_descriptor.as_font_descriptor_resource(),
+                NameObject("/W"): ArrayObject(widths_list),
+                NameObject("/DW"): NumberObject(self.character_widths["default"]),
+                NameObject("/CIDToGIDMap"): NameObject("/Identity")
+            })
+
+            # Create the Type 0 font object
             return DictionaryObject({
                 NameObject("/Type"): NameObject("/Font"),
                 NameObject("/Subtype"): NameObject("/Type0"),

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -545,6 +545,7 @@ class Font:
                     NameObject("/Ordering"): TextStringObject("Identity"),
                     NameObject("/Supplement"): NumberObject(0)
                 }),
+                NameObject("/FontDescriptor"): self.font_descriptor.as_font_descriptor_resource()
             })
 
             # Build the widths (/W) array. This can have two formats:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -632,7 +632,6 @@ class Font:
         ensures that ToUnicode, FontDescriptor, FontFile, and, ultimately, the font
         resource itself, are registered with the PdfWriter instance as indirect objects.
         """
-
         font_resource = self.as_font_resource()
         if "/ToUnicode" in font_resource:
             font_resource[NameObject("/ToUnicode")] = writer._add_object(font_resource["/ToUnicode"])

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -542,7 +542,7 @@ class Font:
         # In the loop, char is the decoded GID string (the reverse unicode hack)
         # and character_map[char] is the actual character.
         # The widths (/W) array can have two formats:
-        # [first_cid [w1 w2 w3]] or [first last width]
+        #    [first_cid [w1 w2 w3]] or [first last width]
         # Here we choose the first format and simply provide one array with one width for every cid.
         for gid_str, actual_char in self.character_map.items():
             uni_point = ord(actual_char)
@@ -612,7 +612,7 @@ class Font:
                 NameObject("/ToUnicode"): to_unicode_stream,
             })
 
-        # Fallback: Return a font resource for the 14 Adobe Core fonts.
+        # Fallback: Return a font resource for one of the 14 Adobe Core fonts.
         return DictionaryObject({
             NameObject("/Type"): NameObject("/Font"),
             NameObject("/Subtype"): NameObject("/Type1"),
@@ -621,12 +621,18 @@ class Font:
             NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
         })
 
-    def add_to_writer(
+    def _add_to_writer(
         self,
         writer: PdfWriter,
         target_resource_dict: DictionaryObject,
         font_resource_name: NameObject
     ) -> IndirectObject:
+        """
+        Some objects in a font resource need to be indirect objects. This method
+        ensures that ToUnicode, FontDescriptor, FontFile, and, ultimately, the font
+        resource itself, are registered with the PdfWriter instance as indirect objects.
+        """
+
         font_resource = self.as_font_resource()
         if "/ToUnicode" in font_resource:
             font_resource[NameObject("/ToUnicode")] = writer._add_object(font_resource["/ToUnicode"])

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -918,22 +918,7 @@ class PdfWriter(PdfDocCommon):
             x_offset: The horizontal offset for the appearance stream.
             y_offset: The vertical offset for the appearance stream.
         """
-        # Prepare XObject resource dictionary on the page. This currently
-        # only deals with font resources, but can easily be adapted to also
-        # include other resources.
         pg_res = cast(DictionaryObject, page[PG.RESOURCES])
-        if "/Resources" in appearance_stream_obj:
-            ap_stream_res = cast(DictionaryObject, appearance_stream_obj["/Resources"])
-            ap_stream_font_dict = cast(DictionaryObject, ap_stream_res.get("/Font", DictionaryObject()))
-            if "/Font" not in pg_res:
-                font_dict_ref = self._add_object(DictionaryObject())
-                pg_res[NameObject("/Font")] = font_dict_ref
-            pg_font_res = cast(DictionaryObject, pg_res["/Font"].get_object())
-            # Merge fonts from the appearance stream into the page's font resources
-            for font_name, font_res in ap_stream_font_dict.items():
-                if font_name not in pg_font_res:
-                    font_res_ref = self._add_object(font_res)
-                    pg_font_res[font_name] = font_res_ref
         # Always add the resolved stream object to the writer to get a new IndirectObject.
         # This ensures we have a valid IndirectObject managed by *this* writer.
         xobject_ref = self._add_object(appearance_stream_obj)
@@ -952,6 +937,73 @@ class PdfWriter(PdfDocCommon):
         xobject_cm = Transformation().translate(x_offset, y_offset)
         xobject_drawing_commands = f"q\n{xobject_cm._to_cm()}\n{xobject_name} Do\nQ".encode()
         self._merge_content_stream_to_page(page, xobject_drawing_commands)
+
+    def _add_font_resource(
+            self,
+            target_resource_dict: DictionaryObject,
+            font_resource: DictionaryObject,
+            font_resource_name: NameObject
+        ) -> IndirectObject:
+        # See if we can add the font to the page font resources
+        if "/ToUnicode" in font_resource and not isinstance(font_resource.raw_get("/ToUnicode"), IndirectObject):
+                to_unicode_ref = self._add_object(font_resource["/ToUnicode"])
+                font_resource[NameObject("/ToUnicode")] = to_unicode_ref
+
+        if "/DescendantFonts" in font_resource:
+            descendant_fonts = cast(ArrayObject, font_resource["/DescendantFonts"])
+            font_resource_dict = cast(DictionaryObject, descendant_fonts[0])
+        else:
+            font_resource_dict = font_resource
+
+        if "/FontDescriptor" in font_resource_dict:
+            font_descriptor_obj = cast(DictionaryObject, font_resource_dict["/FontDescriptor"])
+            for key in ["/FontFile", "/FontFile2", "/FontFile3"]:
+                if key in font_descriptor_obj:
+                    font_file_ref = self._add_object(font_descriptor_obj[key])
+                    font_descriptor_obj[NameObject(key)] = font_file_ref
+            if not isinstance(
+                font_resource_dict.raw_get("/FontDescriptor"), IndirectObject
+            ):
+                font_resource_dict[NameObject("/FontDescriptor")] = self._add_object(
+                    font_resource_dict["/FontDescriptor"]
+                )
+        font_resource_ref = self._add_object(font_resource)
+        target_resource_dict[font_resource_name] = font_resource_ref
+        return font_resource_ref
+
+    def _sync_appearance_stream_font_resources(
+        self,
+        appearance_stream_obj: StreamObject,
+        target_resource_dict: DictionaryObject
+    ) -> None:
+        """
+        Unified helper to sync fonts from an AP stream to a target
+        resource dictionary (e.g., AcroForm /DR or Page /Resources).
+        """
+        appearance_stream_resources = cast(
+            DictionaryObject,
+            appearance_stream_obj.get("/Resources", DictionaryObject())
+        )
+        appearance_stream_font_resources = cast(
+            DictionaryObject,
+            appearance_stream_resources.get("/Font", DictionaryObject()).get_object()
+        )
+        # Assume that appearance_stream_font_resources is not empty. It shouldn't be, because this code is
+        # only reached when dealing with text field annotations, which by definition have an associated font.
+        target_fonts = target_resource_dict.setdefault(NameObject("/Font"), DictionaryObject().get_object())
+        for font_name, font_res in appearance_stream_font_resources.items():
+            if font_name not in target_fonts:
+                font_res_ref = self._add_font_resource(
+                    target_fonts,
+                    cast(DictionaryObject, font_res),
+                    font_name
+                )
+                appearance_stream_font_resources[font_name] = font_res_ref
+            else:
+                existing_font = target_fonts[font_name]
+                appearance_stream_font_resources[font_name] = getattr(
+                    existing_font, "indirect_reference", existing_font
+                )
 
     FFBITS_NUL = FA.FfBits(0)
 
@@ -1093,8 +1145,16 @@ class PdfWriter(PdfDocCommon):
                     annotation.get(FA.FT) == "/Sig"
                 ):  # deprecated  # not implemented yet
                     logger_warning("Signature forms not implemented yet", source=__name__)
-                if flatten and appearance_stream_obj is not None:
-                    self._add_apstream_object(page, appearance_stream_obj, field, rectangle[0], rectangle[1])
+
+                # Make font resources and font descriptors indirect objects
+                if appearance_stream_obj:
+                    if flatten:
+                        sync_target = cast(DictionaryObject, page[PG.RESOURCES])
+                    else:
+                        sync_target = acro_form.setdefault(NameObject("/DR"), DictionaryObject())
+                    self._sync_appearance_stream_font_resources(appearance_stream_obj, sync_target)
+                    if flatten:
+                        self._add_apstream_object(page, appearance_stream_obj, field, rectangle[0], rectangle[1])
 
     def reattach_fields(
         self, page: Optional[PageObject] = None

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -938,39 +938,6 @@ class PdfWriter(PdfDocCommon):
         xobject_drawing_commands = f"q\n{xobject_cm._to_cm()}\n{xobject_name} Do\nQ".encode()
         self._merge_content_stream_to_page(page, xobject_drawing_commands)
 
-    def _add_font_resource(
-            self,
-            target_resource_dict: DictionaryObject,
-            font_resource: DictionaryObject,
-            font_resource_name: NameObject
-        ) -> IndirectObject:
-        # See if we can add the font to the page font resources
-        if "/ToUnicode" in font_resource and not isinstance(font_resource.raw_get("/ToUnicode"), IndirectObject):
-                to_unicode_ref = self._add_object(font_resource["/ToUnicode"])
-                font_resource[NameObject("/ToUnicode")] = to_unicode_ref
-
-        if "/DescendantFonts" in font_resource:
-            descendant_fonts = cast(ArrayObject, font_resource["/DescendantFonts"])
-            font_resource_dict = cast(DictionaryObject, descendant_fonts[0])
-        else:
-            font_resource_dict = font_resource
-
-        if "/FontDescriptor" in font_resource_dict:
-            font_descriptor_obj = cast(DictionaryObject, font_resource_dict["/FontDescriptor"])
-            for key in ["/FontFile", "/FontFile2", "/FontFile3"]:
-                if key in font_descriptor_obj:
-                    font_file_ref = self._add_object(font_descriptor_obj[key])
-                    font_descriptor_obj[NameObject(key)] = font_file_ref
-            if not isinstance(
-                font_resource_dict.raw_get("/FontDescriptor"), IndirectObject
-            ):
-                font_resource_dict[NameObject("/FontDescriptor")] = self._add_object(
-                    font_resource_dict["/FontDescriptor"]
-                )
-        font_resource_ref = self._add_object(font_resource)
-        target_resource_dict[font_resource_name] = font_resource_ref
-        return font_resource_ref
-
     FFBITS_NUL = FA.FfBits(0)
 
     def update_page_form_field_values(

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -971,40 +971,6 @@ class PdfWriter(PdfDocCommon):
         target_resource_dict[font_resource_name] = font_resource_ref
         return font_resource_ref
 
-    def _sync_appearance_stream_font_resources(
-        self,
-        appearance_stream_obj: StreamObject,
-        target_resource_dict: DictionaryObject
-    ) -> None:
-        """
-        Unified helper to sync fonts from an AP stream to a target
-        resource dictionary (e.g., AcroForm /DR or Page /Resources).
-        """
-        appearance_stream_resources = cast(
-            DictionaryObject,
-            appearance_stream_obj.get("/Resources", DictionaryObject())
-        )
-        appearance_stream_font_resources = cast(
-            DictionaryObject,
-            appearance_stream_resources.get("/Font", DictionaryObject()).get_object()
-        )
-        # Assume that appearance_stream_font_resources is not empty. It shouldn't be, because this code is
-        # only reached when dealing with text field annotations, which by definition have an associated font.
-        target_fonts = target_resource_dict.setdefault(NameObject("/Font"), DictionaryObject().get_object())
-        for font_name, font_res in appearance_stream_font_resources.items():
-            if font_name not in target_fonts:
-                font_res_ref = self._add_font_resource(
-                    target_fonts,
-                    cast(DictionaryObject, font_res),
-                    font_name
-                )
-                appearance_stream_font_resources[font_name] = font_res_ref
-            else:
-                existing_font = target_fonts[font_name]
-                appearance_stream_font_resources[font_name] = getattr(
-                    existing_font, "indirect_reference", existing_font
-                )
-
     FFBITS_NUL = FA.FfBits(0)
 
     def update_page_form_field_values(
@@ -1122,11 +1088,11 @@ class PdfWriter(PdfDocCommon):
                     # Textbox; we need to generate the appearance stream object
                     if isinstance(value, tuple):
                         appearance_stream_obj = TextStreamAppearance.from_text_annotation(
-                            acro_form, parent_annotation, annotation, value[1], value[2]
+                            self, page, flatten, acro_form, parent_annotation, annotation, value[1], value[2]
                         )
                     else:
                         appearance_stream_obj = TextStreamAppearance.from_text_annotation(
-                            acro_form, parent_annotation, annotation
+                            self, page, flatten, acro_form, parent_annotation, annotation
                         )
                     # Add the appearance stream object
                     if AA.AP not in annotation:
@@ -1146,15 +1112,8 @@ class PdfWriter(PdfDocCommon):
                 ):  # deprecated  # not implemented yet
                     logger_warning("Signature forms not implemented yet", source=__name__)
 
-                # Make font resources and font descriptors indirect objects
-                if appearance_stream_obj:
-                    if flatten:
-                        sync_target = cast(DictionaryObject, page[PG.RESOURCES])
-                    else:
-                        sync_target = acro_form.setdefault(NameObject("/DR"), DictionaryObject())
-                    self._sync_appearance_stream_font_resources(appearance_stream_obj, sync_target)
-                    if flatten:
-                        self._add_apstream_object(page, appearance_stream_obj, field, rectangle[0], rectangle[1])
+                if appearance_stream_obj and flatten:
+                    self._add_apstream_object(page, appearance_stream_obj, field, rectangle[0], rectangle[1])
 
     def reattach_fields(
         self, page: Optional[PageObject] = None

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -6,9 +6,10 @@ from typing import Any, Optional, Union, cast
 
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
-from .._font import HAS_FONTTOOLS, Font
+from .._font import Font
 from .._utils import logger_warning
 from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes
+from ..errors import PdfReadError
 from ..generic import (
     DecodedStreamObject,
     DictionaryObject,
@@ -16,7 +17,7 @@ from ..generic import (
     NumberObject,
     RectangleObject,
 )
-from ..generic._base import ByteStringObject, TextStringObject, is_null_or_none
+from ..generic._base import ByteStringObject, TextStringObject
 
 DEFAULT_FONT_SIZE_IN_MULTILINE = 12
 
@@ -313,6 +314,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         layout: Optional[BaseStreamConfig] = None,
         text: str = "",
         selection: Optional[list[str]] = None,
+        font: Optional[Font] = None,
         font_resource: Optional[DictionaryObject] = None,
         font_name: str = "/Helv",
         font_size: float = 0.0,
@@ -333,7 +335,9 @@ class TextStreamAppearance(BaseStreamAppearance):
             layout: The basic layout parameters.
             text: The text to be rendered in the form field.
             selection: An optional list of strings that should be highlighted as selected.
-            font_resource: An optional variable that represents a PDF font dictionary.
+            font: A Font object. Falls back to Type 1 Helvetica if not given.
+            font_resource: An optional variable that represents a PDF font dictionary. Falls back
+                to Type 1 Helvetica if not given.
             font_name: The name of the font resource, e.g., "/Helv".
             font_size: The font size. If 0, it's auto-calculated.
             font_color: The font color string.
@@ -347,15 +351,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         """
         super().__init__(layout)
 
-        # If a font resource was added, get the font character map
-        if font_resource:
-            font = Font.from_font_resource(font_resource)
-        else:
-            logger_warning(
-                "Font dictionary for %(font_name)s not found; defaulting to Helvetica.",
-                source=__name__,
-                font_name=font_name,
-            )
+        if not font or not font_resource:
             font_name = "/Helv"
             core_font_metrics = CORE_FONT_METRICS["Helvetica"]
             font = Font(
@@ -367,42 +363,6 @@ class TextStreamAppearance(BaseStreamAppearance):
                 character_widths=core_font_metrics.character_widths
             )
             font_resource = font.as_font_resource()
-
-        # Check whether the font resource is able to encode the text value.
-        encodable = True
-        try:
-            if font.character_map:
-                supported_chars = set(font.character_map.values())
-                encodable = all(char in supported_chars for char in text)
-            elif isinstance(font.encoding, str):
-                text.encode(font.encoding, "surrogatepass")
-            else:
-                supported_chars = set(font.encoding.values())
-                encodable = all(char in supported_chars for char in text)
-            # We should add a final check against the character_map (CMap) of the font,
-            # but we don't appear to have PDF forms with such fonts, so we skip this for
-            # now.
-
-        except UnicodeEncodeError:
-            encodable = False
-
-        if not encodable and font.font_descriptor.font_file and HAS_FONTTOOLS and font.sub_type == "TrueType":
-            # If we have a font file, we can try to produce a new font resource with an encoding
-            # that does include the necessary characters.
-            font = font.from_truetype_font_file(BytesIO(font.font_descriptor.font_file.get_data()))
-            font_resource = font.as_font_resource()
-            font_name = f"/{font.name}"
-            supported_chars = set(font.character_map.values())
-            encodable = all(char in supported_chars for char in text)
-
-        if not encodable:
-            logger_warning(
-                "Text string '%(text)s' contains characters not supported by font encoding. "
-                "This may result in text corruption. "
-                "Consider calling writer.update_page_form_field_values with auto_regenerate=True.",
-                source=__name__,
-                text=text,
-            )
 
         font_glyph_byte_map: dict[str, bytes] = {}
         if isinstance(font.encoding, str):
@@ -442,8 +402,9 @@ class TextStreamAppearance(BaseStreamAppearance):
     def _find_annotation_font_resource(
             font_name: str,
             annotation: DictionaryObject,
-            acro_form: DictionaryObject
-        ) -> tuple[str, DictionaryObject]:
+            acro_form: DictionaryObject,
+            text: str
+        ) -> tuple[str, DictionaryObject, Font]:
         # Try to find a resource dictionary for the font by examining the annotation and, if that fails,
         # the AcroForm resources dictionary
         acro_form_resources: Any = cast(
@@ -455,11 +416,12 @@ class TextStreamAppearance(BaseStreamAppearance):
         )
         acro_form_font_resources = acro_form_resources.get("/Font", DictionaryObject())
         font_resource = acro_form_font_resources.get(font_name, None)
-
-        # Normally, we should have found a font resource by now. However, when a user has provided a specific
-        # font name, we may not have found the associated font resource among the AcroForm resources. Also, in
-        # case of the 14 Adobe Core fonts, we may be expected to construct a font resource ourselves.
-        if is_null_or_none(font_resource):
+        if font_resource:
+            font = Font.from_font_resource(font_resource)
+        else:
+            # Normally, we should have found a font resource by now. However, when a user has provided a specific
+            # font name, we may not have found the associated font resource among the AcroForm resources. Also, in
+            # case of the 14 Adobe Core fonts, we may be expected to construct a font resource ourselves.
             if font_name.removeprefix("/") not in CORE_FONT_METRICS:
                 # Default to Helvetica if we haven't found a font resource and cannot construct one ourselves.
                 logger_warning(
@@ -469,16 +431,41 @@ class TextStreamAppearance(BaseStreamAppearance):
                 )
                 font_name = "/Helvetica"
             core_font_metrics = CORE_FONT_METRICS[font_name.removeprefix("/")]
-            font_resource = Font(
+            font = Font(
                 name=font_name.removeprefix("/"),
                 character_map={},
                 encoding=dict(zip(range(256), fill_from_encoding("cp1252"))),  # WinAnsiEncoding
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
                 character_widths=core_font_metrics.character_widths
-            ).as_font_resource()
+            )
+            font_resource = font.as_font_resource()
 
-        return font_name, font_resource
+        # If we have found a font resource, it still might not be able to encode the text value we received
+        encodable = font.can_encode(text)
+
+        if not encodable:
+            # If we have a font file, we can try to produce a new font resource with an encoding
+            # that does include the necessary characters.
+            if font.font_descriptor.font_file and font.sub_type == "TrueType":
+                try:
+                    font = font.from_truetype_font_file(BytesIO(font.font_descriptor.font_file.get_data()))
+                    font_resource = font.as_font_resource()
+                    font_name = "/PYPDF1"  # This means we most probably do not clash with an existing font name
+                    encodable = font.can_encode(text)
+                except (ImportError, PdfReadError) as e:
+                    logger_warning("Unable to use embedded font for encoding: %(e)s", source=__name__, e=e)
+
+            if not encodable:
+                logger_warning(
+                    "Text string '%(text)s' contains characters not supported by font encoding. "
+                    "This may result in text corruption. "
+                    "Consider calling writer.update_page_form_field_values with auto_regenerate=True.",
+                    source=__name__,
+                    text=text,
+                )
+
+        return font_name, font_resource, font
 
     @classmethod
     def from_text_annotation(
@@ -562,7 +549,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         if user_font_size > 0:
             font_size = user_font_size
 
-        font_name, font_resource = cls._find_annotation_font_resource(font_name, annotation, acro_form)
+        font_name, font_resource, font = cls._find_annotation_font_resource(font_name, annotation, acro_form, text)
 
         # Retrieve formatting information
         is_comb = False
@@ -586,6 +573,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             layout,
             text,
             selection,
+            font,
             font_resource,
             font_name=font_name,
             font_size=font_size,

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -4,22 +4,28 @@ import re
 from dataclasses import dataclass
 from enum import IntEnum
 from io import BytesIO
-from typing import Any, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
 from .._font import Font
 from .._utils import logger_warning
-from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes
+from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes, PageAttributes
 from ..errors import PdfReadError
 from ..generic import (
     DecodedStreamObject,
     DictionaryObject,
+    IndirectObject,
     NameObject,
     NumberObject,
     RectangleObject,
 )
 from ..generic._base import ByteStringObject, TextStringObject
+
+if TYPE_CHECKING:
+    from pypdf._writer import PdfWriter
+
+    from .._page import PageObject
 
 DEFAULT_FONT_SIZE_IN_MULTILINE = 12
 
@@ -317,7 +323,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         text: str = "",
         selection: list[str] | None = None,
         font: Font | None = None,
-        font_resource: DictionaryObject | None = None,
+        font_resource: DictionaryObject | IndirectObject | None = None,
         font_name: str = "/Helv",
         font_size: float = 0.0,
         font_color: str = "0 g",
@@ -469,9 +475,33 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         return font_name, font_resource, font
 
+    @staticmethod
+    def _sync_appearance_stream_font_resources(
+        writer: PdfWriter,
+        font_name: str,
+        font_resource: DictionaryObject,
+        target_resource_dict: DictionaryObject
+    ) -> DictionaryObject | IndirectObject:
+        """
+        Unified helper to sync fonts from an AP stream to a target
+        resource dictionary (e.g., AcroForm /DR or Page /Resources).
+        """
+        target_fonts = target_resource_dict.setdefault(NameObject("/Font"), DictionaryObject()).get_object()
+        if font_name not in target_fonts:
+            return writer._add_font_resource(
+                target_fonts,
+                font_resource,
+                NameObject(font_name)
+            )
+
+        return cast(Union[DictionaryObject, IndirectObject], target_fonts[font_name])
+
     @classmethod
     def from_text_annotation(
         cls,
+        writer: PdfWriter,
+        page: PageObject,
+        flatten: bool,
         acro_form: DictionaryObject,  # _root_object[CatalogDictionary.ACRO_FORM])
         field: DictionaryObject,
         annotation: DictionaryObject,
@@ -487,6 +517,10 @@ class TextStreamAppearance(BaseStreamAppearance):
         It respects inheritance for properties like default appearance (`/DA`).
 
         Args:
+            writer: The PdfWriter instance that we are creating text stream appearances for.
+            page: The page that we are processing annotations for.
+            flatten: Whether we flatten text annotations or not. If true, add new font resource
+                to the page font resources. Otherwise, add them to the AcroForm resources.
             acro_form: The root AcroForm dictionary from the PDF catalog.
             field: The field dictionary object.
             annotation: The widget annotation dictionary object associated with the field.
@@ -553,6 +587,14 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         font_name, font_resource, font = cls._find_annotation_font_resource(font_name, annotation, acro_form, text)
 
+        # Synchronise font resources
+        if flatten:
+            sync_target = cast(DictionaryObject, page[PageAttributes.RESOURCES])
+        else:
+            sync_target = acro_form.setdefault(NameObject("/DR"), DictionaryObject())
+
+        font_resource_ref = cls._sync_appearance_stream_font_resources(writer, font_name, font_resource, sync_target)
+
         # Retrieve formatting information
         is_comb = False
         max_length = None
@@ -576,7 +618,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             text,
             selection,
             font,
-            font_resource,
+            font_resource_ref,
             font_name=font_name,
             font_size=font_size,
             font_color=font_color,
@@ -597,7 +639,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                     if "/Font" not in value:
                         value.get_object()[NameObject("/Font")] = DictionaryObject()
                     value["/Font"].get_object()[NameObject(font_name)] = getattr(
-                        font_resource, "indirect_reference", font_resource
+                        font_resource_ref, "indirect_reference", font_resource_ref
                     )
                 else:
                     new_appearance_stream[key] = value

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -412,7 +412,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             annotation: DictionaryObject,
             acro_form: DictionaryObject,
             text: str
-        ) -> tuple[str, DictionaryObject, Font]:
+        ) -> tuple[str, Font]:
         # Try to find a resource dictionary for the font by examining the annotation and, if that fails,
         # the AcroForm resources dictionary
         acro_form_resources: Any = cast(
@@ -447,7 +447,6 @@ class TextStreamAppearance(BaseStreamAppearance):
                 font_descriptor=core_font_metrics.font_descriptor,
                 character_widths=core_font_metrics.character_widths
             )
-            font_resource = font.as_font_resource()
 
         # If we have found a font resource, it still might not be able to encode the text value we received
         encodable = font.can_encode(text)
@@ -458,7 +457,6 @@ class TextStreamAppearance(BaseStreamAppearance):
             if font.font_descriptor.font_file and font.sub_type == "TrueType":
                 try:
                     font = font.from_truetype_font_file(BytesIO(font.font_descriptor.font_file.get_data()))
-                    font_resource = font.as_font_resource()
                     font_name = "/PYPDF1"  # This means we most probably do not clash with an existing font name
                     encodable = font.can_encode(text)
                 except (ImportError, PdfReadError) as e:
@@ -473,13 +471,13 @@ class TextStreamAppearance(BaseStreamAppearance):
                     text=text,
                 )
 
-        return font_name, font_resource, font
+        return font_name, font
 
     @staticmethod
     def _sync_appearance_stream_font_resources(
         writer: PdfWriter,
         font_name: str,
-        font_resource: DictionaryObject,
+        font: Font,
         target_resource_dict: DictionaryObject
     ) -> DictionaryObject | IndirectObject:
         """
@@ -488,9 +486,9 @@ class TextStreamAppearance(BaseStreamAppearance):
         """
         target_fonts = target_resource_dict.setdefault(NameObject("/Font"), DictionaryObject()).get_object()
         if font_name not in target_fonts:
-            return writer._add_font_resource(
+            return font.add_to_writer(
+                writer,
                 target_fonts,
-                font_resource,
                 NameObject(font_name)
             )
 
@@ -585,7 +583,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         if user_font_size > 0:
             font_size = user_font_size
 
-        font_name, font_resource, font = cls._find_annotation_font_resource(font_name, annotation, acro_form, text)
+        font_name, font = cls._find_annotation_font_resource(font_name, annotation, acro_form, text)
 
         # Synchronise font resources
         if flatten:
@@ -593,7 +591,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         else:
             sync_target = acro_form.setdefault(NameObject("/DR"), DictionaryObject())
 
-        font_resource_ref = cls._sync_appearance_stream_font_resources(writer, font_name, font_resource, sync_target)
+        font_resource_ref = cls._sync_appearance_stream_font_resources(writer, font_name, font, sync_target)
 
         # Retrieve formatting information
         is_comb = False

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
 from enum import IntEnum
 from io import BytesIO
-from typing import Any, Optional, Union, cast
+from typing import Any, Union, cast
 
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
@@ -25,7 +27,7 @@ DEFAULT_FONT_SIZE_IN_MULTILINE = 12
 @dataclass
 class BaseStreamConfig:
     """A container representing the basic layout of an appearance stream."""
-    rectangle: Union[RectangleObject, tuple[float, float, float, float]] = (0.0, 0.0, 0.0, 0.0)
+    rectangle: RectangleObject | tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
     border_width: int = 1  # The width of the border in points
     border_style: str = BorderStyles.SOLID
 
@@ -33,7 +35,7 @@ class BaseStreamConfig:
 class BaseStreamAppearance(DecodedStreamObject):
     """A class representing the very base of an appearance stream, that is, a rectangle and a border."""
 
-    def __init__(self, layout: Optional[BaseStreamConfig] = None) -> None:
+    def __init__(self, layout: BaseStreamConfig | None) -> None:
         """
         Takes the appearance stream layout as an argument.
 
@@ -145,16 +147,16 @@ class TextStreamAppearance(BaseStreamAppearance):
     def _generate_appearance_stream_data(
         self,
         text: str,
-        selection: Union[list[str], None],
+        selection: list[str] | None ,
         font: Font,
-        font_glyph_byte_map: Optional[dict[str, bytes]] = None,
+        font_glyph_byte_map: dict[str, bytes] | None = None,
         font_name: str = "/Helv",
         font_size: float = 0.0,
         font_color: str = "0 g",
         is_multiline: bool = False,
         alignment: TextAlignment = TextAlignment.LEFT,
         is_comb: bool = False,
-        max_length: Optional[int] = None
+        max_length: int | None = None
     ) -> bytes:
         """
         Generates the raw bytes of the PDF appearance stream for a text field.
@@ -311,18 +313,18 @@ class TextStreamAppearance(BaseStreamAppearance):
 
     def __init__(
         self,
-        layout: Optional[BaseStreamConfig] = None,
+        layout: BaseStreamConfig | None = None,
         text: str = "",
-        selection: Optional[list[str]] = None,
-        font: Optional[Font] = None,
-        font_resource: Optional[DictionaryObject] = None,
+        selection: list[str] | None = None,
+        font: Font | None = None,
+        font_resource: DictionaryObject | None = None,
         font_name: str = "/Helv",
         font_size: float = 0.0,
         font_color: str = "0 g",
         is_multiline: bool = False,
         alignment: TextAlignment = TextAlignment.LEFT,
         is_comb: bool = False,
-        max_length: Optional[int] = None
+        max_length: int | None = None
     ) -> None:
         """
         Initializes a TextStreamAppearance object.
@@ -475,7 +477,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         annotation: DictionaryObject,
         user_font_name: str = "",
         user_font_size: float = -1,
-    ) -> "TextStreamAppearance":
+    ) -> TextStreamAppearance:
         """
         Creates a TextStreamAppearance object from a text field annotation.
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -1,11 +1,12 @@
 import re
 from dataclasses import dataclass
 from enum import IntEnum
+from io import BytesIO
 from typing import Any, Optional, Union, cast
 
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
-from .._font import Font
+from .._font import HAS_FONTTOOLS, Font
 from .._utils import logger_warning
 from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes
 from ..generic import (
@@ -370,18 +371,29 @@ class TextStreamAppearance(BaseStreamAppearance):
         # Check whether the font resource is able to encode the text value.
         encodable = True
         try:
-            if isinstance(font.encoding, str):
+            if font.character_map:
+                supported_chars = set(font.character_map.values())
+                encodable = all(char in supported_chars for char in text)
+            elif isinstance(font.encoding, str):
                 text.encode(font.encoding, "surrogatepass")
             else:
                 supported_chars = set(font.encoding.values())
-                if any(char not in supported_chars for char in text):
-                    encodable = False
+                encodable = all(char in supported_chars for char in text)
             # We should add a final check against the character_map (CMap) of the font,
             # but we don't appear to have PDF forms with such fonts, so we skip this for
             # now.
 
         except UnicodeEncodeError:
             encodable = False
+
+        if not encodable and font.font_descriptor.font_file and HAS_FONTTOOLS and font.sub_type == "TrueType":
+            # If we have a font file, we can try to produce a new font resource with an encoding
+            # that does include the necessary characters.
+            font = font.from_truetype_font_file(BytesIO(font.font_descriptor.font_file.get_data()))
+            font_resource = font.as_font_resource()
+            font_name = f"/{font.name}"
+            supported_chars = set(font.character_map.values())
+            encodable = all(char in supported_chars for char in text)
 
         if not encodable:
             logger_warning(

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -448,7 +448,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                 character_widths=core_font_metrics.character_widths
             )
 
-        # If we have found a font resource, it still might not be able to encode the text value we received
+        # If we have found a font resource, it still might not be able to encode the text value we received.
         encodable = font.can_encode(text)
 
         if not encodable:
@@ -464,9 +464,11 @@ class TextStreamAppearance(BaseStreamAppearance):
 
             if not encodable:
                 logger_warning(
-                    "Text string '%(text)s' contains characters not supported by font encoding. "
-                    "This may result in text corruption. "
-                    "Consider calling writer.update_page_form_field_values with auto_regenerate=True.",
+                    (
+                        "Text string '%(text)s' contains characters not supported by font encoding. "
+                        "This may result in text corruption. "
+                        "Consider calling writer.update_page_form_field_values with auto_regenerate=True."
+                    ),
                     source=__name__,
                     text=text,
                 )
@@ -486,7 +488,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         """
         target_fonts = target_resource_dict.setdefault(NameObject("/Font"), DictionaryObject()).get_object()
         if font_name not in target_fonts:
-            return font.add_to_writer(
+            return font._add_to_writer(
                 writer,
                 target_fonts,
                 NameObject(font_name)
@@ -591,7 +593,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         else:
             sync_target = acro_form.setdefault(NameObject("/DR"), DictionaryObject())
 
-        font_resource_ref = cls._sync_appearance_stream_font_resources(writer, font_name, font, sync_target)
+        font_resource_reference = cls._sync_appearance_stream_font_resources(writer, font_name, font, sync_target)
 
         # Retrieve formatting information
         is_comb = False
@@ -616,7 +618,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             text,
             selection,
             font,
-            font_resource_ref,
+            font_resource_reference,
             font_name=font_name,
             font_size=font_size,
             font_color=font_color,
@@ -637,7 +639,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                     if "/Font" not in value:
                         value.get_object()[NameObject("/Font")] = DictionaryObject()
                     value["/Font"].get_object()[NameObject(font_name)] = getattr(
-                        font_resource_ref, "indirect_reference", font_resource_ref
+                        font_resource_reference, "indirect_reference", font_resource_reference
                     )
                 else:
                     new_appearance_stream[key] = value

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -404,11 +404,11 @@ class TextStreamAppearance(BaseStreamAppearance):
                 text=text,
             )
 
-        font_glyph_byte_map: dict[str, bytes]
+        font_glyph_byte_map: dict[str, bytes] = {}
         if isinstance(font.encoding, str):
-            font_glyph_byte_map = {
-                v: k.encode(font.encoding) for k, v in font.character_map.items()
-            }
+            font.character_map.pop(-1, None)  # Remove -1 key that does not map a character
+            for k, v in font.character_map.items():
+                font_glyph_byte_map[v] = k.encode(font.encoding)
         else:
             font_glyph_byte_map = {v: bytes((k,)) for k, v in font.encoding.items()}
             font_encoding_rev = {v: bytes((k,)) for k, v in font.encoding.items()}

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -39,6 +39,18 @@ def test_font_descriptor():
     assert my_font.font_descriptor.italic_angle == 0
     assert my_font.font_descriptor.flags == 33
     assert my_font.font_descriptor.bbox == (-113.0, -250.0, 749.0, 801.0)
+    font_descriptor_resource = my_font.font_descriptor.as_font_descriptor_resource()
+    assert font_descriptor_resource == {
+        "/Type": "/FontDescriptor",
+        "/FontName": "/Courier-Bold",
+        "/Flags": 33,
+        "/FontBBox": [-113, -250, 749, 801],
+        "/ItalicAngle": 0.0,
+        "/Ascent": 629,
+        "/Descent": -157,
+        "/CapHeight": 562,
+        "/XHeight": 439
+    }
 
 
 def test_font_file():

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,7 +1,4 @@
 """Test font-related functionality."""
-import os
-import subprocess
-import sys
 from io import BytesIO
 
 import pytest
@@ -107,36 +104,3 @@ def test_font_from_font_file():
                 tt_font_object.save(crippled_font_data)
                 with pytest.raises(PdfReadError, match=r"Font file does not have a cmap table"):
                     Font.from_truetype_font_file(crippled_font_data)
-
-
-def test_font_from_font_file_no_fonttools(tmp_path):
-    env = os.environ.copy()
-    env["COVERAGE_PROCESS_START"] = "pyproject.toml"
-
-    source_file = tmp_path / "script.py"
-    source_file.write_text(
-        """
-import sys
-from io import BytesIO
-
-import pytest
-
-sys.modules["fontTools.ttLib"] = None
-from pypdf._font import Font
-
-with pytest.raises(ImportError, match=r"^The 'fontTools' library is required to use 'from_truetype_font_file'$"):
-    Font.from_truetype_font_file(BytesIO(b""))
-"""
-    )
-
-    try:
-        env["PYTHONPATH"] = "." + os.pathsep + env["PYTHONPATH"]
-    except KeyError:
-        env["PYTHONPATH"] = "."
-    result = subprocess.run(  # noqa: S603
-        [sys.executable, source_file],
-        capture_output=True,
-        env=env,
-    )
-    assert result.returncode == 0
-    assert result.stdout == b""

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,4 +1,7 @@
 """Test font-related functionality."""
+import os
+import subprocess
+import sys
 from io import BytesIO
 
 import pytest
@@ -104,3 +107,36 @@ def test_font_from_font_file():
                 tt_font_object.save(crippled_font_data)
                 with pytest.raises(PdfReadError, match=r"Font file does not have a cmap table"):
                     Font.from_truetype_font_file(crippled_font_data)
+
+
+def test_font_from_font_file_no_fonttools(tmp_path):
+    env = os.environ.copy()
+    env["COVERAGE_PROCESS_START"] = "pyproject.toml"
+
+    source_file = tmp_path / "script.py"
+    source_file.write_text(
+        """
+import sys
+from io import BytesIO
+
+import pytest
+
+sys.modules["fontTools.ttLib"] = None
+from pypdf._font import Font
+
+with pytest.raises(ImportError, match=r"^The 'fontTools' library is required to use 'from_truetype_font_file'$"):
+    Font.from_truetype_font_file(BytesIO(b""))
+"""
+    )
+
+    try:
+        env["PYTHONPATH"] = "." + os.pathsep + env["PYTHONPATH"]
+    except KeyError:
+        env["PYTHONPATH"] = "."
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, source_file],
+        capture_output=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert result.stdout == b""

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1841,6 +1841,8 @@ def test_update_form_fields3(caplog, tmp_path):
     with mock.patch("pypdf._font.HAS_FONTTOOLS", False):
         writer.update_page_form_field_values(writer.pages[0], {"subsemnatul": "Σ"})
         assert "Unable to use embedded font for encoding" in caplog.text
+        # Also test that an ImportError is raised by the Font class
+        assert "The 'fontTools' library is required to use 'from_truetype_font_file'" in caplog.text
 
 
 @pytest.mark.enable_socket

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,10 +1,8 @@
 """Test the pypdf._writer module."""
 
-import os
 import re
 import shutil
 import subprocess
-import sys
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -40,7 +38,7 @@ from pypdf.generic import (
     TextStringObject,
 )
 
-from . import RESOURCE_ROOT, SAMPLE_ROOT, TESTS_ROOT, get_data_from_url, is_sublist
+from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url, is_sublist
 from .test_images import image_similarity
 
 GHOSTSCRIPT_BINARY = shutil.which("gs")
@@ -1829,7 +1827,7 @@ def test_update_form_fields3(caplog, tmp_path):
         "strada": "Căpitan Nicolae Licăreț",
         "adresa_judet": "Конференция",
     }
-    writer.update_page_form_field_values(writer.pages[0], data, auto_regenerate=False, flatten=True)
+    writer.update_page_form_field_values(writer.pages[0], data, flatten=True)
     writer.write(output)
     output.seek(0)
     reader = PdfReader(output)
@@ -1840,41 +1838,9 @@ def test_update_form_fields3(caplog, tmp_path):
     assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
 
     # Also test for the case where fonttools is missing.
-    env = os.environ.copy()
-    env["COVERAGE_PROCESS_START"] = "pyproject.toml"
-    # We should have just downloaded the issue-file, so we can link to that.
-    file_path: Path = TESTS_ROOT / "pdf_cache" / name
-    source_file = tmp_path / "script.py"
-    source_file.write_text(
-        """
-import sys
-
-import pytest
-
-sys.modules["fontTools.ttLib"] = None
-from pypdf._font import Font
-from pypdf._writer import PdfWriter
-
-writer = PdfWriter()
-writer.append(sys.argv[1])
-data = {"subsemnatul": "Σ"}
-writer.update_page_form_field_values(writer.pages[0], data, auto_regenerate=False, flatten=True)
-
-""",
-        encoding="utf-8"
-    )
-
-    try:
-        env["PYTHONPATH"] = "." + os.pathsep + env["PYTHONPATH"]
-    except KeyError:
-        env["PYTHONPATH"] = "."
-    result = subprocess.run(  # noqa: S603
-        [sys.executable, source_file, str(file_path)],
-        capture_output=True,
-        env=env,
-    )
-    assert result.returncode == 0
-    assert b"Unable to use embedded font for encoding" in result.stderr
+    with mock.patch("pypdf._font.HAS_FONTTOOLS", False):
+        writer.update_page_form_field_values(writer.pages[0], {"subsemnatul": "Σ"})
+        assert "Unable to use embedded font for encoding" in caplog.text
 
 
 @pytest.mark.enable_socket

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1821,6 +1821,14 @@ def test_update_form_fields3(caplog, tmp_path):
     writer = PdfWriter()
     output = BytesIO()
     writer.append(BytesIO(get_data_from_url(url=url, name=name)))
+    # First test for the case where fonttools is missing.
+    with mock.patch("pypdf._font.HAS_FONTTOOLS", False):
+        writer.update_page_form_field_values(writer.pages[0], {"subsemnatul": "Σ"})
+        assert "Unable to use embedded font for encoding" in caplog.text
+        # Also test that an ImportError is raised by the Font class
+        assert "The 'fontTools' library is required to use 'from_truetype_font_file'" in caplog.text
+
+    # Test with fonttools
     data = {
         "subsemnatul": "Σὲ γνωρίζω ἀπὸ τὴν κόψη",
         "localitatea": "شهرزاد",
@@ -1836,13 +1844,6 @@ def test_update_form_fields3(caplog, tmp_path):
         if expected_value != "شهرزاد":
             assert expected_value in extracted_text
     assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
-
-    # Also test for the case where fonttools is missing.
-    with mock.patch("pypdf._font.HAS_FONTTOOLS", False):
-        writer.update_page_form_field_values(writer.pages[0], {"subsemnatul": "Σ"})
-        assert "Unable to use embedded font for encoding" in caplog.text
-        # Also test that an ImportError is raised by the Font class
-        assert "The 'fontTools' library is required to use 'from_truetype_font_file'" in caplog.text
 
 
 @pytest.mark.enable_socket

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,8 +1,10 @@
 """Test the pypdf._writer module."""
 
+import os
 import re
 import shutil
 import subprocess
+import sys
 from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -38,7 +40,7 @@ from pypdf.generic import (
     TextStringObject,
 )
 
-from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url, is_sublist
+from . import RESOURCE_ROOT, SAMPLE_ROOT, TESTS_ROOT, get_data_from_url, is_sublist
 from .test_images import image_similarity
 
 GHOSTSCRIPT_BINARY = shutil.which("gs")
@@ -1812,6 +1814,67 @@ def test_update_form_fields2(caplog):
         "test2.p3 YY": "21",
     }
     assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
+
+
+@pytest.mark.enable_socket
+def test_update_form_fields3(caplog, tmp_path):
+    url = "https://github.com/user-attachments/files/21073581/CERERE.INMATRICULARE.form.pdf"
+    name = "iss3361.pdf"
+    writer = PdfWriter()
+    output = BytesIO()
+    writer.append(BytesIO(get_data_from_url(url=url, name=name)))
+    data = {
+        "subsemnatul": "Σὲ γνωρίζω ἀπὸ τὴν κόψη",
+        "localitatea": "شهرزاد",
+        "strada": "Căpitan Nicolae Licăreț",
+        "adresa_judet": "Конференция",
+    }
+    writer.update_page_form_field_values(writer.pages[0], data, auto_regenerate=False, flatten=True)
+    writer.write(output)
+    output.seek(0)
+    reader = PdfReader(output)
+    extracted_text = reader.pages[0].extract_text()
+    for expected_value in data.values():
+        if expected_value != "شهرزاد":
+            assert expected_value in extracted_text
+    assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
+
+    # Also test for the case where fonttools is missing.
+    env = os.environ.copy()
+    env["COVERAGE_PROCESS_START"] = "pyproject.toml"
+    # We should have just downloaded the issue-file, so we can link to that.
+    file_path: Path = TESTS_ROOT / "pdf_cache" / name
+    source_file = tmp_path / "script.py"
+    source_file.write_text(
+        """
+import sys
+
+import pytest
+
+sys.modules["fontTools.ttLib"] = None
+from pypdf._font import Font
+from pypdf._writer import PdfWriter
+
+writer = PdfWriter()
+writer.append(sys.argv[1])
+data = {"subsemnatul": "Σ"}
+writer.update_page_form_field_values(writer.pages[0], data, auto_regenerate=False, flatten=True)
+
+""",
+        encoding="utf-8"
+    )
+
+    try:
+        env["PYTHONPATH"] = "." + os.pathsep + env["PYTHONPATH"]
+    except KeyError:
+        env["PYTHONPATH"] = "."
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, source_file, str(file_path)],
+        capture_output=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert b"Unable to use embedded font for encoding" in result.stderr
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
This PR adds a new method to _font.py, `from_truetype_font_file`, which initialises a Font instance from an embedded font file. I'm assuming that this might also work with a real file. Furthermore, it adds a lot of information to as_font_resource, to enable producing a CID TrueType font resource that enables encoding more characters than a TrueType font resource.

This fixes https://github.com/py-pdf/pypdf/issues/3361.

Contributes to fixing https://github.com/py-pdf/pypdf/issues/3514.

Might be related to https://github.com/py-pdf/pypdf/issues/3318. EDIT, it is not.

Includes all work from https://github.com/py-pdf/pypdf/pull/3602.

EDIT.

How it works:
We detect if a text value for a text widget annotation can be encoded using an existing font resource. If not, and we have an embedded TrueType font, we assume that we are expected to create a new font resource. We use the embedded font file to initialise a new Font instance, and then produce a new font resource from this instance. After having done so, we make the associated font descriptor an indirect object later on, as per the PDF specification.

Some notes:
I think that the more elegant way would be produce a short embedded font resource with only the characters in the text value. Also, it should have been possible to reuse the original font descriptor, but I can't seem to make that work.

