### PR TITLE
SEC: Avoid infinite loop in read_from_stream for broken files

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -501,7 +501,7 @@ class PdfReader(PdfDocCommon):
 
             current_object = (indirect_reference.idnum, indirect_reference.generation)
             if current_object in self._known_objects:
-                raise PdfReadError(f"Detected loop with self reference for {indirect_reference!r}.")
+                raise LimitReachedError(f"Detected loop with self reference for {indirect_reference!r}.")
             self._known_objects.add(current_object)
             retval = read_object(self.stream, self)  # type: ignore
             self._known_objects.remove(current_object)

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -594,6 +594,8 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 tok = read_non_whitespace(stream)
                 stream.seek(-1, 1)
                 value = read_object(stream, pdf, forced_encoding)
+            except (RecursionError, LimitReachedError) as exc:
+                raise PdfReadError(exc.__repr__())
             except Exception as exc:
                 if pdf is not None and pdf.strict:
                     raise PdfReadError(exc.__repr__())

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -9,7 +9,7 @@ from typing import Callable
 import pytest
 
 from pypdf import PdfReader, PdfWriter
-from pypdf.errors import LimitReachedError
+from pypdf.errors import LimitReachedError, PdfReadError
 from pypdf.generic import (
     ArrayObject,
     ContentStream,
@@ -265,3 +265,22 @@ def test_content_stream__array_based__output_length():
             match=r"^Array\-based stream has at least 75003501 > 75000000 output bytes\.$"
     ):
         _ = reader.pages[0].get_contents()
+
+
+@pytest.mark.timeout(5)
+def test_dictionary_object__read_from_stream__infinite_loop(caplog):
+    data = b"""1 0 obj
+<<
+<</Length 1 0 R>>
+stream
+trailer
+<< /Size 1 >>
+startxref
+0
+%%EOF
+"""
+    buffer = BytesIO(data)
+
+    reader = PdfReader(buffer, strict=False)
+    with pytest.raises(expected_exception=PdfReadError, match=r"^Cannot find Root object in pdf$"):
+        assert len(reader.pages) == 0

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1888,7 +1888,9 @@ def test_infinite_loop_for_length_value():
 
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     writer = PdfWriter()
-    with pytest.raises(PdfReadError, match=r"^Detected loop with self reference for IndirectObject\(165, 0, \d+\)\.$"):
+    with pytest.raises(
+            LimitReachedError, match=r"^Detected loop with self reference for IndirectObject\(165, 0, \d+\)\.$"
+    ):
         writer.add_page(reader.pages[0])
 
 


### PR DESCRIPTION
This only affects the non-strict mode and is triggered for errors which should always trigger a hard error, id est recursion and filter limit errors.