### PR TITLE
BUG: resolve UnboundLocalError for xobjs in _get_image

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -237,7 +237,9 @@ class Transformation:
         m = self.ctm
         return Transformation(ctm=(m[0], m[1], m[2], m[3], m[4] + tx, m[5] + ty))
 
-    def scale(self, sx: Optional[float] = None, sy: Optional[float] = None) -> "Transformation":
+    def scale(
+        self, sx: Optional[float] = None, sy: Optional[float] = None
+    ) -> "Transformation":
         """
         Scale the contents of a page towards the origin of the coordinate system.
 
@@ -288,10 +290,14 @@ class Transformation:
         return f"Transformation(ctm={self.ctm})"
 
     @overload
-    def apply_on(self, pt: list[float], as_object: bool = False) -> list[float]: ...
+    def apply_on(self, pt: list[float], as_object: bool = False) -> list[float]:
+        ...
 
     @overload
-    def apply_on(self, pt: tuple[float, float], as_object: bool = False) -> tuple[float, float]: ...
+    def apply_on(
+        self, pt: tuple[float, float], as_object: bool = False
+    ) -> tuple[float, float]:
+        ...
 
     def apply_on(
         self,
@@ -367,7 +373,8 @@ class ImageFile:
         """
         if pil_not_imported:
             raise ImportError(
-                "pillow is required to do image extraction. It can be installed via 'pip install pypdf[image]'"
+                "pillow is required to do image extraction. "
+                "It can be installed via 'pip install pypdf[image]'"
             )
 
         from ._reader import PdfReader  # noqa: PLC0415
@@ -388,7 +395,9 @@ class ImageFile:
         self.indirect_reference.pdf._objects[self.indirect_reference.idnum - 1] = (
             page_image.indirect_reference.get_object()
         )
