### PR TITLE
SEC: Prevent infinite loop from circular xref /Prev references

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -871,7 +871,16 @@ class PdfReader(PdfDocCommon):
         self.xref_free_entry = {}
         self.xref_objStm = {}
         self.trailer = DictionaryObject()
+        visited_xref_offsets: set[int] = set()
         while startxref is not None:
+            # Detect circular /Prev references in the xref chain
+            if startxref in visited_xref_offsets:
+                logger_warning(
+                    f"Circular xref chain detected at offset {startxref}, stopping",
+                    __name__,
+                )
+                break
+            visited_xref_offsets.add(startxref)
             # load the xref table
             stream.seek(startxref, 0)
             x = stream.read(1)


### PR DESCRIPTION
## Summary

Fixes #3654

A crafted PDF with circular `/Prev` references in its cross-reference table causes `_read_xref_tables_and_trailers()` to loop indefinitely, hanging the process. This is a denial-of-service vulnerability (CWE-835) for any application that parses untrusted PDFs.

## Root Cause

In `_reader.py`, the `while startxref is not None` loop at line ~874 follows `/Prev` pointers to walk the xref chain but has no guard against circular references. If `/Prev` points back to an already-visited offset, the loop never terminates.

## Fix

Added a `visited_xref_offsets` set that tracks every xref offset before processing. If a previously-seen offset is encountered, the loop logs a warning and breaks — consistent with the existing circular-reference guard pattern used elsewhere in pypdf (e.g., outlines traversal after CVE-2026-24688).

## Security Note

This is the same vulnerability class as CVE-2026-24688 and GHSA-hm9v-vj3r-r55m. A GitHub Security Advisory / CVE assignment may be appropriate.

## Test

Discovered in production processing LCSC datasheets. The affected PDF triggers "Overwriting cache for X Y" log spam in an infinite loop during xref parsing.