### PR TITLE
ENH: Expose /Perms verification result on Encryption object

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -272,21 +272,28 @@ class PdfDocCommon:
 
     @property
     @abstractmethod
-    def root_object(self) -> DictionaryObject: ...  # pragma: no cover
+    def root_object(self) -> DictionaryObject:
+        ...  # pragma: no cover
 
     @property
     @abstractmethod
-    def pdf_header(self) -> str: ...  # pragma: no cover
+    def pdf_header(self) -> str:
+        ...  # pragma: no cover
 
     @abstractmethod
-    def get_object(self, indirect_reference: Union[int, IndirectObject]) -> Optional[PdfObject]: ...  # pragma: no cover
+    def get_object(
+        self, indirect_reference: Union[int, IndirectObject]
+    ) -> Optional[PdfObject]:
+        ...  # pragma: no cover
 
     @abstractmethod
-    def _replace_object(self, indirect: IndirectObject, obj: PdfObject) -> PdfObject: ...  # pragma: no cover
+    def _replace_object(self, indirect: IndirectObject, obj: PdfObject) -> PdfObject:
+        ...  # pragma: no cover
 
     @property
     @abstractmethod
-    def _info(self) -> Optional[DictionaryObject]: ...  # pragma: no cover
+    def _info(self) -> Optional[DictionaryObject]:
+        ...  # pragma: no cover
 
     @property
     def metadata(self) -> Optional[DocumentInformation]:
@@ -304,7 +311,8 @@ class PdfDocCommon:
         return retval
 
     @property
-    def xmp_metadata(self) -> Optional[XmpInformation]: ...  # pragma: no cover
+    def xmp_metadata(self) -> Optional[XmpInformation]:
+        ...  # pragma: no cover
 
     @property
     def viewer_preferences(self) -> Optional[ViewerPreferences]:
@@ -370,7 +378,9 @@ class PdfDocCommon:
         """
         top = cast(DictionaryObject, self.root_object["/Pages"])
 
-        def recursive_call(node: DictionaryObject, mi: int) -> tuple[Optional[PdfObject], int]:
+        def recursive_call(
+            node: DictionaryObject, mi: int
+        ) -> tuple[Optional[PdfObject], int]:
             ma = cast(int, node.get("/Count", 1))  # default 1 for /Page types
             if node["/Type"] == "/Page":
                 if page_number == mi:
@@ -402,7 +412,9 @@ class PdfDocCommon:
 
     def get_named_dest_root(self) -> ArrayObject:
         named_dest = ArrayObject()
-        if CA.NAMES in self.root_object and isinstance(self.root_object[CA.NAMES], DictionaryObject):
+        if CA.NAMES in self.root_object and isinstance(
+            self.root_object[CA.NAMES], DictionaryObject
+        ):
             names = cast(DictionaryObject, self.root_object[CA.NAMES])
             if CA.DESTS in names and isinstance(names[CA.DESTS], DictionaryObject):
                 # §3.6.3 Name Dictionary (PDF spec 1.7)
@@ -563,7 +575,9 @@ class PdfDocCommon:
             return cast(str, parent["/TM"])
         if "/Parent" in parent:
             return (
-                self._get_qualified_field_name(cast(DictionaryObject, parent["/Parent"]))
+                self._get_qualified_field_name(
+                    cast(DictionaryObject, parent["/Parent"])
+                )
                 + "."
                 + cast(str, parent.get("/T", ""))
             )
@@ -589,7 +603,9 @@ class PdfDocCommon:
             retval[key][NameObject("/_States_")] = obj[NameObject(FA.Opt)]
         if obj.get(FA.FT, "") == "/Btn" and "/AP" in obj:
             #  Checkbox
-            retval[key][NameObject("/_States_")] = ArrayObject(list(obj["/AP"]["/N"].keys()))
+            retval[key][NameObject("/_States_")] = ArrayObject(
+                list(obj["/AP"]["/N"].keys())
+            )
             if "/Off" not in retval[key]["/_States_"]:
                 retval[key][NameObject("/_States_")].append(NameObject("/Off"))
         elif obj.get(FA.FT, "") == "/Btn" and obj.get(FA.Ff, 0) & FA.FfBits.Radio != 0:
@@ -601,7 +617,10 @@ class PdfDocCommon:
                     if s not in states:
                         states.append(s)
                 retval[key][NameObject("/_States_")] = ArrayObject(states)
-            if obj.get(FA.Ff, 0) & FA.FfBits.NoToggleToOff != 0 and "/Off" in retval[key]["/_States_"]:
+            if (
+                obj.get(FA.Ff, 0) & FA.FfBits.NoToggleToOff != 0
+                and "/Off" in retval[key]["/_States_"]
+            ):
                 del retval[key]["/_States_"][retval[key]["/_States_"].index("/Off")]
         # at last for order
         self._check_kids(field, retval, fileobj, stack)
@@ -614,7 +633,9 @@ class PdfDocCommon:
         stack: list[PdfObject],
     ) -> None:
         if tree in stack:
-            logger_warning(f"{self._get_qualified_field_name(tree)} already parsed", __name__)
+            logger_warning(
+                f"{self._get_qualified_field_name(tree)} already parsed", __name__
+            )
             return
         stack.append(tree)
         if PagesAttributes.KIDS in tree:
@@ -625,7 +646,9 @@ class PdfDocCommon:
 
     def _write_field(self, fileobj: Any, field: Any, field_attributes: Any) -> None:
         field_attributes_tuple = FA.attributes()
-        field_attributes_tuple = field_attributes_tuple + CheckboxRadioButtonAttributes.attributes()
+        field_attributes_tuple = (
+            field_attributes_tuple + CheckboxRadioButtonAttributes.attributes()
+        )
 
         for attr in field_attributes_tuple:
             if attr in (
@@ -677,7 +700,11 @@ class PdfDocCommon:
         def indexed_key(k: str, fields: dict[Any, Any]) -> str:
             if k not in fields:
                 return k
-            return k + "." + str(sum(1 for kk in fields if kk.startswith(k + ".")) + 2)
+            return (
+                k
+                + "."
+                + str(sum(1 for kk in fields if kk.startswith(k + ".")) + 2)
+            )
 
         # Retrieve document form fields
         formfields = self.get_fields()
@@ -692,7 +719,9 @@ class PdfDocCommon:
                     ff[indexed_key(cast(str, value["/T"]), ff)] = value.get("/V")
         return ff
 
-    def get_pages_showing_field(self, field: Union[Field, PdfObject, IndirectObject]) -> list[PageObject]:
+    def get_pages_showing_field(
+        self, field: Union[Field, PdfObject, IndirectObject]
+    ) -> list[PageObject]:
         """
         Provides list of pages where the field is called.
 
@@ -717,7 +746,9 @@ class PdfDocCommon:
             if key in obj:
                 return obj[key]
             if "/Parent" in obj:
