### PR TITLE
Security: Use of Deprecated RC4 and ECB Mode Ciphers

### DIFF
--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -86,21 +86,25 @@ class CryptAES(CryptBase):
 
 
 def rc4_encrypt(key: bytes, data: bytes) -> bytes:
+    """RC4 encryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     encryptor = Cipher(ARC4(key), mode=None).encryptor()
     return encryptor.update(data) + encryptor.finalize()
 
 
 def rc4_decrypt(key: bytes, data: bytes) -> bytes:
+    """RC4 decryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     decryptor = Cipher(ARC4(key), mode=None).decryptor()
     return decryptor.update(data) + decryptor.finalize()
 
 
 def aes_ecb_encrypt(key: bytes, data: bytes) -> bytes:
+    """AES-ECB encryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     encryptor = Cipher(AES(key), mode=ECB()).encryptor()
     return encryptor.update(data) + encryptor.finalize()
 
 
 def aes_ecb_decrypt(key: bytes, data: bytes) -> bytes:
+    """AES-ECB decryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     decryptor = Cipher(AES(key), mode=ECB()).decryptor()
     return decryptor.update(data) + decryptor.finalize()
 

--- a/pypdf/_crypt_providers/_fallback.py
+++ b/pypdf/_crypt_providers/_fallback.py
@@ -70,14 +70,17 @@ class CryptAES(CryptBase):
 
 
 def rc4_encrypt(key: bytes, data: bytes) -> bytes:
+    """RC4 encryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     return CryptRC4(key).encrypt(data)
 
 
 def rc4_decrypt(key: bytes, data: bytes) -> bytes:
+    """RC4 decryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     return CryptRC4(key).decrypt(data)
 
 
 def aes_ecb_encrypt(key: bytes, data: bytes) -> bytes:
+    """AES-ECB encryption. *Legacy PDF compatibility only – do not use for new cryptographic purposes.*"""
     raise DependencyError(_DEPENDENCY_ERROR_STR)
 
 


### PR DESCRIPTION
## Problem

The cryptography providers expose `rc4_encrypt`/`rc4_decrypt` (RC4 is broken) and `aes_ecb_encrypt`/`aes_ecb_decrypt` (ECB mode lacks diffusion and leaks patterns). While these are required for PDF format compatibility with older encryption standards, their availability as general-purpose functions could lead to misuse.

**Severity**: `low`
**File**: `pypdf/_crypt_providers/_cryptography.py`

## Solution

Add deprecation warnings or documentation comments clearly marking these functions as legacy PDF compatibility only. Consider restricting their visibility or adding warnings when they are invoked.

## Changes

- `pypdf/_crypt_providers/_cryptography.py` (modified)
- `pypdf/_crypt_providers/_fallback.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