-        cast(PdfObject, self.indirect_reference.get_object()).indirect_reference = self.indirect_reference
+        cast(
+            PdfObject, self.indirect_reference.get_object()
+        ).indirect_reference = self.indirect_reference
         # change the object attributes
         extension, byte_stream, img = _xobj_to_image(
             cast(DictionaryObject, self.indirect_reference.get_object()),
@@ -432,10 +441,12 @@ class VirtualListImages(Sequence[ImageFile]):
         return [(x, self[x]) for x in self.ids_function()]
 
     @overload
-    def __getitem__(self, index: Union[int, str, list[str]]) -> ImageFile: ...
+    def __getitem__(self, index: Union[int, str, list[str]]) -> ImageFile:
+        ...
 
     @overload
-    def __getitem__(self, index: slice) -> Sequence[ImageFile]: ...
+    def __getitem__(self, index: slice) -> Sequence[ImageFile]:
+        ...
 
     def __getitem__(
         self, index: Union[int, slice, str, list[str], tuple[str]]
@@ -511,7 +522,9 @@ class PageObject(DictionaryObject):
             Hash considering type and value.
 
         """
-        return hash((DictionaryObject, tuple(((k, v.hash_bin()) for k, v in self.items()))))
+        return hash(
+            (DictionaryObject, tuple(((k, v.hash_bin()) for k, v in self.items())))
+        )
 
     def hash_value_data(self) -> bytes:
         data = super().hash_value_data()
@@ -570,8 +583,7 @@ class PageObject(DictionaryObject):
             else:
                 raise PageSizeNotDefinedError
         page.__setitem__(
-            NameObject(PG.MEDIABOX),
-            RectangleObject((0, 0, width, height)),  # type: ignore
+            NameObject(PG.MEDIABOX), RectangleObject((0, 0, width, height))  # type: ignore
         )
 
         return page
@@ -596,9 +608,9 @@ class PageObject(DictionaryObject):
             ancest = []
         lst: list[Union[str, list[str]]] = []
         if (
-            PG.RESOURCES not in obj
-            or is_null_or_none(resources := obj[PG.RESOURCES])
-            or RES.XOBJECT not in cast(DictionaryObject, resources)
+                PG.RESOURCES not in obj or
+                is_null_or_none(resources := obj[PG.RESOURCES]) or
+                RES.XOBJECT not in cast(DictionaryObject, resources)
         ):
             return [] if self.inline_images is None else list(self.inline_images.keys())
 
@@ -627,7 +639,9 @@ class PageObject(DictionaryObject):
             id = id[0]
         xobjs: Optional[DictionaryObject] = None
         try:
-            xobjs = cast(DictionaryObject, cast(DictionaryObject, obj[PG.RESOURCES])[RES.XOBJECT])
+            xobjs = cast(
+                DictionaryObject, cast(DictionaryObject, obj[PG.RESOURCES])[RES.XOBJECT]
+            )
         except KeyError:
             if not (id[0] == "~" and id[-1] == "~"):
                 raise
@@ -642,7 +656,6 @@ class PageObject(DictionaryObject):
             if xobjs is None:  # pragma: no cover
                 raise KeyError(f"Cannot access image object {id} without XObject resources")
             from .generic._image_xobject import _xobj_to_image  # noqa: PLC0415
-
             imgd = _xobj_to_image(cast(DictionaryObject, xobjs[id]))
             extension, byte_stream = imgd[:2]
             return ImageFile(
@@ -721,10 +734,13 @@ class PageObject(DictionaryObject):
         assert content is not None, "mypy"
         for param, ope in content.operations:
             if ope == b"INLINE IMAGE":
-                imgs_data.append({"settings": param["settings"], "__streamdata__": param["data"]})
+                imgs_data.append(
+                    {"settings": param["settings"], "__streamdata__": param["data"]}
+                )
             elif ope in (b"BI", b"EI", b"ID"):  # pragma: no cover
                 raise PdfReadError(
-                    f"{ope!r} operator met whereas not expected, please share use case with pypdf dev team"
+                    f"{ope!r} operator met whereas not expected, "
+                    "please share use case with pypdf dev team"
                 )
         files = {}
         for num, ii in enumerate(imgs_data):
@@ -736,7 +752,9 @@ class PageObject(DictionaryObject):
                 if k in {"/Length", "/L"}:  # no length is expected
                     continue
                 if isinstance(v, list):
-                    v = ArrayObject([self._translate_value_inline_image(k, x) for x in v])
+                    v = ArrayObject(
+                        [self._translate_value_inline_image(k, x) for x in v]
+                    )
                 else:
                     v = self._translate_value_inline_image(k, v)
                 k = NameObject(_INLINE_IMAGE_KEY_MAPPING[k])
@@ -744,7 +762,6 @@ class PageObject(DictionaryObject):
                     init[k] = v
             ii["object"] = EncodedStreamObject.initialize_from_dictionary(init)
             from .generic._image_xobject import _xobj_to_image  # noqa: PLC0415
-
             extension, byte_stream, img = _xobj_to_image(ii["object"])
             files[f"~{num}~"] = ImageFile(
                 name=f"~{num}~{extension}",
@@ -779,7 +796,13 @@ class PageObject(DictionaryObject):
         r = -self.rotation  # rotation to apply is in the otherway
         self.rotation = 0
         mb = RectangleObject(self.mediabox)
-        trsf = Transformation().translate(-float(mb.left + mb.width / 2), -float(mb.bottom + mb.height / 2)).rotate(r)
+        trsf = (
+            Transformation()
+            .translate(
+                -float(mb.left + mb.width / 2), -float(mb.bottom + mb.height / 2)
+            )
+            .rotate(r)
+        )
         pt1 = trsf.apply_on(mb.lower_left)
         pt2 = trsf.apply_on(mb.upper_right)
         trsf = trsf.translate(-min(pt1[0], pt2[0]), -min(pt1[1], pt2[1]))
@@ -824,7 +847,9 @@ class PageObject(DictionaryObject):
         try:
             assert isinstance(self.indirect_reference, IndirectObject)
             pdf = self.indirect_reference.pdf
-            is_pdf_writer = hasattr(pdf, "_add_object")  # expect isinstance(pdf, PdfWriter)
+            is_pdf_writer = hasattr(
+                pdf, "_add_object"
+            )  # expect isinstance(pdf, PdfWriter)
         except (AssertionError, AttributeError):
             pdf = None
             is_pdf_writer = False
@@ -867,7 +892,9 @@ class PageObject(DictionaryObject):
             new_res.update(res1.get(resource, DictionaryObject()).get_object())
         else:
             new_res = cast(DictionaryObject, res1[resource])
-        page2res = cast(DictionaryObject, res2.get(resource, DictionaryObject()).get_object())
+        page2res = cast(
+            DictionaryObject, res2.get(resource, DictionaryObject()).get_object()
+        )
         rename_res = {}
         for key in page2res:
             unique_key, same_value = compute_unique_key(key)
@@ -966,7 +993,9 @@ class PageObject(DictionaryObject):
             return ContentStream(resolved_object, pdf)
         return None
 
-    def replace_contents(self, content: Union[None, ContentStream, EncodedStreamObject, ArrayObject]) -> None:
+    def replace_contents(
+        self, content: Union[None, ContentStream, EncodedStreamObject, ArrayObject]
+    ) -> None:
         """
         Replace the page contents with the new content and nullify old objects
         Args:
@@ -978,7 +1007,6 @@ class PageObject(DictionaryObject):
             return
 
         from pypdf._writer import PdfWriter  # noqa: PLC0415
-
         if not isinstance(self.indirect_reference.pdf, PdfWriter):
             deprecate(
                 "Calling `PageObject.replace_contents()` for pages not assigned to a writer is deprecated "
@@ -1028,7 +1056,9 @@ class PageObject(DictionaryObject):
         # forces recalculation of inline_images
         self.inline_images = None
 
-    def merge_page(self, page2: "PageObject", expand: bool = False, over: bool = True) -> None:
+    def merge_page(
+        self, page2: "PageObject", expand: bool = False, over: bool = True
+    ) -> None:
         """
         Merge the content streams of two pages into one.
 
@@ -1061,8 +1091,12 @@ class PageObject(DictionaryObject):
         # rename.
         try:
             assert isinstance(self.indirect_reference, IndirectObject)
-            if hasattr(self.indirect_reference.pdf, "_add_object"):  # to detect PdfWriter
-                return self._merge_page_writer(page2, page2transformation, ctm, over, expand)
+            if hasattr(
+                self.indirect_reference.pdf, "_add_object"
+            ):  # to detect PdfWriter
+                return self._merge_page_writer(
+                    page2, page2transformation, ctm, over, expand
+                )
         except (AssertionError, AttributeError):
             pass
 
@@ -1087,7 +1121,9 @@ class PageObject(DictionaryObject):
             RES.SHADING,
             RES.PROPERTIES,
         ):
-            new, newrename = self._merge_resources(original_resources, page2resources, res)
+            new, newrename = self._merge_resources(
+                original_resources, page2resources, res
+            )
             if new:
                 new_resources[NameObject(res)] = new
                 rename.update(newrename)
@@ -1095,7 +1131,9 @@ class PageObject(DictionaryObject):
         # Combine /ProcSet sets, making sure there's a consistent order
         new_resources[NameObject(RES.PROC_SET)] = ArrayObject(
             sorted(
-                set(original_resources.get(RES.PROC_SET, ArrayObject()).get_object()).union(
+                set(
+                    original_resources.get(RES.PROC_SET, ArrayObject()).get_object()
+                ).union(
                     set(page2resources.get(RES.PROC_SET, ArrayObject()).get_object())
                 )
             )
@@ -1129,7 +1167,9 @@ class PageObject(DictionaryObject):
             page2content.operations.insert(2, ([], b"n"))
             if page2transformation is not None:
                 page2content = page2transformation(page2content)
-            page2content = PageObject._content_stream_rename(page2content, rename, self.pdf)
+            page2content = PageObject._content_stream_rename(
+                page2content, rename, self.pdf
+            )
             page2content.isolate_graphics_state()
             if over:
                 new_content_array.append(page2content)
@@ -1180,7 +1220,9 @@ class PageObject(DictionaryObject):
             if res in page2resources:
                 if res not in original_resources:
                     original_resources[NameObject(res)] = DictionaryObject()
-                _, newrename = self._merge_resources(original_resources, page2resources, res, False)
+                _, newrename = self._merge_resources(
+                    original_resources, page2resources, res, False
+                )
                 rename.update(newrename)
         # Combine /ProcSet sets.
         if RES.PROC_SET in page2resources:
@@ -1266,7 +1308,9 @@ class PageObject(DictionaryObject):
             page2content.operations.insert(2, ([], b"n"))
             if page2transformation is not None:
                 page2content = page2transformation(page2content)
-            page2content = PageObject._content_stream_rename(page2content, rename, self.pdf)
+            page2content = PageObject._content_stream_rename(
+                page2content, rename, self.pdf
+            )
             page2content.isolate_graphics_state()
             if over:
                 new_content_array.append(page2content)
@@ -1279,7 +1323,9 @@ class PageObject(DictionaryObject):
 
         self.replace_contents(new_content_array)
 
-    def _expand_mediabox(self, page2: "PageObject", ctm: Optional[CompressedTransformationMatrix]) -> None:
+    def _expand_mediabox(
+        self, page2: "PageObject", ctm: Optional[CompressedTransformationMatrix]
+    ) -> None:
         corners1 = (
             self.mediabox.left.as_numeric(),
             self.mediabox.bottom.as_numeric(),
@@ -1298,8 +1344,14 @@ class PageObject(DictionaryObject):
         )
         if ctm is not None:
             ctm = tuple(float(x) for x in ctm)  # type: ignore[assignment]
-            new_x = tuple(ctm[0] * corners2[i] + ctm[2] * corners2[i + 1] + ctm[4] for i in range(0, 8, 2))
-            new_y = tuple(ctm[1] * corners2[i] + ctm[3] * corners2[i + 1] + ctm[5] for i in range(0, 8, 2))
+            new_x = tuple(
+                ctm[0] * corners2[i] + ctm[2] * corners2[i + 1] + ctm[4]
+                for i in range(0, 8, 2)
+            )
+            new_y = tuple(
+                ctm[1] * corners2[i] + ctm[3] * corners2[i + 1] + ctm[5]
+                for i in range(0, 8, 2)
+            )
         else:
             new_x = corners2[0:8:2]
             new_y = corners2[1:8:2]
@@ -1338,13 +1390,17 @@ class PageObject(DictionaryObject):
             ctm = ctm.ctm
         self._merge_page(
             page2,
-            lambda page2_content: PageObject._add_transformation_matrix(page2_content, page2.pdf, ctm),
+            lambda page2_content: PageObject._add_transformation_matrix(
+                page2_content, page2.pdf, ctm
+            ),
             ctm,
             over,
             expand,
         )
 
-    def merge_scaled_page(self, page2: "PageObject", scale: float, over: bool = True, expand: bool = False) -> None:
+    def merge_scaled_page(
+        self, page2: "PageObject", scale: float, over: bool = True, expand: bool = False
+    ) -> None:
         """
         Similar to :meth:`~pypdf._page.PageObject.merge_page`, but the stream to be merged
         is scaled by applying a transformation matrix.
@@ -1444,8 +1500,14 @@ class PageObject(DictionaryObject):
             ]
 
             ctm = tuple(float(x) for x in ctm)  # type: ignore[assignment]
-            new_x = [ctm[0] * corners[i] + ctm[2] * corners[i + 1] + ctm[4] for i in range(0, 8, 2)]
-            new_y = [ctm[1] * corners[i] + ctm[3] * corners[i + 1] + ctm[5] for i in range(0, 8, 2)]
+            new_x = [
+                ctm[0] * corners[i] + ctm[2] * corners[i + 1] + ctm[4]
+                for i in range(0, 8, 2)
+            ]
+            new_y = [
+                ctm[1] * corners[i] + ctm[3] * corners[i + 1] + ctm[5]
+                for i in range(0, 8, 2)
+            ]
 
             self.mediabox.lower_left = (min(new_x), min(new_y))
             self.mediabox.upper_right = (max(new_x), max(new_y))
@@ -1545,7 +1607,9 @@ class PageObject(DictionaryObject):
                     content.indirect_reference.idnum - 1  # type: ignore
                 ] = content_obj
             except AttributeError:
-                if self.indirect_reference is not None and hasattr(self.indirect_reference.pdf, "_add_object"):
+                if self.indirect_reference is not None and hasattr(
+                    self.indirect_reference.pdf, "_add_object"
+                ):
                     self.replace_contents(content_obj)
                 else:
                     raise ValueError("Page must be part of a PdfWriter")
@@ -1569,7 +1633,9 @@ class PageObject(DictionaryObject):
 
     def _debug_for_extract(self) -> str:  # pragma: no cover
         out = ""
-        for ope, op in ContentStream(self["/Contents"].get_object(), self.pdf, "bytes").operations:
+        for ope, op in ContentStream(
+            self["/Contents"].get_object(), self.pdf, "bytes"
+        ).operations:
             if op == b"TJ":
                 s = [x for x in ope[0] if isinstance(x, str)]
             else:
@@ -1657,7 +1723,9 @@ class PageObject(DictionaryObject):
                     pass
 
         try:
-            content = obj[content_key].get_object() if isinstance(content_key, str) else obj
+            content = (
+                obj[content_key].get_object() if isinstance(content_key, str) else obj
+            )
             if not isinstance(content, ContentStream):
                 content = ContentStream(content, pdf, "bytes")
         except (AttributeError, KeyError):  # no content can be extracted (certainly empty page)
@@ -1689,7 +1757,9 @@ class PageObject(DictionaryObject):
                         if isinstance(op, (str, bytes)):
                             extractor.process_operation(b"Tj", [op])
                         if isinstance(op, (int, float, NumberObject, FloatObject)) and (
-                            abs(float(op)) >= _confirm_space_width and extractor.text and extractor.text[-1] != " "
+                            abs(float(op)) >= _confirm_space_width
+                            and extractor.text
+                            and extractor.text[-1] != " "
                         ):
                             extractor.process_operation(b"Tj", [" "])
             elif operator == b"TD":
@@ -1826,10 +1896,17 @@ class PageObject(DictionaryObject):
         if debug_path:  # pragma: no cover
             import json  # noqa: PLC0415
 
-            debug_path.joinpath("fonts.json").write_text(json.dumps(fonts, indent=2, default=asdict), "utf-8")
+            debug_path.joinpath("fonts.json").write_text(
+                json.dumps(fonts, indent=2, default=asdict),
+                "utf-8"
+            )
 
-        ops = iter(ContentStream(self["/Contents"].get_object(), self.pdf, "bytes").operations)
-        bt_groups = _layout_mode.text_show_operations(ops, fonts, strip_rotated, debug_path)
+        ops = iter(
+            ContentStream(self["/Contents"].get_object(), self.pdf, "bytes").operations
+        )
+        bt_groups = _layout_mode.text_show_operations(
+            ops, fonts, strip_rotated, debug_path
+        )
 
         if not bt_groups:
             return ""
@@ -1938,7 +2015,7 @@ class PageObject(DictionaryObject):
                 scale_weight=kwargs.get("layout_mode_scale_weight", 1.25),
                 strip_rotated=kwargs.get("layout_mode_strip_rotated", True),
                 debug_path=kwargs.get("layout_mode_debug_path"),
-                font_height_weight=kwargs.get("layout_mode_font_height_weight", 1),
+                font_height_weight=kwargs.get("layout_mode_font_height_weight", 1)
             )
         if len(args) >= 1:
             if isinstance(args[0], str):