-                return _get_inherited(cast(DictionaryObject, obj["/Parent"].get_object()), key)
+                return _get_inherited(
+                    cast(DictionaryObject, obj["/Parent"].get_object()), key
+                )
             return None
 
         try:
@@ -732,7 +763,11 @@ class PdfDocCommon:
             if "/P" in field:
                 ret = [field["/P"].get_object()]
             else:
-                ret = [p for p in self.pages if field.indirect_reference in p.get("/Annots", "")]
+                ret = [
+                    p
+                    for p in self.pages
+                    if field.indirect_reference in p.get("/Annots", "")
+                ]
         else:
             kids = field.get("/Kids", ())
             for k in kids:
@@ -742,9 +777,15 @@ class PdfDocCommon:
                     if "/P" in k:
                         ret += [k["/P"].get_object()]
                     else:
-                        ret += [p for p in self.pages if k.indirect_reference in p.get("/Annots", "")]
+                        ret += [
+                            p
+                            for p in self.pages
+                            if k.indirect_reference in p.get("/Annots", "")
+                        ]
         return [
-            x if isinstance(x, PageObject) else (self.pages[self._get_page_number_by_indirect(x.indirect_reference)])  # type: ignore
+            x
+            if isinstance(x, PageObject)
+            else (self.pages[self._get_page_number_by_indirect(x.indirect_reference)])  # type: ignore
             for x in ret
         ]
 
@@ -873,7 +914,8 @@ class PdfDocCommon:
     @abstractmethod
     def _get_page_number_by_indirect(
         self, indirect_reference: Union[None, int, NullObject, IndirectObject]
-    ) -> Optional[int]: ...  # pragma: no cover
+    ) -> Optional[int]:
+        ...  # pragma: no cover
 
     def get_page_number(self, page: PageObject) -> Optional[int]:
         """
@@ -905,7 +947,11 @@ class PdfDocCommon:
     def _build_destination(
         self,
         title: Union[str, bytes],
-        array: Optional[list[Union[NumberObject, IndirectObject, None, NullObject, DictionaryObject]]],
+        array: Optional[
+            list[
+                Union[NumberObject, IndirectObject, None, NullObject, DictionaryObject]
+            ]
+        ],
     ) -> Destination:
         page, typ = None, None
         # handle outline items with missing or invalid destination
@@ -962,7 +1008,9 @@ class PdfDocCommon:
             # named destination, addresses NameObject Issue #193
             # TODO: Keep named destination instead of replacing it?
             try:
-                outline_item = self._build_destination(title, self._named_destinations[dest].dest_array)
+                outline_item = self._build_destination(
+                    title, self._named_destinations[dest].dest_array
+                )
             except KeyError:
                 # named destination not found in Name Dict
                 outline_item = self._build_destination(title, None)
@@ -993,7 +1041,9 @@ class PdfDocCommon:
                 # with positive = open/unfolded, negative = closed/folded
                 outline_item[NameObject("/Count")] = node["/Count"]
             #  if count is 0 we will consider it as open (to have available is_open)
-            outline_item[NameObject("/%is_open%")] = BooleanObject(node.get("/Count", 0) >= 0)
+            outline_item[NameObject("/%is_open%")] = BooleanObject(
+                node.get("/Count", 0) >= 0
+            )
         outline_item.node = node
         try:
             outline_item.indirect_reference = node.indirect_reference
@@ -1151,7 +1201,9 @@ class PdfDocCommon:
                     try:
                         self._flatten(list_only, obj, inherit, **addt)
                     except RecursionError:
-                        raise PdfReadError("Maximum recursion depth reached during page flattening.")
+                        raise PdfReadError(
+                            "Maximum recursion depth reached during page flattening."
+                        )
         elif t == "/Page":
             for attr_in, value in inherit.items():
                 # if the page has its own value, it does not inherit the
@@ -1225,7 +1277,9 @@ class PdfDocCommon:
         """
         return IndirectObject(num, gen, self).get_object()
 
-    def decode_permissions(self, permissions_code: int) -> dict[str, bool]:  # pragma: no cover
+    def decode_permissions(
+        self, permissions_code: int
+    ) -> dict[str, bool]:  # pragma: no cover
         """Take the permissions as an integer, return the allowed access."""
         deprecation_with_replacement(
             old_name="decode_permissions",
@@ -1245,7 +1299,10 @@ class PdfDocCommon:
             "print_high_quality": UserAccessPermissions.PRINT_TO_REPRESENTATION,
         }
 
-        return {key: permissions_code & flag != 0 for key, flag in permissions_mapping.items()}
+        return {
+            key: permissions_code & flag != 0
+            for key, flag in permissions_mapping.items()
+        }
 
     @property
     def user_access_permissions(self) -> Optional[UserAccessPermissions]:
@@ -1321,7 +1378,12 @@ class PdfDocCommon:
     @property
     def attachments(self) -> Mapping[str, list[bytes]]:
         """Mapping of attachment filenames to their content."""
-        return LazyDict({name: (self._get_attachment_list, name) for name in self._list_attachments()})
+        return LazyDict(
+            {
+                name: (self._get_attachment_list, name)
+                for name in self._list_attachments()
+            }
+        )
 
     @property
     def attachment_list(self) -> Generator[EmbeddedFile, None, None]:
@@ -1349,7 +1411,9 @@ class PdfDocCommon:
             return out
         return [out]
 
-    def _get_attachments(self, filename: Optional[str] = None) -> dict[str, Union[bytes, list[bytes]]]:
+    def _get_attachments(
+        self, filename: Optional[str] = None
+    ) -> dict[str, Union[bytes, list[bytes]]]:
         """
         Retrieves all or selected file attachments of the PDF as a dictionary of file names
         and the file data as a bytestring.

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1306,7 +1306,17 @@ class PdfDocCommon:
 
     @property
     def user_access_permissions(self) -> Optional[UserAccessPermissions]:
-        """Get the user access permissions for encrypted documents. Returns None if not encrypted."""
+        """
+        Get the user access permissions for encrypted documents.
+        Returns None if not encrypted.
+
+        .. warning::
+
+            For AES-256 encrypted documents (R=5/R=6), the returned
+            permissions are derived from the ``/P`` field, which is
+            only trustworthy if the ``/Perms`` integrity check passed.
+            Check ``reader._encryption.perms_valid`` to verify.
+        """
         if self._encryption is None:
             return None
         return UserAccessPermissions(self._encryption.P)

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1315,11 +1315,31 @@ class PdfDocCommon:
             For AES-256 encrypted documents (R=5/R=6), the returned
             permissions are derived from the ``/P`` field, which is
             only trustworthy if the ``/Perms`` integrity check passed.
-            Check ``reader._encryption.perms_valid`` to verify.
+            Check :attr:`permissions_valid` to verify.
         """
         if self._encryption is None:
             return None
         return UserAccessPermissions(self._encryption.P)
