### PR TITLE
BUG: Fix compress_identical_objects ignoring remove_orphans parameter

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1646,17 +1646,18 @@ class PdfWriter(PdfDocCommon):
                 replace_in_obj(obj, cnv_rev)
 
         # remove orphans (if applicable)
-        orphans[self.root_object.indirect_reference.idnum - 1] = False  # type: ignore
+        if remove_orphans:
+            orphans[self.root_object.indirect_reference.idnum - 1] = False  # type: ignore
 
-        if not is_null_or_none(self._info):
-            orphans[self._info.indirect_reference.idnum - 1] = False  # type: ignore
+            if not is_null_or_none(self._info):
+                orphans[self._info.indirect_reference.idnum - 1] = False  # type: ignore
 
-        try:
-            orphans[self._ID.indirect_reference.idnum - 1] = False  # type: ignore
-        except AttributeError:
-            pass
-        for i in compress(range(len(self._objects)), orphans):
-            self._objects[i] = None
+            try:
+                orphans[self._ID.indirect_reference.idnum - 1] = False  # type: ignore
+            except AttributeError:
+                pass
+            for i in compress(range(len(self._objects)), orphans):
+                self._objects[i] = None
 
     def get_reference(self, obj: PdfObject) -> IndirectObject:
         idnum = self._objects.index(obj) + 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2568,6 +2568,25 @@ def test_compress_identical_objects():
     assert len(out2.getvalue()) > len(out3.getvalue())
 
 
+def test_compress_identical_objects_remove_orphans_parameter():
+    """Cf #3306 - remove_orphans parameter was ignored."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    # Add an orphan object (not referenced by anything)
+    from pypdf.generic import DictionaryObject, NameObject
+
+    orphan = DictionaryObject({NameObject("/Type"): NameObject("/Test")})
+    writer._add_object(orphan)
+    num_objects_before = len(writer._objects)
+    # With remove_orphans=False, orphan objects should be kept
+    writer.compress_identical_objects(remove_orphans=False)
+    num_objects_no_remove = sum(1 for o in writer._objects if o is not None)
+    # With remove_orphans=True, orphan objects should be removed
+    writer.compress_identical_objects(remove_orphans=True)
+    num_objects_with_remove = sum(1 for o in writer._objects if o is not None)
+    assert num_objects_no_remove > num_objects_with_remove
+
+
 def test_set_need_appearances_writer():
     """Minimal test for coverage"""
     writer = PdfWriter()


### PR DESCRIPTION
## Description

Fixes #3306

The `remove_orphans` parameter in `PdfWriter.compress_identical_objects()` was accepted but never checked, causing orphan objects to always be removed regardless of the parameter value.

## Changes

- **pypdf/_writer.py**: Wrapped the orphan-removal block with `if remove_orphans:` check
- **tests/test_writer.py**: Added test verifying `remove_orphans=False` preserves orphan objects and `remove_orphans=True` removes them

## Verification

```python
# Before fix: remove_orphans=False still removed orphans (5 -> 4 objects)
# After fix: remove_orphans=False preserves orphans (5 objects kept)
```