@@ -2096,12 +2173,16 @@ class _VirtualList(Sequence[PageObject]):
         return self.length_function()
 
     @overload
-    def __getitem__(self, index: int) -> PageObject: ...
+    def __getitem__(self, index: int) -> PageObject:
+        ...
 
     @overload
-    def __getitem__(self, index: slice) -> Sequence[PageObject]: ...
+    def __getitem__(self, index: slice) -> Sequence[PageObject]:
+        ...
 
-    def __getitem__(self, index: Union[int, slice]) -> Union[PageObject, Sequence[PageObject]]:
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[PageObject, Sequence[PageObject]]:
         if isinstance(index, slice):
             indices = range(*index.indices(len(self)))
             cls = type(self)
@@ -2135,7 +2216,9 @@ class _VirtualList(Sequence[PageObject]):
             raise IndexError("Index out of range")
         ind = self[index].indirect_reference
         assert ind is not None
-        parent: Optional[PdfObject] = cast(DictionaryObject, ind.get_object()).get("/Parent", None)
+        parent: Optional[PdfObject] = cast(DictionaryObject, ind.get_object()).get(
+            "/Parent", None
+        )
         first = True
         while parent is not None:
             parent = cast(DictionaryObject, parent.get_object())
@@ -2149,7 +2232,9 @@ class _VirtualList(Sequence[PageObject]):
                 except Exception:  # pragma: no cover
                     pass
                 if "/Count" in parent:
