### PR TITLE
DEV: Update cache key handling in CI

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -30,6 +30,7 @@ jobs:
     - name: Cache Downloaded Files
       id: cache-downloaded-files-windows
       uses: actions/cache@v5
+      if: github.ref == 'refs/heads/main'
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-${{ github.run_id }}
@@ -79,6 +80,7 @@ jobs:
     - name: Cache Downloaded Files
       id: cache-downloaded-files-mac
       uses: actions/cache@v5
+      if: github.ref == 'refs/heads/main'
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-${{ github.run_id }}
@@ -144,6 +146,7 @@ jobs:
     - name: Cache Downloaded Files
       id: cache-downloaded-files
       uses: actions/cache@v5
+      if: github.ref == 'refs/heads/main'
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-${{ github.run_id }}

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -32,9 +32,17 @@ jobs:
       uses: actions/cache@v5
       with:
         path: '**/tests/pdf_cache/*'
-        key: cache-downloaded-files-${{ github.run_id }}
-        restore-keys:
-          cache-downloaded-files
+        key: cache-downloaded-files-main-${{ github.run_id }}
+        restore-keys: |
+          cache-downloaded-files-main-
+        enableCrossOsArchive: true
+    - name: Restore Downloaded Files
+      uses: actions/cache/restore@v5
+      if: github.ref != 'refs/heads/main'
+      with:
+        path: '**/tests/pdf_cache/*'
+        key: cache-downloaded-files-main-
+        restore-keys: cache-downloaded-files-main-
         enableCrossOsArchive: true
     - name: Setup Python
       uses: actions/setup-python@v6
@@ -73,9 +81,16 @@ jobs:
       uses: actions/cache@v5
       with:
         path: '**/tests/pdf_cache/*'
-        key: cache-downloaded-files-${{ github.run_id }}
-        restore-keys:
-          cache-downloaded-files
+        key: cache-downloaded-files-main-${{ github.run_id }}
+        restore-keys: |
+          cache-downloaded-files-main-
+    - name: Restore Downloaded Files
+      uses: actions/cache/restore@v5
+      if: github.ref != 'refs/heads/main'
+      with:
+        path: '**/tests/pdf_cache/*'
+        key: cache-downloaded-files-main-
+        restore-keys: cache-downloaded-files-main-
     - name: Setup Python (3.11+)
       uses: actions/setup-python@v6
       with:
@@ -131,9 +146,16 @@ jobs:
       uses: actions/cache@v5
       with:
         path: '**/tests/pdf_cache/*'
-        key: cache-downloaded-files-${{ github.run_id }}
-        restore-keys:
-          cache-downloaded-files
+        key: cache-downloaded-files-main-${{ github.run_id }}
+        restore-keys: |
+          cache-downloaded-files-main-
+    - name: Restore Downloaded Files
+      uses: actions/cache/restore@v5
+      if: github.ref != 'refs/heads/main'
+      with:
+        path: '**/tests/pdf_cache/*'
+        key: cache-downloaded-files-main-
+        restore-keys: cache-downloaded-files-main-
     - name: Setup Python
       uses: actions/setup-python@v6
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'

--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -36,6 +36,7 @@ jobs:
         key: cache-downloaded-files-main-${{ github.run_id }}
         restore-keys: |
           cache-downloaded-files-main-
+          cache-downloaded-files
         enableCrossOsArchive: true
     - name: Restore Downloaded Files
       uses: actions/cache/restore@v5
@@ -43,7 +44,9 @@ jobs:
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-
-        restore-keys: cache-downloaded-files-main-
+        restore-keys: |
+          cache-downloaded-files-main-
+          cache-downloaded-files
         enableCrossOsArchive: true
     - name: Setup Python
       uses: actions/setup-python@v6
@@ -86,13 +89,16 @@ jobs:
         key: cache-downloaded-files-main-${{ github.run_id }}
         restore-keys: |
           cache-downloaded-files-main-
+          cache-downloaded-files
     - name: Restore Downloaded Files
       uses: actions/cache/restore@v5
       if: github.ref != 'refs/heads/main'
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-
-        restore-keys: cache-downloaded-files-main-
+        restore-keys: |
+          cache-downloaded-files-main-
+          cache-downloaded-files
     - name: Setup Python (3.11+)
       uses: actions/setup-python@v6
       with:
@@ -152,13 +158,16 @@ jobs:
         key: cache-downloaded-files-main-${{ github.run_id }}
         restore-keys: |
           cache-downloaded-files-main-
+          cache-downloaded-files
     - name: Restore Downloaded Files
       uses: actions/cache/restore@v5
       if: github.ref != 'refs/heads/main'
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-
-        restore-keys: cache-downloaded-files-main-
+        restore-keys: |
+          cache-downloaded-files-main-
+          cache-downloaded-files
     - name: Setup Python
       uses: actions/setup-python@v6
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'


### PR DESCRIPTION
* Do not write cache on PRs.
* Use a more dynamic cache instead of the outdated fixed `cache-downloaded-files`.