+
+    @property
+    def permissions_valid(self) -> Optional[bool]:
+        """
+        Whether the ``/Perms`` integrity check passed for this document.
+
+        For AES-256 encrypted documents (R=5/R=6), the ``/Perms`` field
+        is an encrypted copy of the permissions that can be verified
+        independently. Returns ``False`` if this check fails (the ``/P``
+        permissions may have been tampered with).
+
+        Returns ``None`` if the document is not encrypted or has not yet
+        been decrypted via :meth:`decrypt()<pypdf.PdfReader.decrypt>`.
+        Returns ``True`` for non-AES-256 encryption (no ``/Perms`` to check).
+        """
+        if self._encryption is None:
+            return None
+        if not self._encryption.is_decrypted():
+            return None
+        return self._encryption.perms_valid
 
     @property
     @abstractmethod

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -272,28 +272,21 @@ class PdfDocCommon:
 
     @property
     @abstractmethod
-    def root_object(self) -> DictionaryObject:
-        ...  # pragma: no cover
+    def root_object(self) -> DictionaryObject: ...  # pragma: no cover
 
     @property
     @abstractmethod
-    def pdf_header(self) -> str:
-        ...  # pragma: no cover
+    def pdf_header(self) -> str: ...  # pragma: no cover
 
     @abstractmethod
-    def get_object(
-        self, indirect_reference: Union[int, IndirectObject]
-    ) -> Optional[PdfObject]:
-        ...  # pragma: no cover
+    def get_object(self, indirect_reference: Union[int, IndirectObject]) -> Optional[PdfObject]: ...  # pragma: no cover
 
     @abstractmethod
-    def _replace_object(self, indirect: IndirectObject, obj: PdfObject) -> PdfObject:
-        ...  # pragma: no cover
+    def _replace_object(self, indirect: IndirectObject, obj: PdfObject) -> PdfObject: ...  # pragma: no cover
 
     @property
     @abstractmethod
-    def _info(self) -> Optional[DictionaryObject]:
-        ...  # pragma: no cover
+    def _info(self) -> Optional[DictionaryObject]: ...  # pragma: no cover
 
     @property
     def metadata(self) -> Optional[DocumentInformation]:
@@ -311,8 +304,7 @@ class PdfDocCommon:
         return retval
 
     @property
-    def xmp_metadata(self) -> Optional[XmpInformation]:
-        ...  # pragma: no cover
+    def xmp_metadata(self) -> Optional[XmpInformation]: ...  # pragma: no cover
 
     @property
     def viewer_preferences(self) -> Optional[ViewerPreferences]:
@@ -378,9 +370,7 @@ class PdfDocCommon:
         """
         top = cast(DictionaryObject, self.root_object["/Pages"])
 
-        def recursive_call(
-            node: DictionaryObject, mi: int
-        ) -> tuple[Optional[PdfObject], int]:
+        def recursive_call(node: DictionaryObject, mi: int) -> tuple[Optional[PdfObject], int]:
             ma = cast(int, node.get("/Count", 1))  # default 1 for /Page types
             if node["/Type"] == "/Page":
                 if page_number == mi:
@@ -412,9 +402,7 @@ class PdfDocCommon:
 
     def get_named_dest_root(self) -> ArrayObject:
         named_dest = ArrayObject()
-        if CA.NAMES in self.root_object and isinstance(
-            self.root_object[CA.NAMES], DictionaryObject
-        ):
+        if CA.NAMES in self.root_object and isinstance(self.root_object[CA.NAMES], DictionaryObject):
             names = cast(DictionaryObject, self.root_object[CA.NAMES])
             if CA.DESTS in names and isinstance(names[CA.DESTS], DictionaryObject):
                 # §3.6.3 Name Dictionary (PDF spec 1.7)
@@ -575,9 +563,7 @@ class PdfDocCommon:
             return cast(str, parent["/TM"])
         if "/Parent" in parent:
             return (
-                self._get_qualified_field_name(
-                    cast(DictionaryObject, parent["/Parent"])
-                )
+                self._get_qualified_field_name(cast(DictionaryObject, parent["/Parent"]))
                 + "."
                 + cast(str, parent.get("/T", ""))
             )
@@ -603,9 +589,7 @@ class PdfDocCommon:
             retval[key][NameObject("/_States_")] = obj[NameObject(FA.Opt)]
         if obj.get(FA.FT, "") == "/Btn" and "/AP" in obj:
             #  Checkbox
-            retval[key][NameObject("/_States_")] = ArrayObject(
-                list(obj["/AP"]["/N"].keys())
-            )
+            retval[key][NameObject("/_States_")] = ArrayObject(list(obj["/AP"]["/N"].keys()))
             if "/Off" not in retval[key]["/_States_"]:
                 retval[key][NameObject("/_States_")].append(NameObject("/Off"))
         elif obj.get(FA.FT, "") == "/Btn" and obj.get(FA.Ff, 0) & FA.FfBits.Radio != 0:
@@ -617,10 +601,7 @@ class PdfDocCommon:
                     if s not in states:
                         states.append(s)
                 retval[key][NameObject("/_States_")] = ArrayObject(states)
-            if (
-                obj.get(FA.Ff, 0) & FA.FfBits.NoToggleToOff != 0
-                and "/Off" in retval[key]["/_States_"]
-            ):
+            if obj.get(FA.Ff, 0) & FA.FfBits.NoToggleToOff != 0 and "/Off" in retval[key]["/_States_"]:
                 del retval[key]["/_States_"][retval[key]["/_States_"].index("/Off")]
         # at last for order
         self._check_kids(field, retval, fileobj, stack)
@@ -633,9 +614,7 @@ class PdfDocCommon:
         stack: list[PdfObject],
     ) -> None:
         if tree in stack:
-            logger_warning(
-                f"{self._get_qualified_field_name(tree)} already parsed", __name__
-            )
+            logger_warning(f"{self._get_qualified_field_name(tree)} already parsed", __name__)
             return
         stack.append(tree)
         if PagesAttributes.KIDS in tree:
@@ -646,9 +625,7 @@ class PdfDocCommon:
 
     def _write_field(self, fileobj: Any, field: Any, field_attributes: Any) -> None:
         field_attributes_tuple = FA.attributes()
-        field_attributes_tuple = (
-            field_attributes_tuple + CheckboxRadioButtonAttributes.attributes()
-        )
+        field_attributes_tuple = field_attributes_tuple + CheckboxRadioButtonAttributes.attributes()
 
         for attr in field_attributes_tuple:
             if attr in (
@@ -700,11 +677,7 @@ class PdfDocCommon:
         def indexed_key(k: str, fields: dict[Any, Any]) -> str:
             if k not in fields:
                 return k
-            return (
-                k
-                + "."
-                + str(sum(1 for kk in fields if kk.startswith(k + ".")) + 2)
-            )
+            return k + "." + str(sum(1 for kk in fields if kk.startswith(k + ".")) + 2)
 
         # Retrieve document form fields
         formfields = self.get_fields()
@@ -719,9 +692,7 @@ class PdfDocCommon:
                     ff[indexed_key(cast(str, value["/T"]), ff)] = value.get("/V")
         return ff
 
-    def get_pages_showing_field(
-        self, field: Union[Field, PdfObject, IndirectObject]
-    ) -> list[PageObject]:
+    def get_pages_showing_field(self, field: Union[Field, PdfObject, IndirectObject]) -> list[PageObject]:
         """
         Provides list of pages where the field is called.
 
