### PR TITLE
DEV: Remove unused reverse encoding dicts

### DIFF
--- a/pypdf/_codecs/__init__.py
+++ b/pypdf/_codecs/__init__.py
@@ -30,10 +30,6 @@ _win_encoding = fill_from_encoding("cp1252")
 _mac_encoding = fill_from_encoding("mac_roman")
 
 
-_win_encoding_rev: dict[str, int] = rev_encoding(_win_encoding)
-_mac_encoding_rev: dict[str, int] = rev_encoding(_mac_encoding)
-_symbol_encoding_rev: dict[str, int] = rev_encoding(_symbol_encoding)
-_zapfding_encoding_rev: dict[str, int] = rev_encoding(_zapfding_encoding)
 _pdfdoc_encoding_rev: dict[str, int] = rev_encoding(_pdfdoc_encoding)
 
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -536,6 +536,14 @@ class CheckboxRadioButtonAttributes:
         }
 
 
+class FieldFlag(IntFlag):
+    """Table 8.70 Field flags common to all field types."""
+
+    READ_ONLY = 1
+    REQUIRED = 2
+    NO_EXPORT = 4
+
+
 class DocumentInformationAttributes:
     """Table 10.2 Entries in the document information dictionary."""
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -536,14 +536,6 @@ class CheckboxRadioButtonAttributes:
         }
 
 
-class FieldFlag(IntFlag):
-    """Table 8.70 Field flags common to all field types."""
-
-    READ_ONLY = 1
-    REQUIRED = 2
-    NO_EXPORT = 4
-
-
 class DocumentInformationAttributes:
     """Table 10.2 Entries in the document information dictionary."""
 


### PR DESCRIPTION
## Summary
- Removed 5 unused symbols identified via static analysis using [Skylos](https://github.com/duriantaco/skylos) (zero references across entire codebase)
- 2 files changed, 12 deletions, 0 additions

## Changes

| Symbol | File | Reason |
|--------|------|--------|
| `FieldFlag` | `pypdf/constants.py` | IntFlag class (Table 8.70) never used or imported anywhere |
| `_win_encoding_rev` | `pypdf/_codecs/__init__.py` | Reverse encoding dict never referenced, not in `__all__` |
| `_mac_encoding_rev` | `pypdf/_codecs/__init__.py` | Reverse encoding dict never referenced, not in `__all__` |
| `_symbol_encoding_rev` | `pypdf/_codecs/__init__.py` | Reverse encoding dict never referenced, not in `__all__` |
| `_zapfding_encoding_rev` | `pypdf/_codecs/__init__.py` | Reverse encoding dict never referenced, not in `__all__` |

`_pdfdoc_encoding_rev` is kept — it is used in `generic/_base.py` and exported in `__all__`.

## Test plan
- [x] Each symbol has zero references in the entire repo (confirmed via grep)
- [x] No imports broken

Found with [Skylos](https://github.com/duriantaco/skylos) — dead code detection for Python.