-                    parent[NameObject("/Count")] = NumberObject(cast(int, parent["/Count"]) - 1)
+                    parent[NameObject("/Count")] = NumberObject(
+                        cast(int, parent["/Count"]) - 1
+                    )
                 if len(cast(ArrayObject, parent["/Kids"])) == 0:
                     # No more objects in this part of this subtree
                     ind = parent.indirect_reference
@@ -2202,7 +2287,12 @@ def _get_fonts_walk(
 
         if (
             ("/CharProcs" in f)
-            or ("/FontDescriptor" in f and any(x in cast(DictionaryObject, f["/FontDescriptor"]) for x in fontkeys))
+            or (
+                "/FontDescriptor" in f
+                and any(
+                    x in cast(DictionaryObject, f["/FontDescriptor"]) for x in fontkeys
+                )
+            )
             or (
                 "/DescendantFonts" in f
                 and "/FontDescriptor"
@@ -2234,16 +2324,25 @@ def _get_fonts_walk(
             process_font(f)
     if "/Resources" in obj:
         if "/Font" in cast(DictionaryObject, obj["/Resources"]):
-            for f in cast(DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/Font"]).values():
+            for f in cast(
+                DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/Font"]
+            ).values():
                 process_font(f)
         if "/XObject" in cast(DictionaryObject, obj["/Resources"]):
-            for x in cast(DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/XObject"]).values():
+            for x in cast(
+                DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/XObject"]
+            ).values():
                 _get_fonts_walk(cast(DictionaryObject, x.get_object()), fnt, emb)
     if "/Annots" in obj:
         for a in cast(ArrayObject, obj["/Annots"]):
             _get_fonts_walk(cast(DictionaryObject, a.get_object()), fnt, emb)
     if "/AP" in obj:
-        if cast(DictionaryObject, cast(DictionaryObject, obj["/AP"])["/N"]).get("/Type") == "/XObject":
+        if (
+            cast(DictionaryObject, cast(DictionaryObject, obj["/AP"])["/N"]).get(
+                "/Type"
+            )
+            == "/XObject"
+        ):
             _get_fonts_walk(
                 cast(DictionaryObject, cast(DictionaryObject, obj["/AP"])["/N"]),
                 fnt,

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -237,9 +237,7 @@ class Transformation:
         m = self.ctm
         return Transformation(ctm=(m[0], m[1], m[2], m[3], m[4] + tx, m[5] + ty))
 
-    def scale(
-        self, sx: Optional[float] = None, sy: Optional[float] = None
-    ) -> "Transformation":
+    def scale(self, sx: Optional[float] = None, sy: Optional[float] = None) -> "Transformation":
         """
         Scale the contents of a page towards the origin of the coordinate system.
 
@@ -290,14 +288,10 @@ class Transformation:
         return f"Transformation(ctm={self.ctm})"
 
     @overload
-    def apply_on(self, pt: list[float], as_object: bool = False) -> list[float]:
-        ...
+    def apply_on(self, pt: list[float], as_object: bool = False) -> list[float]: ...
 
     @overload
-    def apply_on(
-        self, pt: tuple[float, float], as_object: bool = False
-    ) -> tuple[float, float]:
-        ...
+    def apply_on(self, pt: tuple[float, float], as_object: bool = False) -> tuple[float, float]: ...
 
     def apply_on(
         self,
@@ -373,8 +367,7 @@ class ImageFile:
         """
         if pil_not_imported:
             raise ImportError(
-                "pillow is required to do image extraction. "
-                "It can be installed via 'pip install pypdf[image]'"
+                "pillow is required to do image extraction. It can be installed via 'pip install pypdf[image]'"
             )
 
         from ._reader import PdfReader  # noqa: PLC0415
@@ -395,9 +388,7 @@ class ImageFile:
         self.indirect_reference.pdf._objects[self.indirect_reference.idnum - 1] = (
             page_image.indirect_reference.get_object()
         )
-        cast(
-            PdfObject, self.indirect_reference.get_object()
-        ).indirect_reference = self.indirect_reference
+        cast(PdfObject, self.indirect_reference.get_object()).indirect_reference = self.indirect_reference
         # change the object attributes
         extension, byte_stream, img = _xobj_to_image(
             cast(DictionaryObject, self.indirect_reference.get_object()),
@@ -441,12 +432,10 @@ class VirtualListImages(Sequence[ImageFile]):
         return [(x, self[x]) for x in self.ids_function()]
 
     @overload
-    def __getitem__(self, index: Union[int, str, list[str]]) -> ImageFile:
-        ...
+    def __getitem__(self, index: Union[int, str, list[str]]) -> ImageFile: ...
 
     @overload
-    def __getitem__(self, index: slice) -> Sequence[ImageFile]:
-        ...
+    def __getitem__(self, index: slice) -> Sequence[ImageFile]: ...
 
     def __getitem__(
         self, index: Union[int, slice, str, list[str], tuple[str]]
@@ -522,9 +511,7 @@ class PageObject(DictionaryObject):
             Hash considering type and value.
 
         """
-        return hash(
-            (DictionaryObject, tuple(((k, v.hash_bin()) for k, v in self.items())))
-        )
+        return hash((DictionaryObject, tuple(((k, v.hash_bin()) for k, v in self.items()))))
 
     def hash_value_data(self) -> bytes:
         data = super().hash_value_data()
@@ -583,7 +570,8 @@ class PageObject(DictionaryObject):
             else:
                 raise PageSizeNotDefinedError
         page.__setitem__(
-            NameObject(PG.MEDIABOX), RectangleObject((0, 0, width, height))  # type: ignore
+            NameObject(PG.MEDIABOX),
+            RectangleObject((0, 0, width, height)),  # type: ignore
         )
 
         return page
@@ -608,9 +596,9 @@ class PageObject(DictionaryObject):
             ancest = []
         lst: list[Union[str, list[str]]] = []
         if (
-                PG.RESOURCES not in obj or
-                is_null_or_none(resources := obj[PG.RESOURCES]) or
-                RES.XOBJECT not in cast(DictionaryObject, resources)
+            PG.RESOURCES not in obj
+            or is_null_or_none(resources := obj[PG.RESOURCES])
+            or RES.XOBJECT not in cast(DictionaryObject, resources)
         ):
             return [] if self.inline_images is None else list(self.inline_images.keys())
 
@@ -637,10 +625,9 @@ class PageObject(DictionaryObject):
             id = list(id)
         if isinstance(id, list) and len(id) == 1:
             id = id[0]
+        xobjs: Optional[DictionaryObject] = None
         try:
-            xobjs = cast(
-                DictionaryObject, cast(DictionaryObject, obj[PG.RESOURCES])[RES.XOBJECT]
-            )
+            xobjs = cast(DictionaryObject, cast(DictionaryObject, obj[PG.RESOURCES])[RES.XOBJECT])
         except KeyError:
             if not (id[0] == "~" and id[-1] == "~"):
                 raise
@@ -652,7 +639,10 @@ class PageObject(DictionaryObject):
                     raise KeyError("No inline image can be found")
                 return self.inline_images[id]
 
+            if xobjs is None:  # pragma: no cover
+                raise KeyError(f"Cannot access image object {id} without XObject resources")
             from .generic._image_xobject import _xobj_to_image  # noqa: PLC0415
+
             imgd = _xobj_to_image(cast(DictionaryObject, xobjs[id]))
             extension, byte_stream = imgd[:2]
             return ImageFile(
@@ -662,6 +652,8 @@ class PageObject(DictionaryObject):
                 indirect_reference=xobjs[id].indirect_reference,
             )
         # in a subobject
+        if xobjs is None:  # pragma: no cover
+            raise KeyError(f"Cannot access image object {id} without XObject resources")
         ids = id[1:]
         return self._get_image(ids, cast(DictionaryObject, xobjs[id[0]]))
 
@@ -729,13 +721,10 @@ class PageObject(DictionaryObject):
         assert content is not None, "mypy"
         for param, ope in content.operations:
             if ope == b"INLINE IMAGE":
-                imgs_data.append(
-                    {"settings": param["settings"], "__streamdata__": param["data"]}
-                )
+                imgs_data.append({"settings": param["settings"], "__streamdata__": param["data"]})
             elif ope in (b"BI", b"EI", b"ID"):  # pragma: no cover
                 raise PdfReadError(
-                    f"{ope!r} operator met whereas not expected, "
-                    "please share use case with pypdf dev team"
+                    f"{ope!r} operator met whereas not expected, please share use case with pypdf dev team"
                 )
         files = {}
         for num, ii in enumerate(imgs_data):
@@ -747,9 +736,7 @@ class PageObject(DictionaryObject):
                 if k in {"/Length", "/L"}:  # no length is expected
                     continue
                 if isinstance(v, list):
-                    v = ArrayObject(
-                        [self._translate_value_inline_image(k, x) for x in v]
-                    )
+                    v = ArrayObject([self._translate_value_inline_image(k, x) for x in v])
                 else:
                     v = self._translate_value_inline_image(k, v)
                 k = NameObject(_INLINE_IMAGE_KEY_MAPPING[k])
@@ -757,6 +744,7 @@ class PageObject(DictionaryObject):
                     init[k] = v
             ii["object"] = EncodedStreamObject.initialize_from_dictionary(init)
             from .generic._image_xobject import _xobj_to_image  # noqa: PLC0415
+
             extension, byte_stream, img = _xobj_to_image(ii["object"])
             files[f"~{num}~"] = ImageFile(
                 name=f"~{num}~{extension}",
@@ -791,13 +779,7 @@ class PageObject(DictionaryObject):
         r = -self.rotation  # rotation to apply is in the otherway
         self.rotation = 0
         mb = RectangleObject(self.mediabox)
-        trsf = (
-            Transformation()
-            .translate(
-                -float(mb.left + mb.width / 2), -float(mb.bottom + mb.height / 2)
-            )
-            .rotate(r)
-        )
+        trsf = Transformation().translate(-float(mb.left + mb.width / 2), -float(mb.bottom + mb.height / 2)).rotate(r)
         pt1 = trsf.apply_on(mb.lower_left)
         pt2 = trsf.apply_on(mb.upper_right)
         trsf = trsf.translate(-min(pt1[0], pt2[0]), -min(pt1[1], pt2[1]))
@@ -842,9 +824,7 @@ class PageObject(DictionaryObject):
         try:
             assert isinstance(self.indirect_reference, IndirectObject)
             pdf = self.indirect_reference.pdf
-            is_pdf_writer = hasattr(
-                pdf, "_add_object"
-            )  # expect isinstance(pdf, PdfWriter)
+            is_pdf_writer = hasattr(pdf, "_add_object")  # expect isinstance(pdf, PdfWriter)
         except (AssertionError, AttributeError):
             pdf = None
             is_pdf_writer = False
@@ -887,9 +867,7 @@ class PageObject(DictionaryObject):
             new_res.update(res1.get(resource, DictionaryObject()).get_object())
         else:
             new_res = cast(DictionaryObject, res1[resource])
-        page2res = cast(
-            DictionaryObject, res2.get(resource, DictionaryObject()).get_object()
-        )
+        page2res = cast(DictionaryObject, res2.get(resource, DictionaryObject()).get_object())
         rename_res = {}
         for key in page2res:
             unique_key, same_value = compute_unique_key(key)
@@ -988,9 +966,7 @@ class PageObject(DictionaryObject):
             return ContentStream(resolved_object, pdf)
         return None
 
-    def replace_contents(
-        self, content: Union[None, ContentStream, EncodedStreamObject, ArrayObject]
-    ) -> None:
+    def replace_contents(self, content: Union[None, ContentStream, EncodedStreamObject, ArrayObject]) -> None:
         """
         Replace the page contents with the new content and nullify old objects
         Args:
@@ -1002,6 +978,7 @@ class PageObject(DictionaryObject):
             return
 
         from pypdf._writer import PdfWriter  # noqa: PLC0415
+
         if not isinstance(self.indirect_reference.pdf, PdfWriter):
             deprecate(
                 "Calling `PageObject.replace_contents()` for pages not assigned to a writer is deprecated "
@@ -1051,9 +1028,7 @@ class PageObject(DictionaryObject):
         # forces recalculation of inline_images
         self.inline_images = None
 
-    def merge_page(
-        self, page2: "PageObject", expand: bool = False, over: bool = True
-    ) -> None:
+    def merge_page(self, page2: "PageObject", expand: bool = False, over: bool = True) -> None:
         """
         Merge the content streams of two pages into one.
 
@@ -1086,12 +1061,8 @@ class PageObject(DictionaryObject):
         # rename.
         try:
             assert isinstance(self.indirect_reference, IndirectObject)
-            if hasattr(
-                self.indirect_reference.pdf, "_add_object"
-            ):  # to detect PdfWriter
-                return self._merge_page_writer(
-                    page2, page2transformation, ctm, over, expand
-                )
+            if hasattr(self.indirect_reference.pdf, "_add_object"):  # to detect PdfWriter
+                return self._merge_page_writer(page2, page2transformation, ctm, over, expand)
         except (AssertionError, AttributeError):
             pass
 
@@ -1116,9 +1087,7 @@ class PageObject(DictionaryObject):
             RES.SHADING,
             RES.PROPERTIES,
         ):
-            new, newrename = self._merge_resources(
-                original_resources, page2resources, res
-            )
+            new, newrename = self._merge_resources(original_resources, page2resources, res)
             if new:
                 new_resources[NameObject(res)] = new
                 rename.update(newrename)
@@ -1126,9 +1095,7 @@ class PageObject(DictionaryObject):
         # Combine /ProcSet sets, making sure there's a consistent order
         new_resources[NameObject(RES.PROC_SET)] = ArrayObject(
             sorted(
-                set(
-                    original_resources.get(RES.PROC_SET, ArrayObject()).get_object()
-                ).union(
+                set(original_resources.get(RES.PROC_SET, ArrayObject()).get_object()).union(
                     set(page2resources.get(RES.PROC_SET, ArrayObject()).get_object())
                 )
             )
@@ -1162,9 +1129,7 @@ class PageObject(DictionaryObject):
             page2content.operations.insert(2, ([], b"n"))
             if page2transformation is not None:
                 page2content = page2transformation(page2content)
-            page2content = PageObject._content_stream_rename(
-                page2content, rename, self.pdf
-            )
+            page2content = PageObject._content_stream_rename(page2content, rename, self.pdf)
             page2content.isolate_graphics_state()
             if over:
                 new_content_array.append(page2content)
@@ -1215,9 +1180,7 @@ class PageObject(DictionaryObject):
             if res in page2resources:
                 if res not in original_resources:
                     original_resources[NameObject(res)] = DictionaryObject()
-                _, newrename = self._merge_resources(
-                    original_resources, page2resources, res, False
-                )
+                _, newrename = self._merge_resources(original_resources, page2resources, res, False)
                 rename.update(newrename)
         # Combine /ProcSet sets.
         if RES.PROC_SET in page2resources:
@@ -1303,9 +1266,7 @@ class PageObject(DictionaryObject):
             page2content.operations.insert(2, ([], b"n"))
             if page2transformation is not None:
                 page2content = page2transformation(page2content)
-            page2content = PageObject._content_stream_rename(
-                page2content, rename, self.pdf
-            )
+            page2content = PageObject._content_stream_rename(page2content, rename, self.pdf)
             page2content.isolate_graphics_state()
             if over:
                 new_content_array.append(page2content)
@@ -1318,9 +1279,7 @@ class PageObject(DictionaryObject):
 
         self.replace_contents(new_content_array)
 
-    def _expand_mediabox(
-        self, page2: "PageObject", ctm: Optional[CompressedTransformationMatrix]
-    ) -> None:
+    def _expand_mediabox(self, page2: "PageObject", ctm: Optional[CompressedTransformationMatrix]) -> None:
         corners1 = (
             self.mediabox.left.as_numeric(),
             self.mediabox.bottom.as_numeric(),
@@ -1339,14 +1298,8 @@ class PageObject(DictionaryObject):
         )
         if ctm is not None:
             ctm = tuple(float(x) for x in ctm)  # type: ignore[assignment]
-            new_x = tuple(
-                ctm[0] * corners2[i] + ctm[2] * corners2[i + 1] + ctm[4]
-                for i in range(0, 8, 2)
-            )
-            new_y = tuple(
-                ctm[1] * corners2[i] + ctm[3] * corners2[i + 1] + ctm[5]
-                for i in range(0, 8, 2)
-            )
+            new_x = tuple(ctm[0] * corners2[i] + ctm[2] * corners2[i + 1] + ctm[4] for i in range(0, 8, 2))
+            new_y = tuple(ctm[1] * corners2[i] + ctm[3] * corners2[i + 1] + ctm[5] for i in range(0, 8, 2))
         else:
             new_x = corners2[0:8:2]
             new_y = corners2[1:8:2]
@@ -1385,17 +1338,13 @@ class PageObject(DictionaryObject):
             ctm = ctm.ctm
         self._merge_page(
             page2,
-            lambda page2_content: PageObject._add_transformation_matrix(
-                page2_content, page2.pdf, ctm
-            ),
+            lambda page2_content: PageObject._add_transformation_matrix(page2_content, page2.pdf, ctm),
             ctm,
             over,
             expand,
         )
 
-    def merge_scaled_page(
-        self, page2: "PageObject", scale: float, over: bool = True, expand: bool = False
-    ) -> None:
+    def merge_scaled_page(self, page2: "PageObject", scale: float, over: bool = True, expand: bool = False) -> None:
         """
         Similar to :meth:`~pypdf._page.PageObject.merge_page`, but the stream to be merged
         is scaled by applying a transformation matrix.
@@ -1495,14 +1444,8 @@ class PageObject(DictionaryObject):
             ]
 
             ctm = tuple(float(x) for x in ctm)  # type: ignore[assignment]
-            new_x = [
-                ctm[0] * corners[i] + ctm[2] * corners[i + 1] + ctm[4]
-                for i in range(0, 8, 2)
-            ]
-            new_y = [
-                ctm[1] * corners[i] + ctm[3] * corners[i + 1] + ctm[5]
-                for i in range(0, 8, 2)
-            ]
+            new_x = [ctm[0] * corners[i] + ctm[2] * corners[i + 1] + ctm[4] for i in range(0, 8, 2)]
+            new_y = [ctm[1] * corners[i] + ctm[3] * corners[i + 1] + ctm[5] for i in range(0, 8, 2)]
 
             self.mediabox.lower_left = (min(new_x), min(new_y))
             self.mediabox.upper_right = (max(new_x), max(new_y))
@@ -1602,9 +1545,7 @@ class PageObject(DictionaryObject):
                     content.indirect_reference.idnum - 1  # type: ignore
                 ] = content_obj
             except AttributeError:
-                if self.indirect_reference is not None and hasattr(
-                    self.indirect_reference.pdf, "_add_object"
-                ):
+                if self.indirect_reference is not None and hasattr(self.indirect_reference.pdf, "_add_object"):
                     self.replace_contents(content_obj)
                 else:
                     raise ValueError("Page must be part of a PdfWriter")
@@ -1628,9 +1569,7 @@ class PageObject(DictionaryObject):
 
     def _debug_for_extract(self) -> str:  # pragma: no cover
         out = ""
-        for ope, op in ContentStream(
-            self["/Contents"].get_object(), self.pdf, "bytes"
-        ).operations:
+        for ope, op in ContentStream(self["/Contents"].get_object(), self.pdf, "bytes").operations:
             if op == b"TJ":
                 s = [x for x in ope[0] if isinstance(x, str)]
             else:
@@ -1718,9 +1657,7 @@ class PageObject(DictionaryObject):
                     pass
 
         try:
-            content = (
-                obj[content_key].get_object() if isinstance(content_key, str) else obj
-            )
+            content = obj[content_key].get_object() if isinstance(content_key, str) else obj
             if not isinstance(content, ContentStream):
                 content = ContentStream(content, pdf, "bytes")
         except (AttributeError, KeyError):  # no content can be extracted (certainly empty page)
@@ -1752,9 +1689,7 @@ class PageObject(DictionaryObject):
                         if isinstance(op, (str, bytes)):
                             extractor.process_operation(b"Tj", [op])
                         if isinstance(op, (int, float, NumberObject, FloatObject)) and (
-                            abs(float(op)) >= _confirm_space_width
-                            and extractor.text
-                            and extractor.text[-1] != " "
+                            abs(float(op)) >= _confirm_space_width and extractor.text and extractor.text[-1] != " "
                         ):
                             extractor.process_operation(b"Tj", [" "])
             elif operator == b"TD":
@@ -1891,17 +1826,10 @@ class PageObject(DictionaryObject):
         if debug_path:  # pragma: no cover
             import json  # noqa: PLC0415
 
-            debug_path.joinpath("fonts.json").write_text(
-                json.dumps(fonts, indent=2, default=asdict),
-                "utf-8"
-            )
+            debug_path.joinpath("fonts.json").write_text(json.dumps(fonts, indent=2, default=asdict), "utf-8")
 
-        ops = iter(
-            ContentStream(self["/Contents"].get_object(), self.pdf, "bytes").operations
-        )
-        bt_groups = _layout_mode.text_show_operations(
-            ops, fonts, strip_rotated, debug_path
-        )
+        ops = iter(ContentStream(self["/Contents"].get_object(), self.pdf, "bytes").operations)
+        bt_groups = _layout_mode.text_show_operations(ops, fonts, strip_rotated, debug_path)
 
         if not bt_groups:
             return ""
@@ -2010,7 +1938,7 @@ class PageObject(DictionaryObject):
                 scale_weight=kwargs.get("layout_mode_scale_weight", 1.25),
                 strip_rotated=kwargs.get("layout_mode_strip_rotated", True),
                 debug_path=kwargs.get("layout_mode_debug_path"),
-                font_height_weight=kwargs.get("layout_mode_font_height_weight", 1)
+                font_height_weight=kwargs.get("layout_mode_font_height_weight", 1),
             )
         if len(args) >= 1:
             if isinstance(args[0], str):
@@ -2168,16 +2096,12 @@ class _VirtualList(Sequence[PageObject]):
         return self.length_function()
 
     @overload
-    def __getitem__(self, index: int) -> PageObject:
-        ...
+    def __getitem__(self, index: int) -> PageObject: ...
 
     @overload
-    def __getitem__(self, index: slice) -> Sequence[PageObject]:
-        ...
+    def __getitem__(self, index: slice) -> Sequence[PageObject]: ...
 
-    def __getitem__(
-        self, index: Union[int, slice]
-    ) -> Union[PageObject, Sequence[PageObject]]:
+    def __getitem__(self, index: Union[int, slice]) -> Union[PageObject, Sequence[PageObject]]:
         if isinstance(index, slice):
             indices = range(*index.indices(len(self)))
             cls = type(self)
@@ -2211,9 +2135,7 @@ class _VirtualList(Sequence[PageObject]):
             raise IndexError("Index out of range")
         ind = self[index].indirect_reference
         assert ind is not None
-        parent: Optional[PdfObject] = cast(DictionaryObject, ind.get_object()).get(
-            "/Parent", None
-        )
+        parent: Optional[PdfObject] = cast(DictionaryObject, ind.get_object()).get("/Parent", None)
         first = True
         while parent is not None:
             parent = cast(DictionaryObject, parent.get_object())
@@ -2227,9 +2149,7 @@ class _VirtualList(Sequence[PageObject]):
                 except Exception:  # pragma: no cover
                     pass
                 if "/Count" in parent:
-                    parent[NameObject("/Count")] = NumberObject(
-                        cast(int, parent["/Count"]) - 1
-                    )
+                    parent[NameObject("/Count")] = NumberObject(cast(int, parent["/Count"]) - 1)
                 if len(cast(ArrayObject, parent["/Kids"])) == 0:
                     # No more objects in this part of this subtree
                     ind = parent.indirect_reference
@@ -2282,12 +2202,7 @@ def _get_fonts_walk(
 
         if (
             ("/CharProcs" in f)
-            or (
-                "/FontDescriptor" in f
-                and any(
-                    x in cast(DictionaryObject, f["/FontDescriptor"]) for x in fontkeys
-                )
-            )
+            or ("/FontDescriptor" in f and any(x in cast(DictionaryObject, f["/FontDescriptor"]) for x in fontkeys))
             or (
                 "/DescendantFonts" in f
                 and "/FontDescriptor"
@@ -2319,25 +2234,16 @@ def _get_fonts_walk(
             process_font(f)
     if "/Resources" in obj:
         if "/Font" in cast(DictionaryObject, obj["/Resources"]):
-            for f in cast(
-                DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/Font"]
-            ).values():
+            for f in cast(DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/Font"]).values():
                 process_font(f)
         if "/XObject" in cast(DictionaryObject, obj["/Resources"]):
-            for x in cast(
-                DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/XObject"]
-            ).values():
+            for x in cast(DictionaryObject, cast(DictionaryObject, obj["/Resources"])["/XObject"]).values():
                 _get_fonts_walk(cast(DictionaryObject, x.get_object()), fnt, emb)
     if "/Annots" in obj:
         for a in cast(ArrayObject, obj["/Annots"]):
             _get_fonts_walk(cast(DictionaryObject, a.get_object()), fnt, emb)
     if "/AP" in obj:
-        if (
-            cast(DictionaryObject, cast(DictionaryObject, obj["/AP"])["/N"]).get(
-                "/Type"
-            )
-            == "/XObject"
-        ):
+        if cast(DictionaryObject, cast(DictionaryObject, obj["/AP"])["/N"]).get("/Type") == "/XObject":
             _get_fonts_walk(
                 cast(DictionaryObject, cast(DictionaryObject, obj["/AP"])["/N"]),
                 fnt,

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -642,9 +642,11 @@ class PageObject(DictionaryObject):
             xobjs = cast(
                 DictionaryObject, cast(DictionaryObject, obj[PG.RESOURCES])[RES.XOBJECT]
             )
-        except KeyError:
+        except KeyError as exc:
             if not (id[0] == "~" and id[-1] == "~"):
-                raise
+                raise KeyError(
+                    f"Cannot access image object {id} without XObject resources"
+                ) from exc
         if isinstance(id, str):
             if id[0] == "~" and id[-1] == "~":
                 if self.inline_images is None:
@@ -653,8 +655,7 @@ class PageObject(DictionaryObject):
                     raise KeyError("No inline image can be found")
                 return self.inline_images[id]
 
-            if xobjs is None:
-                raise KeyError(f"Cannot access image object {id} without XObject resources")
+            assert xobjs is not None
             from .generic._image_xobject import _xobj_to_image  # noqa: PLC0415
             imgd = _xobj_to_image(cast(DictionaryObject, xobjs[id]))
             extension, byte_stream = imgd[:2]
@@ -665,8 +666,7 @@ class PageObject(DictionaryObject):
                 indirect_reference=xobjs[id].indirect_reference,
             )
         # in a subobject
-        if xobjs is None:  # pragma: no cover
-            raise KeyError(f"Cannot access image object {id} without XObject resources")
+        assert xobjs is not None
         ids = id[1:]
         return self._get_image(ids, cast(DictionaryObject, xobjs[id[0]]))
 

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -649,11 +649,11 @@ class PageObject(DictionaryObject):
             if id[0] == "~" and id[-1] == "~":
                 if self.inline_images is None:
                     self.inline_images = self._get_inline_images()
-                if self.inline_images is None:  # pragma: no cover
+                if self.inline_images is None:
                     raise KeyError("No inline image can be found")
                 return self.inline_images[id]
 
-            if xobjs is None:  # pragma: no cover
+            if xobjs is None:
                 raise KeyError(f"Cannot access image object {id} without XObject resources")
             from .generic._image_xobject import _xobj_to_image  # noqa: PLC0415
             imgd = _xobj_to_image(cast(DictionaryObject, xobjs[id]))

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -235,6 +235,24 @@ def test_get_inline_image_without_xobject_resources():
         assert page._get_image("~0~") is inline_image
 
 
+def test_get_inline_image_without_xobject_resources_raises_when_missing():
+    page = PageObject(None, None)
+
+    with mock.patch.object(page, "_get_inline_images", return_value=None):
+        with pytest.raises(KeyError, match="No inline image can be found"):
+            page._get_image("~0~")
+
+
+def test_get_xobject_image_without_xobject_resources_raises():
+    page = PageObject(None, None)
+
+    with pytest.raises(
+        KeyError,
+        match="Cannot access image object /Im0 without XObject resources",
+    ):
+        page._get_image("/Im0")
+
+
 @pytest.mark.enable_socket
 @pytest.mark.timeout(30)
 def test_loop_in_image_keys():

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -227,6 +227,14 @@ def test_image_extraction(src, page_index, image_key, expected):
     assert image_similarity(BytesIO(actual_image.data), expected) >= 0.99
 
 
+def test_get_inline_image_without_xobject_resources():
+    page = PageObject(None, None)
+    inline_image = mock.sentinel.inline_image
+
+    with mock.patch.object(page, "_get_inline_images", return_value={"~0~": inline_image}):
+        assert page._get_image("~0~") is inline_image
+
+
 @pytest.mark.enable_socket
 @pytest.mark.timeout(30)
 def test_loop_in_image_keys():

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -238,9 +238,11 @@ def test_get_inline_image_without_xobject_resources():
 def test_get_inline_image_without_xobject_resources_raises_when_missing():
     page = PageObject(None, None)
 
-    with mock.patch.object(page, "_get_inline_images", return_value=None):
-        with pytest.raises(KeyError, match="No inline image can be found"):
-            page._get_image("~0~")
+    with (
+        mock.patch.object(page, "_get_inline_images", return_value=None),
+        pytest.raises(KeyError, match="No inline image can be found"),
+    ):
+        page._get_image("~0~")
 
 
 def test_get_xobject_image_without_xobject_resources_raises():

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -229,7 +229,7 @@ def test_image_extraction(src, page_index, image_key, expected):
 
 def test_get_inline_image_without_xobject_resources():
     page = PageObject(None, None)
-    inline_image = mock.sentinel.inline_image
+    inline_image = object()
 
     with mock.patch.object(page, "_get_inline_images", return_value={"~0~": inline_image}):
         assert page._get_image("~0~") is inline_image


### PR DESCRIPTION
## Description

Fixes a potential `UnboundLocalError` in the `_get_image()` method of `pypdf/_page.py`.

### The Bug

In `pypdf/_page.py`, the `_get_image()` method uses a `try-except` block to retrieve XObject resources:

```python
try:
    xobjs = cast(
        DictionaryObject, cast(DictionaryObject, obj[PG.RESOURCES])[RES.XOBJECT]
    )
except KeyError:
    if not (id[0] == "~" and id[-1] == "~"):
        raise
# Later...
imgd = _xobj_to_image(cast(DictionaryObject, xobjs[id]))  # BUG: xobjs may be unbound!
```

If a `KeyError` is raised (no XObject resources) but the `id` starts and ends with `~` (indicating an inline image), the exception is silently caught and the code continues. However, for non-inline images, the subsequent code tries to access `xobjs`, which was never assigned, causing `UnboundLocalError: local variable 'xobjs' referenced before assignment`.

### The Fix

Initialize `xobjs = None` before the `try` block and add explicit checks before using it:

```python
xobjs: Optional[DictionaryObject] = None
try:
    xobjs = cast(...)
except KeyError:
    if not (id[0] == "~" and id[-1] == "~"):
        raise

# Later...
if xobjs is None:
    raise KeyError(f"Cannot access image object {id} without XObject resources")
imgd = _xobj_to_image(cast(DictionaryObject, xobjs[id]))
```

This ensures that if `xobjs` is `None`, we raise a clear `KeyError` instead of crashing with an `UnboundLocalError`.

### Testing

The fix maintains backward compatibility:
- Inline images (id like `~0~`) continue to work without XObject resources
- Non-inline images properly raise `KeyError` if XObject resources are missing