@@ -746,9 +717,7 @@ class PdfDocCommon:
             if key in obj:
                 return obj[key]
             if "/Parent" in obj:
-                return _get_inherited(
-                    cast(DictionaryObject, obj["/Parent"].get_object()), key
-                )
+                return _get_inherited(cast(DictionaryObject, obj["/Parent"].get_object()), key)
             return None
 
         try:
@@ -763,11 +732,7 @@ class PdfDocCommon:
             if "/P" in field:
                 ret = [field["/P"].get_object()]
             else:
-                ret = [
-                    p
-                    for p in self.pages
-                    if field.indirect_reference in p.get("/Annots", "")
-                ]
+                ret = [p for p in self.pages if field.indirect_reference in p.get("/Annots", "")]
         else:
             kids = field.get("/Kids", ())
             for k in kids:
@@ -777,15 +742,9 @@ class PdfDocCommon:
                     if "/P" in k:
                         ret += [k["/P"].get_object()]
                     else:
-                        ret += [
-                            p
-                            for p in self.pages
-                            if k.indirect_reference in p.get("/Annots", "")
-                        ]
+                        ret += [p for p in self.pages if k.indirect_reference in p.get("/Annots", "")]
         return [
-            x
-            if isinstance(x, PageObject)
-            else (self.pages[self._get_page_number_by_indirect(x.indirect_reference)])  # type: ignore
+            x if isinstance(x, PageObject) else (self.pages[self._get_page_number_by_indirect(x.indirect_reference)])  # type: ignore
             for x in ret
         ]
 
@@ -914,8 +873,7 @@ class PdfDocCommon:
     @abstractmethod
     def _get_page_number_by_indirect(
         self, indirect_reference: Union[None, int, NullObject, IndirectObject]
-    ) -> Optional[int]:
-        ...  # pragma: no cover
+    ) -> Optional[int]: ...  # pragma: no cover
 
     def get_page_number(self, page: PageObject) -> Optional[int]:
         """
@@ -947,11 +905,7 @@ class PdfDocCommon:
     def _build_destination(
         self,
         title: Union[str, bytes],
-        array: Optional[
-            list[
-                Union[NumberObject, IndirectObject, None, NullObject, DictionaryObject]
-            ]
-        ],
+        array: Optional[list[Union[NumberObject, IndirectObject, None, NullObject, DictionaryObject]]],
     ) -> Destination:
         page, typ = None, None
         # handle outline items with missing or invalid destination
@@ -1008,9 +962,7 @@ class PdfDocCommon:
             # named destination, addresses NameObject Issue #193
             # TODO: Keep named destination instead of replacing it?
             try:
-                outline_item = self._build_destination(
-                    title, self._named_destinations[dest].dest_array
-                )
+                outline_item = self._build_destination(title, self._named_destinations[dest].dest_array)
             except KeyError:
                 # named destination not found in Name Dict
                 outline_item = self._build_destination(title, None)
@@ -1041,9 +993,7 @@ class PdfDocCommon:
                 # with positive = open/unfolded, negative = closed/folded
                 outline_item[NameObject("/Count")] = node["/Count"]
             #  if count is 0 we will consider it as open (to have available is_open)
-            outline_item[NameObject("/%is_open%")] = BooleanObject(
-                node.get("/Count", 0) >= 0
-            )
+            outline_item[NameObject("/%is_open%")] = BooleanObject(node.get("/Count", 0) >= 0)
         outline_item.node = node
         try:
             outline_item.indirect_reference = node.indirect_reference
@@ -1201,9 +1151,7 @@ class PdfDocCommon:
                     try:
                         self._flatten(list_only, obj, inherit, **addt)
                     except RecursionError:
-                        raise PdfReadError(
-                            "Maximum recursion depth reached during page flattening."
-                        )
+                        raise PdfReadError("Maximum recursion depth reached during page flattening.")
         elif t == "/Page":
             for attr_in, value in inherit.items():
                 # if the page has its own value, it does not inherit the
@@ -1277,9 +1225,7 @@ class PdfDocCommon:
         """
         return IndirectObject(num, gen, self).get_object()
 
-    def decode_permissions(
-        self, permissions_code: int
-    ) -> dict[str, bool]:  # pragma: no cover
+    def decode_permissions(self, permissions_code: int) -> dict[str, bool]:  # pragma: no cover
         """Take the permissions as an integer, return the allowed access."""
         deprecation_with_replacement(
             old_name="decode_permissions",
@@ -1299,10 +1245,7 @@ class PdfDocCommon:
             "print_high_quality": UserAccessPermissions.PRINT_TO_REPRESENTATION,
         }
 
-        return {
-            key: permissions_code & flag != 0
-            for key, flag in permissions_mapping.items()
-        }
+        return {key: permissions_code & flag != 0 for key, flag in permissions_mapping.items()}
 
     @property
     def user_access_permissions(self) -> Optional[UserAccessPermissions]:
@@ -1339,7 +1282,7 @@ class PdfDocCommon:
             return None
         if not self._encryption.is_decrypted():
             return None
-        return self._encryption.perms_valid
+        return self._encryption._are_permissions_valid
 
     @property
     @abstractmethod
@@ -1378,12 +1321,7 @@ class PdfDocCommon:
     @property
     def attachments(self) -> Mapping[str, list[bytes]]:
         """Mapping of attachment filenames to their content."""
-        return LazyDict(
-            {
-                name: (self._get_attachment_list, name)
-                for name in self._list_attachments()
-            }
-        )
+        return LazyDict({name: (self._get_attachment_list, name) for name in self._list_attachments()})
 
     @property
     def attachment_list(self) -> Generator[EmbeddedFile, None, None]:
@@ -1411,9 +1349,7 @@ class PdfDocCommon:
             return out
         return [out]
 
