### PR TITLE
PI: Fix O(n²) performance in NameObject read/write

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -254,18 +254,27 @@ def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:
         The read bytes.
 
     """
-    name = b""
+    parts: list[bytes] = []
+    total_len = 0
+    tail = b""
     while True:
         tok = stream.read(16)
         if not tok:
-            return name
-        m = regex.search(name + tok)
+            return b"".join(parts)
+        # Search overlap of previous tail + new chunk to catch
+        # multi-byte regex matches spanning chunk boundaries.
+        buf = tail + tok
+        m = regex.search(buf)
         if m is not None:
-            stream.seek(m.start() - (len(name) + len(tok)), 1)
-            name = (name + tok)[: m.start()]
-            break
-        name += tok
-    return name
+            overlap = len(tail)
+            actual_start = total_len - overlap + m.start()
+            stream.seek(actual_start - total_len - len(tok), 1)
+            parts.append(tok)
+            return b"".join(parts)[:actual_start]
+        parts.append(tok)
+        total_len += len(tok)
+        tail = tok[-16:]
+    return b"".join(parts)
 
 
 def read_block_backwards(stream: StreamType, to_read: int) -> bytes:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -274,6 +274,8 @@ def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:
             return b"".join(parts)[:actual_start]
         parts.append(tok)
         total_len += len(tok)
+        # Fixed overlap: 16 bytes is sufficient for the short
+        # delimiter patterns used in PDF parsing.
         tail = tok[-16:]
         if chunk_size < 8192:
             chunk_size <<= 1

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -257,8 +257,9 @@ def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:
     parts: list[bytes] = []
     total_len = 0
     tail = b""
+    chunk_size = 16
     while True:
-        tok = stream.read(16)
+        tok = stream.read(chunk_size)
         if not tok:
             return b"".join(parts)
         # Search overlap of previous tail + new chunk to catch
@@ -274,6 +275,8 @@ def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:
         parts.append(tok)
         total_len += len(tok)
         tail = tok[-16:]
+        if chunk_size < 8192:
+            chunk_size <<= 1
     return b"".join(parts)
 
 

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -29,7 +29,6 @@ import codecs
 import hashlib
 import re
 import sys
-from binascii import unhexlify
 from collections.abc import Sequence
 from math import log10
 from struct import iter_unpack
@@ -840,16 +839,16 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
                 f"Incorrect first char in NameObject, should start with '/': ({self})",
                 "5.0.0",
             )
+        parts = [out]
         for c in self[1:]:
             if c > "~":
-                for x in c.encode("utf-8"):
-                    out += f"#{x:02X}".encode()
+                parts.extend(f"#{x:02X}".encode() for x in c.encode("utf-8"))
             else:
                 try:
-                    out += self.renumber_table[c]
+                    parts.append(self.renumber_table[c])
                 except KeyError:
-                    out += c.encode("utf-8")
-        return out
+                    parts.append(c.encode("utf-8"))
+        return b"".join(parts)
 
     def _sanitize(self) -> "NameObject":
         """
@@ -873,16 +872,21 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
 
     @staticmethod
     def unnumber(sin: bytes) -> bytes:
-        i = sin.find(b"#", 0)
-        while i >= 0:
-            try:
-                sin = sin[:i] + unhexlify(sin[i + 1 : i + 3]) + sin[i + 3 :]
-                i = sin.find(b"#", i + 1)
-            except ValueError:
-                # if the 2 characters after # can not be converted to hex
-                # we change nothing and carry on
-                i = i + 1
-        return sin
+        result = bytearray()
+        i = 0
+        while i < len(sin):
+            if sin[i:i + 1] == b"#":
+                try:
+                    result.append(int(sin[i + 1 : i + 3], 16))
+                    i += 3
+                    continue
+                except (ValueError, IndexError):
+                    # if the 2 characters after # can not be converted to hex
+                    # we change nothing and carry on
+                    pass
+            result.append(sin[i])
+            i += 1
+        return bytes(result)
 
     CHARSETS = ("utf-8", "gbk", "latin1")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,6 +168,26 @@ def test_read_until_regex_match_spanning_later_boundary():
     assert stream.tell() == 47
 
 
