### PR TITLE
ENH: Skip MD5 key derivation for AES-256 encrypted PDFs

### DIFF
--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -903,7 +903,11 @@ class Encryption:
            16-byte random number that is stored as the first 16 bytes of the
            encrypted stream or string.
 
-        Algorithm 3.1a Encryption of data using the AES algorithm
+        Algorithm 3.1a: Encryption of data using the AES-256 algorithm.
+
+        Note: Algorithm 3.1a does not use MD5 key derivation, so AES-256
+        encrypted files can be read on FIPS-enabled systems where MD5 is blocked.
+
         1. Use the 32-byte file encryption key for the AES-256 symmetric key
            algorithm, along with the string or stream data to be encrypted.
            Use the AES algorithm in Cipher Block Chaining (CBC) mode, which
@@ -917,14 +921,20 @@ class Encryption:
 
         assert self._key
         key = self._key
-        n = 5 if self.V == 1 else self.Length // 8
-        key_data = key[:n] + pack1 + pack2
-        key_hash = hashlib.md5(key_data)
-        rc4_key = key_hash.digest()[: min(n + 5, 16)]
 
-        # for AES-128
-        key_hash.update(b"sAlT")
-        aes128_key = key_hash.digest()[: min(n + 5, 16)]
+        # Algorithm 1 (V <= 4): MD5 key derivation. Algorithm 3.1a (V >= 5): key used directly.
+        if self.V <= 4:
+            n = 5 if self.V == 1 else self.Length // 8
+            key_data = key[:n] + pack1 + pack2
+            key_hash = hashlib.md5(key_data)
+            rc4_key = key_hash.digest()[: min(n + 5, 16)]
+
+            # for AES-128
+            key_hash.update(b"sAlT")
+            aes128_key = key_hash.digest()[: min(n + 5, 16)]
+        else:
+            rc4_key = b""
+            aes128_key = b""
 
         # for AES-256
         aes256_key = key

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,6 +1,8 @@
 """Test the pypdf._encryption module."""
+import hashlib
 import secrets
 from io import BytesIO
+from typing import NoReturn
 
 import pytest
 
@@ -437,3 +439,22 @@ def test_are_permissions_valid_false_when_tampered():
     reader = PdfReader(tampered)
     reader.decrypt("user")
     assert reader.are_permissions_valid is False
+
+
+@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
+def test_aes256_decrypt_does_not_call_md5(monkeypatch):
+    """AES-256 decryption must not call hashlib.md5().
+
+    On FIPS-enabled systems hashlib.md5() raises an error, so reading an AES-256
+    PDF must succeed even when MD5 is blocked.
+    """
+    def _fips_md5(*args: object, **kwargs: object) -> NoReturn:
+        raise ValueError("[digital envelope routines] unsupported: md5 blocked by FIPS")
+
+    monkeypatch.setattr(hashlib, "md5", _fips_md5)
+
+    reader = PdfReader(RESOURCE_ROOT / "encryption" / "r6-empty-password.pdf")
+    result = reader.decrypt("")
+    assert result != PasswordType.NOT_DECRYPTED
+    assert len(reader.pages) > 0
+    reader.pages[0].extract_text()


### PR DESCRIPTION
For V>=5 PDFs, the encryption key is used directly without MD5. MD5 computation in _make_crypt_filter() only runs for V<=4, allowing AES-256 encrypted PDFs to be read on FIPS-enabled systems where hashlib.md5() is blocked.

RC4 and AES-128 encrypted PDFs will still correctly fail on FIPS systems, as their key requires MD5.