-    def _get_attachments(
-        self, filename: Optional[str] = None
-    ) -> dict[str, Union[bytes, list[bytes]]]:
+    def _get_attachments(self, filename: Optional[str] = None) -> dict[str, Union[bytes, list[bytes]]]:
         """
         Retrieves all or selected file attachments of the PDF as a dictionary of file names
         and the file data as a bytestring.

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1315,14 +1315,14 @@ class PdfDocCommon:
             For AES-256 encrypted documents (R=5/R=6), the returned
             permissions are derived from the ``/P`` field, which is
             only trustworthy if the ``/Perms`` integrity check passed.
-            Check :attr:`permissions_valid` to verify.
+            Check :attr:`are_permissions_valid` to verify.
         """
         if self._encryption is None:
             return None
         return UserAccessPermissions(self._encryption.P)
 
     @property
-    def permissions_valid(self) -> Optional[bool]:
+    def are_permissions_valid(self) -> Optional[bool]:
         """
         Whether the ``/Perms`` integrity check passed for this document.
 

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -838,6 +838,7 @@ class Encryption:
 
         self._password_type = PasswordType.NOT_DECRYPTED
         self._key: Optional[bytes] = None
+        self.perms_valid: bool = True
 
     def is_decrypted(self) -> bool:
         return self._password_type != PasswordType.NOT_DECRYPTED
@@ -1010,7 +1011,8 @@ class Encryption:
             return b"", PasswordType.NOT_DECRYPTED
 
         # verify Perms
-        if not AlgV5.verify_perms(key, self.values.Perms, self.P, self.EncryptMetadata):
+        self.perms_valid = AlgV5.verify_perms(key, self.values.Perms, self.P, self.EncryptMetadata)
+        if not self.perms_valid:
             logger_warning("ignore '/Perms' verify failed", __name__)
         return key, rc
 

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -385,7 +385,9 @@ class AlgV4:
             The key
 
         """
-        key = AlgV4.compute_key(user_password, rev, key_size, o_entry, P, id1_entry, metadata_encrypted)
+        key = AlgV4.compute_key(
+            user_password, rev, key_size, o_entry, P, id1_entry, metadata_encrypted
+        )
         u_value = AlgV4.compute_U_value(key, rev, id1_entry)
         if rev >= 3:
             u_value = u_value[:16]
@@ -469,7 +471,9 @@ class AlgV4:
 
 class AlgV5:
     @staticmethod
-    def verify_owner_password(R: int, password: bytes, o_value: bytes, oe_value: bytes, u_value: bytes) -> bytes:
+    def verify_owner_password(
+        R: int, password: bytes, o_value: bytes, oe_value: bytes, u_value: bytes
+    ) -> bytes:
         """
         Algorithm 3.2a Computing an encryption key.
 
@@ -529,14 +533,19 @@ class AlgV5:
 
         """
         password = password[:127]
-        if AlgV5.calculate_hash(R, password, o_value[32:40], u_value[:48]) != o_value[:32]:
+        if (
+            AlgV5.calculate_hash(R, password, o_value[32:40], u_value[:48])
+            != o_value[:32]
+        ):
             return b""
         iv = bytes(0 for _ in range(16))
         tmp_key = AlgV5.calculate_hash(R, password, o_value[40:48], u_value[:48])
         return aes_cbc_decrypt(tmp_key, iv, oe_value)
 
     @staticmethod
-    def verify_user_password(R: int, password: bytes, u_value: bytes, ue_value: bytes) -> bytes:
+    def verify_user_password(
+        R: int, password: bytes, u_value: bytes, ue_value: bytes
+    ) -> bytes:
         """
         See :func:`verify_owner_password`.
 
@@ -582,7 +591,9 @@ class AlgV5:
         return k[:32]
 
     @staticmethod
-    def verify_perms(key: bytes, perms: bytes, p: int, metadata_encrypted: bool) -> bool:
+    def verify_perms(
+        key: bytes, perms: bytes, p: int, metadata_encrypted: bool
+    ) -> bool:
         """
         See :func:`verify_owner_password` and :func:`compute_perms_value`.
 
@@ -666,7 +677,9 @@ class AlgV5:
         return u_value, ue_value
 
     @staticmethod
-    def compute_O_value(R: int, password: bytes, key: bytes, u_value: bytes) -> tuple[bytes, bytes]:
+    def compute_O_value(
+        R: int, password: bytes, key: bytes, u_value: bytes
+    ) -> tuple[bytes, bytes]:
         """
         Algorithm 3.9 Computing the encryption dictionary’s O (owner password)
         and OE (owner encryption key) values.
@@ -701,7 +714,9 @@ class AlgV5:
         random_bytes = secrets.token_bytes(16)
         val_salt = random_bytes[:8]
         key_salt = random_bytes[8:]
-        o_value = AlgV5.calculate_hash(R, password, val_salt, u_value) + val_salt + key_salt
+        o_value = (
+            AlgV5.calculate_hash(R, password, val_salt, u_value) + val_salt + key_salt
+        )
         tmp_key = AlgV5.calculate_hash(R, password, key_salt, u_value[:48])
         iv = bytes(0 for _ in range(16))
         oe_value = aes_cbc_encrypt(tmp_key, iv, key)
@@ -921,7 +936,9 @@ class Encryption:
         return CryptFilter(stm_crypt, str_crypt, ef_crypt)
 
     @staticmethod
-    def _get_crypt(method: str, rc4_key: bytes, aes128_key: bytes, aes256_key: bytes) -> CryptBase:
+    def _get_crypt(
+        method: str, rc4_key: bytes, aes128_key: bytes, aes256_key: bytes
+    ) -> CryptBase:
         if method == "/AESV2":
             return CryptAES(aes128_key)
         if method == "/AESV3":
@@ -981,10 +998,14 @@ class Encryption:
     def verify_v5(self, password: bytes) -> tuple[bytes, PasswordType]:
         # TODO: use SASLprep process
         # verify owner password first
-        key = AlgV5.verify_owner_password(self.R, password, self.values.O, self.values.OE, self.values.U)
+        key = AlgV5.verify_owner_password(
+            self.R, password, self.values.O, self.values.OE, self.values.U
+        )
         rc = PasswordType.OWNER_PASSWORD
         if not key:
-            key = AlgV5.verify_user_password(self.R, password, self.values.U, self.values.UE)
+            key = AlgV5.verify_user_password(
+                self.R, password, self.values.U, self.values.UE
+            )
             rc = PasswordType.USER_PASSWORD
         if not key:
             return b"", PasswordType.NOT_DECRYPTED
@@ -995,7 +1016,9 @@ class Encryption:
             logger_warning("ignore '/Perms' verify failed", __name__)
         return key, rc
 
-    def write_entry(self, user_password: str, owner_password: Optional[str]) -> DictionaryObject:
+    def write_entry(
+        self, user_password: str, owner_password: Optional[str]
+    ) -> DictionaryObject:
         user_pwd = self._encode_password(user_password)
         owner_pwd = self._encode_password(owner_password) if owner_password else None
         if owner_pwd is None:
@@ -1005,7 +1028,9 @@ class Encryption:
             self.compute_values_v4(user_pwd, owner_pwd)
         else:
             self._key = secrets.token_bytes(self.Length // 8)
-            values = AlgV5.generate_values(self.R, user_pwd, owner_pwd, self._key, self.P, self.EncryptMetadata)
+            values = AlgV5.generate_values(
+                self.R, user_pwd, owner_pwd, self._key, self.P, self.EncryptMetadata
+            )
             self.values.O = values["/O"]
             self.values.U = values["/U"]
             self.values.OE = values["/OE"]
@@ -1065,7 +1090,9 @@ class Encryption:
     @staticmethod
     def read(encryption_entry: DictionaryObject, first_id_entry: bytes) -> "Encryption":
         if encryption_entry.get("/Filter") != "/Standard":
-            raise NotImplementedError("only Standard PDF encryption handler is available")
+            raise NotImplementedError(
+                "only Standard PDF encryption handler is available"
+            )
         if "/SubFilter" in encryption_entry:
             raise NotImplementedError("/SubFilter NOT supported")
 
@@ -1106,7 +1133,9 @@ class Encryption:
             # CF /Length is in bytes (default 16 for AES-128), convert to bits
             key_bits = cast(int, cf_dict.get("/Length", 16)) * 8
         encrypt_metadata = encryption_entry.get("/EncryptMetadata")
-        encrypt_metadata = encrypt_metadata.value if encrypt_metadata is not None else True
+        encrypt_metadata = (
+            encrypt_metadata.value if encrypt_metadata is not None else True
+        )
         values = EncryptionValues()
         values.O = cast(ByteStringObject, encryption_entry["/O"]).original_bytes
         values.U = cast(ByteStringObject, encryption_entry["/U"]).original_bytes
@@ -1128,7 +1157,9 @@ class Encryption:
         )
 
     @staticmethod
-    def make(alg: EncryptAlgorithm, permissions: int, first_id_entry: bytes) -> "Encryption":
+    def make(
+        alg: EncryptAlgorithm, permissions: int, first_id_entry: bytes
+    ) -> "Encryption":
         alg_ver, alg_rev, key_bits = alg
 
         stm_filter, str_filter, ef_filter = "/V2", "/V2", "/V2"

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -385,9 +385,7 @@ class AlgV4:
             The key
 
         """
