### PR TITLE
SEC: Disallow custom XML entity declarations for XMP metadata

### DIFF
--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -15,9 +15,10 @@ from typing import (
     TypeVar,
     Union,
 )
-from xml.dom.minidom import Document, parseString
+from xml.dom.expatbuilder import ExpatBuilderNS
+from xml.dom.minidom import Document
 from xml.dom.minidom import Element as XmlElement
-from xml.parsers.expat import ExpatError
+from xml.parsers.expat import ExpatError, XMLParserType
 
 from ._protocols import XmpInformationProtocol
 from ._utils import StreamType, deprecate_with_replacement, deprecation_no_replacement
@@ -161,6 +162,34 @@ def _generic_get(
     return None
 
 
+class _XmpBuilder(ExpatBuilderNS):
+    """
+    Custom XML parser denying all entity declarations.
+
+    This is a stripped down and typed version inspired by what *defusedxml* does.
+
+    Why do we need this? The default limits of *libexpat* used by Python only block exponential entity expansion,
+    but not cases like quadratic entity expansion which can still cause quite some memory usage.
+    """
+
+    def custom_entity_declaration_handler(
+            self,
+            entity_name: str,
+            is_parameter_entity: bool,
+            value: Optional[str],
+            base: Optional[str],
+            system_id: str,
+            public_id: Optional[str],
+            notation_name: Optional[str],
+    ) -> None:
+        raise ExpatError(f"Forbidden entities: {entity_name!r}")
+
+    def install(self, parser: XMLParserType) -> None:
+        super().install(parser)
+
+        parser.EntityDeclHandler = self.custom_entity_declaration_handler
+
+
 class XmpInformation(XmpInformationProtocol, PdfObject):
     """
     An object that represents Extensible Metadata Platform (XMP) metadata.
@@ -175,7 +204,7 @@ class XmpInformation(XmpInformationProtocol, PdfObject):
         self.stream = stream
         try:
             data = self.stream.get_data()
-            doc_root: Document = parseString(data)  # noqa: S318
+            doc_root: Document = _XmpBuilder().parseString(data)
         except (AttributeError, ExpatError) as e:
             raise PdfReadError(f"XML in XmpInformation was invalid: {e}")
         self.rdf_root: XmlElement = doc_root.getElementsByTagNameNS(

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -906,8 +906,11 @@ def test_xmp_information__external_entity_expansion(tmpdir):
   </rdf:RDF>
 </x:xmpmeta>""".encode())
 
-    xmp = XmpInformation(stream)
-    assert xmp.dc_creator == ["abc"]
+    with pytest.raises(
+            expected_exception=PdfReadError,
+            match=r"^XML in XmpInformation was invalid: Forbidden entities: 'xxe'$"
+    ):
+        XmpInformation(stream)
 
 
 @pytest.mark.timeout(10)
@@ -935,9 +938,28 @@ def test_xmp_information__exponential_entity_expansion():
 
     with pytest.raises(
             expected_exception=PdfReadError,
-            match=(
-                r"^XML in XmpInformation was invalid: limit on input amplification factor "
-                r"\(from DTD and entities\) breached: line 16, column 60$"
-            )
+            match=r"^XML in XmpInformation was invalid: Forbidden entities: 'lol'$"
+    ):
+        XmpInformation(stream)
+
+
+@pytest.mark.timeout(10)
+def test_xmp_information__quadratic_entity_expansion():
+    stream = ContentStream(pdf=None, stream=None)
+    stream.set_data(f"""<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY a "{'A' * 10_000}">
+]>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="">
+      <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">{'&a;' * 99}</dc:title>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>""".encode())
+
+    with pytest.raises(
+            expected_exception=PdfReadError,
+            match=r"^XML in XmpInformation was invalid: Forbidden entities: 'a'$"
     ):
         XmpInformation(stream)


### PR DESCRIPTION
While *libexpat* already handled the more severe cases, it has still been possible to cause rather high memory usage. For this reason, disallow entity declarations completely.

I decided against *defusedxml* for now, as I do not see the benefit of including an untyped external package for something this small, especially considering that the public maintenance status does not look very promising.