### PR TITLE
TST: Update `test_embedded_file__basic` to use `tmp_path` fixture

### DIFF
--- a/tests/generic/test_files.py
+++ b/tests/generic/test_files.py
@@ -3,9 +3,9 @@ import datetime
 import shutil
 import subprocess
 from io import BytesIO
+from pathlib import Path
 
 import pytest
-from py import path
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.constants import AFRelationship
@@ -28,12 +28,12 @@ PDFATTACH_BINARY = shutil.which("pdfattach")
 
 
 @pytest.mark.skipif(PDFATTACH_BINARY is None, reason="Requires poppler-utils")
-def test_embedded_file__basic(tmpdir: path.LocalPath) -> None:
+def test_embedded_file__basic(tmp_path: Path) -> None:
     assert PDFATTACH_BINARY is not None
     clean_path = SAMPLE_ROOT / "002-trivial-libre-office-writer" / "002-trivial-libre-office-writer.pdf"
-    attached_path = tmpdir / "attached.pdf"
-    file_path = tmpdir / "test.txt"
-    file_path.write_binary(b"Hello World\n")
+    attached_path = tmp_path / "attached.pdf"
+    file_path = tmp_path / "test.txt"
+    file_path.write_bytes(b"Hello World\n")
     subprocess.run([PDFATTACH_BINARY, clean_path, file_path, attached_path])  # noqa: S603
     with PdfReader(str(attached_path)) as reader:
         attachment = next(iter(EmbeddedFile._load(reader.root_object)))


### PR DESCRIPTION
Replace the old `tmpdir` fixture with `tmp_path` in `test_embedded_file__basic` to fix the test collection error when `py` is installed:

```pytb
____________________________________________ ERROR collecting tests/generic/test_files.py _____________________________________________
.venv/lib/python3.12/site-packages/py/_vendored_packages/apipkg/__init__.py:150: in __makeattr
    modpath, attrname = self.__map__[name]
                        ^^^^^^^^^^^^^^^^^^
E   KeyError: 'LocalPath'

During handling of the above exception, another exception occurred:
tests/generic/test_files.py:31: in <module>
    def test_embedded_file__basic(tmpdir: path.LocalPath) -> None:
                                          ^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/py/_vendored_packages/apipkg/__init__.py:155: in __makeattr
    raise AttributeError(name)
E   AttributeError: LocalPath
```