-        key = AlgV4.compute_key(
-            user_password, rev, key_size, o_entry, P, id1_entry, metadata_encrypted
-        )
+        key = AlgV4.compute_key(user_password, rev, key_size, o_entry, P, id1_entry, metadata_encrypted)
         u_value = AlgV4.compute_U_value(key, rev, id1_entry)
         if rev >= 3:
             u_value = u_value[:16]
@@ -471,9 +469,7 @@ class AlgV4:
 
 class AlgV5:
     @staticmethod
-    def verify_owner_password(
-        R: int, password: bytes, o_value: bytes, oe_value: bytes, u_value: bytes
-    ) -> bytes:
+    def verify_owner_password(R: int, password: bytes, o_value: bytes, oe_value: bytes, u_value: bytes) -> bytes:
         """
         Algorithm 3.2a Computing an encryption key.
 
@@ -533,19 +529,14 @@ class AlgV5:
 
         """
         password = password[:127]
-        if (
-            AlgV5.calculate_hash(R, password, o_value[32:40], u_value[:48])
-            != o_value[:32]
-        ):
+        if AlgV5.calculate_hash(R, password, o_value[32:40], u_value[:48]) != o_value[:32]:
             return b""
         iv = bytes(0 for _ in range(16))
         tmp_key = AlgV5.calculate_hash(R, password, o_value[40:48], u_value[:48])
         return aes_cbc_decrypt(tmp_key, iv, oe_value)
 
     @staticmethod
-    def verify_user_password(
-        R: int, password: bytes, u_value: bytes, ue_value: bytes
-    ) -> bytes:
+    def verify_user_password(R: int, password: bytes, u_value: bytes, ue_value: bytes) -> bytes:
         """
         See :func:`verify_owner_password`.
 
@@ -591,9 +582,7 @@ class AlgV5:
         return k[:32]
 
     @staticmethod
-    def verify_perms(
-        key: bytes, perms: bytes, p: int, metadata_encrypted: bool
-    ) -> bool:
+    def verify_perms(key: bytes, perms: bytes, p: int, metadata_encrypted: bool) -> bool:
         """
         See :func:`verify_owner_password` and :func:`compute_perms_value`.
 
@@ -677,9 +666,7 @@ class AlgV5:
         return u_value, ue_value
 
     @staticmethod