+def test_read_until_regex_tail_overlap_is_fixed():
+    """Tail overlap is 16 bytes regardless of chunk size growth.
+
+    Chunk reads: 16, 32, 64 -> total 112. Place a 16-byte pattern starting
+    one byte before the 64-byte chunk boundary (at offset 47) so it spans
+    into the third chunk. This only works if the tail kept from chunk 2
+    covers at least 16 bytes.
+    """
+    pattern = b"ABCDEFGHIJKLMNOP"  # 16 bytes
+    assert len(pattern) == 16
+    # Chunk 1: 16 bytes, chunk 2: 32 bytes -> boundary at offset 48.
+    # Pattern starts at 47, spanning bytes 47-62.
+    payload = b"x" * 47
+    data = payload + pattern + b"rest"
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(re.escape(pattern)))
+    assert result == payload
+    assert stream.tell() == 47
+
+
 @pytest.mark.parametrize(
     ("a", "b", "expected"),
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,6 +94,80 @@ def test_read_until_regex_premature_ending_name():
     assert read_until_regex(stream, re.compile(b".")) == b""
 
 
+def test_read_until_regex_match_in_first_chunk():
+    """Match within the first 16-byte chunk."""
+    stream = io.BytesIO(b"hello world")
+    result = read_until_regex(stream, re.compile(b" "))
+    assert result == b"hello"
+    assert stream.tell() == 5
+
+
+def test_read_until_regex_match_in_second_chunk():
+    """Match lands in the second chunk (past first 16 bytes)."""
+    payload = b"0123456789abcdefghij"
+    assert len(payload) == 20
+    data = payload + b" rest"
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(b" "))
+    assert result == payload
+    assert stream.tell() == 20
+
+
+def test_read_until_regex_match_at_chunk_boundary():
+    """Delimiter sits exactly at byte 16 (first byte of second chunk)."""
+    payload = b"0123456789abcdef"
+    assert len(payload) == 16
+    data = payload + b" after"
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(b" "))
+    assert result == payload
+    assert stream.tell() == 16
+
+
+def test_read_until_regex_multi_byte_spanning_boundary():
+    """Multi-byte regex pattern spans across a chunk boundary."""
+    # "X" at byte 15 (last byte of first chunk), "Y" at byte 16 (first of second)
+    payload = b"0123456789abcde"
+    assert len(payload) == 15
+    data = payload + b"XYafter"
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(b"XY"))
+    assert result == payload
+    assert stream.tell() == 15
+
+
+def test_read_until_regex_no_match_exhausted():
+    """No match — stream is fully consumed and all data returned."""
+    data = b"0123456789" * 10
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(b"ZZZ"))
+    assert result == data
+
+
+def test_read_until_regex_exponential_chunk_growth():
+    """Verify correctness with long input that exercises chunk doubling."""
+    payload = (b"0123456789abcdef" * 3125)[:50_000]
+    assert len(payload) == 50_000
+    data = payload + b"|done"
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(rb"\|"))
+    assert result == payload
+    assert stream.tell() == 50_000
+
+
+def test_read_until_regex_match_spanning_later_boundary():
+    """Multi-byte match spanning a boundary after chunk size has grown."""
+    # Chunk 1: 16 bytes, chunk 2: 32 bytes → total 48 after two reads.
+    # Place "END" at offset 47 so it spans bytes 47-49.
+    payload = (b"0123456789abcdef" * 3)[:47]
+    assert len(payload) == 47
+    data = payload + b"ENDrest"
+    stream = io.BytesIO(data)
+    result = read_until_regex(stream, re.compile(b"END"))
+    assert result == payload
+    assert stream.tell() == 47
+
+
 @pytest.mark.parametrize(
     ("a", "b", "expected"),
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,7 +137,7 @@ def test_read_until_regex_multi_byte_spanning_boundary():
 
 
 def test_read_until_regex_no_match_exhausted():
-    """No match — stream is fully consumed and all data returned."""
+    """No match - stream is fully consumed and all data returned."""
     data = b"0123456789" * 10
     stream = io.BytesIO(data)
     result = read_until_regex(stream, re.compile(b"ZZZ"))


### PR DESCRIPTION
Fixes #3678

- `read_until_regex`: search only new chunk instead of rescanning entire buffer; use list accumulation instead of bytes concatenation
- `NameObject.unnumber`: use bytearray instead of rebuilding bytes on each `#xx` replacement
- `NameObject.renumber`: use `parts.append()` + `join()` instead of `out +=`

A real-world PDF with a ~786KB pathologically encoded name (262,144 hex escapes from repeated UTF-8 mis-encoding) went from hanging indefinitely to completing in ~3 seconds.
