### PR TITLE
BUG: Fix PdfReadError when xref table contains comments before trailer

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -889,6 +889,15 @@ class PdfReader(PdfDocCommon):
                 num += 1
             read_non_whitespace(stream)
             stream.seek(-1, 1)
+            # Skip any PDF comments between xref entries and the trailer
+            # keyword. Some PDF producers (e.g. Vectorizer.AI) insert
+            # comments here which are legal per the PDF spec (§7.2.3).
+            while stream.read(1) == b"%":
+                stream.seek(-1, 1)
+                skip_over_comment(stream)
+                read_non_whitespace(stream)
+                stream.seek(-1, 1)
+            stream.seek(-1, 1)
             trailer_tag = stream.read(7)
             if trailer_tag != b"trailer":
                 # more xrefs!

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2150,3 +2150,38 @@ def test_objstm_does_not_cache_stale_objects_from_non_authoritative_stream():
     # obj 6 must reflect the authoritative version from stream 7.
     field = reader.get_object(6)
     assert field["/V"] == "42"
+
+
+def test_xref_table_with_comments_before_trailer():
+    """Comments between xref entries and trailer are legal per PDF spec §7.2.3.
+
+    Some PDF producers (e.g. Vectorizer.AI) insert human-readable comments
+    between the last xref entry and the ``trailer`` keyword.  pypdf must skip
+    these instead of crashing with ``PdfReadError: Could not read Boolean
+    object``.
+    """
+    pdf_data = (
+        b"%%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Count 1 /Kids [3 0 R] >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /MediaBox [0 0 100 100] /Parent 2 0 R >>\nendobj\n"
+        b"xref\n"
+        b"0 4\n"
+        b"0000000000 65535 f \n"
+        b"%010d 00000 n \n"
+        b"%010d 00000 n \n"
+        b"%010d 00000 n \n"
+        b"%% This is a legal PDF comment\n"
+        b"%% And another one\n"
+        b"trailer\n<< /Size 4 /Root 1 0 R >>\n"
+        b"startxref\n%d\n"
+        b"%%%%EOF\n"
+    )
+    pdf_data = pdf_data % (
+        pdf_data.find(b"1 0 obj") - 1,
+        pdf_data.find(b"2 0 obj") - 1,
+        pdf_data.find(b"3 0 obj") - 1,
+        pdf_data.find(b"xref") - 1,
+    )
+    reader = PdfReader(BytesIO(pdf_data))
+    assert len(reader.pages) == 1


### PR DESCRIPTION
Closes #3709.

## Summary

- Skip PDF comments (`%` to EOL) between xref table entries and the `trailer` keyword in `_read_standard_xref_table`
- Some PDF producers (e.g. Vectorizer.AI) insert comments at this position, which is legal per PDF spec §7.2.3
- Previously this caused `PdfReadError: Could not read Boolean object` because `read_non_whitespace()` stops at `%` and the parser misinterprets `trailer` as a boolean token

## Changes

- **`pypdf/_reader.py`**: Added a loop after reading xref entries that calls `skip_over_comment()` to consume any comment lines before checking for the `trailer` tag
- **`tests/test_reader.py`**: Added `test_xref_table_with_comments_before_trailer` with an inline minimal PDF reproducer containing comment lines between xref entries and trailer

## Test plan

- [x] New test `test_xref_table_with_comments_before_trailer` passes
- [x] All 13 existing xref-related tests pass without regression