-    def compute_O_value(
-        R: int, password: bytes, key: bytes, u_value: bytes
-    ) -> tuple[bytes, bytes]:
+    def compute_O_value(R: int, password: bytes, key: bytes, u_value: bytes) -> tuple[bytes, bytes]:
         """
         Algorithm 3.9 Computing the encryption dictionary’s O (owner password)
         and OE (owner encryption key) values.
@@ -714,9 +701,7 @@ class AlgV5:
         random_bytes = secrets.token_bytes(16)
         val_salt = random_bytes[:8]
         key_salt = random_bytes[8:]
-        o_value = (
-            AlgV5.calculate_hash(R, password, val_salt, u_value) + val_salt + key_salt
-        )
+        o_value = AlgV5.calculate_hash(R, password, val_salt, u_value) + val_salt + key_salt
         tmp_key = AlgV5.calculate_hash(R, password, key_salt, u_value[:48])
         iv = bytes(0 for _ in range(16))
         oe_value = aes_cbc_encrypt(tmp_key, iv, key)
@@ -838,7 +823,7 @@ class Encryption:
 
         self._password_type = PasswordType.NOT_DECRYPTED
         self._key: Optional[bytes] = None
-        self.perms_valid: bool = True
+        self._are_permissions_valid: bool = True
 
     def is_decrypted(self) -> bool:
         return self._password_type != PasswordType.NOT_DECRYPTED
@@ -936,9 +921,7 @@ class Encryption:
         return CryptFilter(stm_crypt, str_crypt, ef_crypt)
 
     @staticmethod
-    def _get_crypt(
-        method: str, rc4_key: bytes, aes128_key: bytes, aes256_key: bytes
-    ) -> CryptBase:
+    def _get_crypt(method: str, rc4_key: bytes, aes128_key: bytes, aes256_key: bytes) -> CryptBase:
         if method == "/AESV2":
             return CryptAES(aes128_key)
         if method == "/AESV3":
@@ -998,27 +981,21 @@ class Encryption:
     def verify_v5(self, password: bytes) -> tuple[bytes, PasswordType]:
         # TODO: use SASLprep process
         # verify owner password first
-        key = AlgV5.verify_owner_password(
-            self.R, password, self.values.O, self.values.OE, self.values.U
-        )
+        key = AlgV5.verify_owner_password(self.R, password, self.values.O, self.values.OE, self.values.U)
         rc = PasswordType.OWNER_PASSWORD
         if not key:
-            key = AlgV5.verify_user_password(
-                self.R, password, self.values.U, self.values.UE
-            )
+            key = AlgV5.verify_user_password(self.R, password, self.values.U, self.values.UE)
             rc = PasswordType.USER_PASSWORD
         if not key:
             return b"", PasswordType.NOT_DECRYPTED
 
         # verify Perms
-        self.perms_valid = AlgV5.verify_perms(key, self.values.Perms, self.P, self.EncryptMetadata)
-        if not self.perms_valid:
+        self._are_permissions_valid = AlgV5.verify_perms(key, self.values.Perms, self.P, self.EncryptMetadata)
+        if not self._are_permissions_valid:
             logger_warning("ignore '/Perms' verify failed", __name__)
         return key, rc
 
-    def write_entry(
-        self, user_password: str, owner_password: Optional[str]
-    ) -> DictionaryObject:
+    def write_entry(self, user_password: str, owner_password: Optional[str]) -> DictionaryObject:
         user_pwd = self._encode_password(user_password)
         owner_pwd = self._encode_password(owner_password) if owner_password else None
         if owner_pwd is None:
@@ -1028,9 +1005,7 @@ class Encryption:
             self.compute_values_v4(user_pwd, owner_pwd)
         else:
             self._key = secrets.token_bytes(self.Length // 8)
-            values = AlgV5.generate_values(
-                self.R, user_pwd, owner_pwd, self._key, self.P, self.EncryptMetadata
-            )
+            values = AlgV5.generate_values(self.R, user_pwd, owner_pwd, self._key, self.P, self.EncryptMetadata)
             self.values.O = values["/O"]
             self.values.U = values["/U"]
             self.values.OE = values["/OE"]
@@ -1090,9 +1065,7 @@ class Encryption:
     @staticmethod
     def read(encryption_entry: DictionaryObject, first_id_entry: bytes) -> "Encryption":
         if encryption_entry.get("/Filter") != "/Standard":
-            raise NotImplementedError(
-                "only Standard PDF encryption handler is available"
-            )
+            raise NotImplementedError("only Standard PDF encryption handler is available")
         if "/SubFilter" in encryption_entry:
             raise NotImplementedError("/SubFilter NOT supported")
 
@@ -1133,9 +1106,7 @@ class Encryption:
             # CF /Length is in bytes (default 16 for AES-128), convert to bits
             key_bits = cast(int, cf_dict.get("/Length", 16)) * 8
         encrypt_metadata = encryption_entry.get("/EncryptMetadata")
-        encrypt_metadata = (
-            encrypt_metadata.value if encrypt_metadata is not None else True
-        )
+        encrypt_metadata = encrypt_metadata.value if encrypt_metadata is not None else True
         values = EncryptionValues()
         values.O = cast(ByteStringObject, encryption_entry["/O"]).original_bytes
         values.U = cast(ByteStringObject, encryption_entry["/U"]).original_bytes
@@ -1157,9 +1128,7 @@ class Encryption:
         )
 
     @staticmethod
-    def make(
-        alg: EncryptAlgorithm, permissions: int, first_id_entry: bytes
-    ) -> "Encryption":
+    def make(alg: EncryptAlgorithm, permissions: int, first_id_entry: bytes) -> "Encryption":
         alg_ver, alg_rev, key_bits = alg
 
         stm_filter, str_filter, ef_filter = "/V2", "/V2", "/V2"

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -384,41 +384,41 @@ def test_encrypt_stream_dictionary(pdf_file_path):
     assert decrypted_image_obj["/ColorSpace"][3] == original_image_obj["/ColorSpace"][3]
 
 
-def test_permissions_valid_none_for_unencrypted():
-    """permissions_valid is None for unencrypted documents."""
+def test_are_permissions_valid_none_for_unencrypted():
+    """are_permissions_valid is None for unencrypted documents."""
     reader = PdfReader(RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
-    assert reader.permissions_valid is None
+    assert reader.are_permissions_valid is None
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
-def test_permissions_valid_none_before_decrypt():
-    """permissions_valid is None for encrypted documents before decrypt()."""
+def test_are_permissions_valid_none_before_decrypt():
+    """are_permissions_valid is None for encrypted documents before decrypt()."""
     reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-both-passwords.pdf")
-    assert reader.permissions_valid is None
+    assert reader.are_permissions_valid is None
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_perms_valid_true_for_valid_r6():
-    """permissions_valid is True when /Perms integrity check passes."""
+    """are_permissions_valid is True when /Perms integrity check passes."""
     reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-owner-password.pdf")
     reader.decrypt("usersecret")
-    assert reader.permissions_valid is True
+    assert reader.are_permissions_valid is True
 
 
 def test_perms_valid_true_for_v4():
-    """permissions_valid defaults to True for V4 encryption (no /Perms field)."""
+    """are_permissions_valid defaults to True for V4 encryption (no /Perms field)."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="RC4-128")
     output = BytesIO()
     writer.write(output)
     reader = PdfReader(output)
     reader.decrypt("user")
