### PR TITLE
Security: CI URL checker performs unrestricted outbound fetches from repository-controlled strings (SSRF risk)

### DIFF
--- a/.github/scripts/check_urls.py
+++ b/.github/scripts/check_urls.py
@@ -1,11 +1,16 @@
 """Check that all test data URLs are still accessible."""  # noqa: INP001
 import ast
+import ipaddress
+import socket
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections.abc import Iterator
 from operator import itemgetter
 from pathlib import Path
 
-from tests import _get_data_from_url, read_yaml_to_list_of_dicts
+from tests import read_yaml_to_list_of_dicts
 
 URL_PREFIXES_TO_IGNORE = (
     "http://ns.adobe.com/tiff/1.0/",
@@ -19,6 +24,70 @@ URL_PREFIXES_TO_IGNORE = (
 PDF_URLS_WHICH_DO_NOT_LOOK_LIKE_PDFS = {
     "https://github.com/user-attachments/files/18381726/tika-957721.pdf",
 }
+
+ALLOWED_URL_HOSTS = (
+    "example.com",
+    "github.com",
+    "githubusercontent.com",
+    "martin-thoma.com",
+    "ns.adobe.com",
+    "pypdf.readthedocs.io",
+)
+
+
+def _is_allowed_host(host: str) -> bool:
+    return any(
+        host == allowed_host or host.endswith(f".{allowed_host}") for allowed_host in ALLOWED_URL_HOSTS
+    )
+
+
+def _resolves_to_public_ip(host: str) -> bool:
+    try:
+        addresses = {info[4][0] for info in socket.getaddrinfo(host, None)}
+    except socket.gaierror:
+        return False
+
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if (
+            ip.is_loopback
+            or ip.is_link_local
+            or ip.is_private
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return False
+    return True
+
+
+def _is_allowed_url(url: str) -> bool:
+    parsed_url = urllib.parse.urlsplit(url)
+    if parsed_url.scheme not in {"http", "https"} or not parsed_url.hostname:
+        return False
+
+    host = parsed_url.hostname.lower()
+    return _is_allowed_host(host) and _resolves_to_public_ip(host)
+
+
+class _SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        redirect_url = urllib.parse.urljoin(req.full_url, newurl)
+        if not _is_allowed_url(redirect_url):
+            raise urllib.error.HTTPError(redirect_url, code, "Blocked redirect target", headers, fp)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_URL_OPENER = urllib.request.build_opener(_SafeRedirectHandler())
+
+
+def _get_data_from_url(url: str) -> bytes:
+    if not _is_allowed_url(url):
+        raise ValueError("URL host is not allowed")
+
+    request = urllib.request.Request(url, headers={"User-Agent": "pypdf-url-checker"})
+    with _URL_OPENER.open(request, timeout=10) as response:
+        return response.read()
 
 
 def get_urls_from_test_files() -> Iterator[str]:
@@ -54,7 +123,7 @@ def check_url(url: str) -> bool:
         return False
 
     if len(data) < 75:
-        sys.stderr.write(f"Not enough data from {url}: {data}\n")
+        sys.stderr.write(f"Not enough data from {url}: {len(data)} bytes\n")
         return False
 
     if (
@@ -62,7 +131,7 @@ def check_url(url: str) -> bool:
             url not in PDF_URLS_WHICH_DO_NOT_LOOK_LIKE_PDFS and
             not data.startswith(b"%PDF-")
     ):
-        sys.stderr.write(f"The file at {url} does not look like a PDF: {data[:50]}\n")
+        sys.stderr.write(f"The file at {url} does not look like a PDF.\n")
         return False
 
     sys.stdout.write(f"URL {url} looks good.\n")


### PR DESCRIPTION
## Problem

The script extracts every `http://`/`https://` string constant from tests and fetches each URL without an allowlist or private-network blocking. A malicious contribution can add internal endpoints (e.g., localhost/metadata services), causing CI to probe internal services. Error paths also print response bytes, which can leak fetched internal data into logs.

**Severity**: `medium`
**File**: `.github/scripts/check_urls.py`

## Solution

Enforce a strict domain allowlist, block private/loopback/link-local IP ranges after DNS resolution, disable redirects to untrusted hosts, and avoid logging raw response bodies.

## Changes

- `.github/scripts/check_urls.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
