### PR TITLE
Security: URLs Constructed from Parsed HTML Content Used in HTTP Requests

### DIFF
--- a/.github/scripts/check_gh_pages_updates.py
+++ b/.github/scripts/check_gh_pages_updates.py
@@ -76,6 +76,10 @@ def main() -> None:
                 f"@{current_version}/", f"@{latest_version}/"
             )
 
+            if not latest_url.startswith("https://cdn.jsdelivr.net/"):
+                sys.stdout.write(f"  ⚠️  {pkg}: unexpected URL domain, skipping\n")
+                continue
+
             try:
                 latest_bytes = fetch_bytes(latest_url)
                 latest_sri = sri_hash(latest_bytes)


### PR DESCRIPTION
## Problem

In `check_gh_pages_updates.py`, URLs are extracted from HTML files using a regex (`JSDELIVR_RE`), then manipulated (version string replaced) and passed to `urllib.request.urlopen` via `fetch_bytes`. If an attacker can inject content into the scanned HTML files (e.g., via a compromised GitHub Pages deployment), they could craft URLs that trigger requests to arbitrary hosts, potentially enabling SSRF.

**Severity**: `medium`
**File**: `.github/scripts/check_gh_pages_updates.py`

## Solution

Validate that constructed URLs still match the expected `cdn.jsdelivr.net` domain before making requests. Add an explicit domain check: `assert url.startswith('https://cdn.jsdelivr.net/')` before calling `fetch_bytes`.

## Changes

- `.github/scripts/check_gh_pages_updates.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