-    assert reader.permissions_valid is True
+    assert reader.are_permissions_valid is True
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_perms_valid_false_when_tampered():
-    """permissions_valid is False when /Perms has been tampered with."""
+    """are_permissions_valid is False when /Perms has been tampered with."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="AES-256")
     output = BytesIO()
@@ -436,4 +436,4 @@ def test_perms_valid_false_when_tampered():
 
     reader = PdfReader(tampered)
     reader.decrypt("user")
-    assert reader.permissions_valid is False
+    assert reader.are_permissions_valid is False

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,5 +1,4 @@
 """Test the pypdf._encryption module."""
-
 import secrets
 from io import BytesIO
 
@@ -293,7 +292,9 @@ def test_pdf_encrypt(pdf_file_path, alg, requires_aes):
         assert exc.value.args[0] == _DEPENDENCY_ERROR_STR
         return
 
-    writer.encrypt(user_password=user_password, owner_password=owner_password, algorithm=alg)
+    writer.encrypt(
+        user_password=user_password, owner_password=owner_password, algorithm=alg
+    )
     with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -381,3 +381,49 @@ def test_encrypt_stream_dictionary(pdf_file_path):
     decrypted_image_obj = reader.get_object(page.images["/I"].indirect_reference)
 
     assert decrypted_image_obj["/ColorSpace"][3] == original_image_obj["/ColorSpace"][3]
+
+
+@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
+def test_perms_valid_true_for_valid_r6():
+    """perms_valid is True when /Perms integrity check passes."""
+    reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-owner-password.pdf")
+    reader.decrypt("usersecret")
+    assert reader._encryption.perms_valid is True
+
+
+def test_perms_valid_true_for_v4():
+    """perms_valid defaults to True for V4 encryption (no /Perms field)."""
+    writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
+    writer.encrypt(user_password="user", owner_password="owner", algorithm="RC4-128")
+    from io import BytesIO
+
+    output = BytesIO()
+    writer.write(output)
+    reader = PdfReader(output)
+    reader.decrypt("user")
+    assert reader._encryption.perms_valid is True
+
+
+@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
+def test_perms_valid_false_when_tampered():
+    """perms_valid is False when /Perms has been tampered with."""
+    from io import BytesIO
+
+    writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
+    writer.encrypt(user_password="user", owner_password="owner", algorithm="AES-256")
+    output = BytesIO()
+    writer.write(output)
+
+    # Tamper with /Perms by modifying the raw bytes
+    data = bytearray(output.getvalue())
+    perms_marker = b"/Perms "
+    idx = data.find(perms_marker)
+    assert idx != -1, "/Perms not found in PDF"
+    # Find the hex string value after /Perms and corrupt a byte
+    start = data.index(b"<", idx)
+    data[start + 2] ^= 0xFF  # flip bits in the first byte of the hex string
+    tampered = BytesIO(bytes(data))
+
+    reader = PdfReader(tampered)
+    reader.decrypt("user")
+    assert reader._encryption.perms_valid is False

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,4 +1,5 @@
 """Test the pypdf._encryption module."""
+
 import secrets
 from io import BytesIO
 
@@ -292,9 +293,7 @@ def test_pdf_encrypt(pdf_file_path, alg, requires_aes):
         assert exc.value.args[0] == _DEPENDENCY_ERROR_STR
         return
 
-    writer.encrypt(
-        user_password=user_password, owner_password=owner_password, algorithm=alg
-    )
+    writer.encrypt(user_password=user_password, owner_password=owner_password, algorithm=alg)
     with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)
 
@@ -398,14 +397,14 @@ def test_are_permissions_valid_none_before_decrypt():
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
-def test_perms_valid_true_for_valid_r6():
+def test_are_permissions_valid_true_for_valid_r6():
     """are_permissions_valid is True when /Perms integrity check passes."""
     reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-owner-password.pdf")
     reader.decrypt("usersecret")
     assert reader.are_permissions_valid is True
 
 
-def test_perms_valid_true_for_v4():
+def test_are_permissions_valid_true_for_v4():
     """are_permissions_valid defaults to True for V4 encryption (no /Perms field)."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="RC4-128")
@@ -417,7 +416,7 @@ def test_perms_valid_true_for_v4():
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
-def test_perms_valid_false_when_tampered():
+def test_are_permissions_valid_false_when_tampered():
     """are_permissions_valid is False when /Perms has been tampered with."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="AES-256")

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -384,28 +384,41 @@ def test_encrypt_stream_dictionary(pdf_file_path):
     assert decrypted_image_obj["/ColorSpace"][3] == original_image_obj["/ColorSpace"][3]
 
 
+def test_permissions_valid_none_for_unencrypted():
+    """permissions_valid is None for unencrypted documents."""
+    reader = PdfReader(RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
+    assert reader.permissions_valid is None
+
+
+@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
+def test_permissions_valid_none_before_decrypt():
+    """permissions_valid is None for encrypted documents before decrypt()."""
+    reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-both-passwords.pdf")
+    assert reader.permissions_valid is None
+
+
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_perms_valid_true_for_valid_r6():
-    """perms_valid is True when /Perms integrity check passes."""
+    """permissions_valid is True when /Perms integrity check passes."""
     reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-owner-password.pdf")
     reader.decrypt("usersecret")
-    assert reader._encryption.perms_valid is True
+    assert reader.permissions_valid is True
 
 
 def test_perms_valid_true_for_v4():
-    """perms_valid defaults to True for V4 encryption (no /Perms field)."""
+    """permissions_valid defaults to True for V4 encryption (no /Perms field)."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="RC4-128")
     output = BytesIO()
     writer.write(output)
     reader = PdfReader(output)
     reader.decrypt("user")
-    assert reader._encryption.perms_valid is True
+    assert reader.permissions_valid is True
 
 
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_perms_valid_false_when_tampered():
-    """perms_valid is False when /Perms has been tampered with."""
+    """permissions_valid is False when /Perms has been tampered with."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="AES-256")
     output = BytesIO()
@@ -423,4 +436,4 @@ def test_perms_valid_false_when_tampered():
 
     reader = PdfReader(tampered)
     reader.decrypt("user")
-    assert reader._encryption.perms_valid is False
+    assert reader.permissions_valid is False

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,5 +1,6 @@
 """Test the pypdf._encryption module."""
 import secrets
+from io import BytesIO
 
 import pytest
 
@@ -395,8 +396,6 @@ def test_perms_valid_true_for_v4():
     """perms_valid defaults to True for V4 encryption (no /Perms field)."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="RC4-128")
-    from io import BytesIO
-
     output = BytesIO()
     writer.write(output)
     reader = PdfReader(output)
@@ -407,8 +406,6 @@ def test_perms_valid_true_for_v4():
 @pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 def test_perms_valid_false_when_tampered():
     """perms_valid is False when /Perms has been tampered with."""
-    from io import BytesIO
-
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "encryption" / "unencrypted.pdf")
     writer.encrypt(user_password="user", owner_password="owner", algorithm="AES-256")
     output = BytesIO()


### PR DESCRIPTION
## Summary

Adds a `perms_valid` attribute to the `Encryption` class that stores the result of `AlgV5.verify_perms()`. This allows callers to programmatically detect when the `/Perms` integrity check fails for AES-256 encrypted documents (R5/R6), indicating the `/P` permissions field may have been tampered with.

Closes #3657

## Changes

- **`_encryption.py`**: Added `self.perms_valid: bool = True` to `Encryption.__init__()`. In `verify_v5()`, the `AlgV5.verify_perms()` result is now stored in `self.perms_valid` instead of only being used in a conditional.
- **`_doc_common.py`**: Added a warning to the `user_access_permissions` docstring noting that returned permissions are only trustworthy if `reader._encryption.perms_valid` is `True`.
- **`tests/test_encryption.py`**: Added 3 tests:
  - `test_perms_valid_true_for_valid_r6` — verifies `perms_valid` is `True` for a valid R6 PDF
  - `test_perms_valid_true_for_v4` — verifies default `True` for V4 (no `/Perms` field)
  - `test_perms_valid_false_when_tampered` — creates an AES-256 PDF, tampers with `/Perms` bytes, verifies `perms_valid` is `False`

## Design Notes

- `perms_valid` defaults to `True` because V4 and below don't use `/Perms` at all — only V5 (R5/R6) introduced the cryptographic integrity check.
- The existing warning log is preserved — this change only adds programmatic access to the verification result.
- No breaking changes — existing behavior is unchanged.