### PR TITLE
BUG: Fallback to lenient AES decryption on padding errors

### DIFF
--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -77,12 +77,22 @@ class CryptAES(CryptBase):
         if not data:
             return data
 
-        cipher = Cipher(self.alg, CBC(iv))
-        decryptor = cipher.decryptor()
-        padded_data = decryptor.update(data) + decryptor.finalize()
+        try:
+            cipher = Cipher(self.alg, CBC(iv))
+            decryptor = cipher.decryptor()
+            padded_data = decryptor.update(data) + decryptor.finalize()
 
-        unpadder = PKCS7(128).unpadder()
-        return unpadder.update(padded_data) + unpadder.finalize()
+            unpadder = PKCS7(128).unpadder()
+            return unpadder.update(padded_data) + unpadder.finalize()
+        except ValueError:
+            if len(data) % 16 != 0:
+                padder = PKCS7(128).padder()
+                data = padder.update(data) + padder.finalize()
+
+            cipher = Cipher(self.alg, CBC(iv))
+            decryptor = cipher.decryptor()
+            d = decryptor.update(data) + decryptor.finalize()
+            return d[: -d[-1]]
 
 
 def rc4_encrypt(key: bytes, data: bytes) -> bytes:

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -40,6 +40,7 @@ from cryptography.hazmat.primitives.ciphers.base import Cipher
 from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
 
 from pypdf._crypt_providers._base import CryptBase
+from pypdf._utils import logger_warning
 
 crypt_provider = ("cryptography", __version__)
 
@@ -58,8 +59,9 @@ class CryptRC4(CryptBase):
 
 
 class CryptAES(CryptBase):
-    def __init__(self, key: bytes) -> None:
+    def __init__(self, key: bytes, strict: bool = False) -> None:
         self.alg = AES(key)
+        self.strict = strict
 
     def encrypt(self, data: bytes) -> bytes:
         iv = secrets.token_bytes(16)
@@ -84,7 +86,10 @@ class CryptAES(CryptBase):
 
             unpadder = PKCS7(128).unpadder()
             return unpadder.update(padded_data) + unpadder.finalize()
-        except ValueError:
+        except ValueError as e:
+            if self.strict:
+                raise
+            logger_warning(f"Invalid padding bytes. {e}", __name__)
             if len(data) % 16 != 0:
                 padder = PKCS7(128).padder()
                 data = padder.update(data) + padder.finalize()

--- a/pypdf/_crypt_providers/_pycryptodome.py
+++ b/pypdf/_crypt_providers/_pycryptodome.py
@@ -64,9 +64,17 @@ class CryptAES(CryptBase):
         if not data:
             return data
 
-        aes = AES.new(self.key, AES.MODE_CBC, iv)
-        padded_data = aes.decrypt(data)
-        return unpad(padded_data, 16)
+        try:
+            aes = AES.new(self.key, AES.MODE_CBC, iv)
+            padded_data = aes.decrypt(data)
+            return unpad(padded_data, 16)
+        except ValueError:
+            if len(data) % 16 != 0:
+                data = pad(data, 16)
+
+            aes = AES.new(self.key, AES.MODE_CBC, iv)
+            d = aes.decrypt(data)
+            return d[: -d[-1]]
 
 
 def rc4_encrypt(key: bytes, data: bytes) -> bytes:

--- a/pypdf/_crypt_providers/_pycryptodome.py
+++ b/pypdf/_crypt_providers/_pycryptodome.py
@@ -32,6 +32,7 @@ from Crypto.Cipher import AES, ARC4
 from Crypto.Util.Padding import pad, unpad
 
 from pypdf._crypt_providers._base import CryptBase
+from pypdf._utils import logger_warning
 
 crypt_provider = ("pycryptodome", __version__)
 
@@ -48,8 +49,9 @@ class CryptRC4(CryptBase):
 
 
 class CryptAES(CryptBase):
-    def __init__(self, key: bytes) -> None:
+    def __init__(self, key: bytes, strict: bool = False) -> None:
         self.key = key
+        self.strict = strict
 
     def encrypt(self, data: bytes) -> bytes:
         iv = secrets.token_bytes(16)
@@ -68,7 +70,10 @@ class CryptAES(CryptBase):
             aes = AES.new(self.key, AES.MODE_CBC, iv)
             padded_data = aes.decrypt(data)
             return unpad(padded_data, 16)
-        except ValueError:
+        except ValueError as e:
+            if self.strict:
+                raise
+            logger_warning(f"Invalid padding bytes. {e}", __name__)
             if len(data) % 16 != 0:
                 data = pad(data, 16)
 

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -822,9 +822,11 @@ class Encryption:
         StrF: str,
         EFF: str,
         values: Optional[EncryptionValues],
+        strict: bool = False,
     ) -> None:
         # §7.6.2, entries common to all encryption dictionaries
         # use same name as keys of encryption dictionaries entries
+        self.strict = strict
         self.V = V
         self.R = R
         self.Length = Length  # key_size
@@ -939,20 +941,20 @@ class Encryption:
         # for AES-256
         aes256_key = key
 
-        stm_crypt = self._get_crypt(self.StmF, rc4_key, aes128_key, aes256_key)
-        str_crypt = self._get_crypt(self.StrF, rc4_key, aes128_key, aes256_key)
-        ef_crypt = self._get_crypt(self.EFF, rc4_key, aes128_key, aes256_key)
+        stm_crypt = self._get_crypt(self.StmF, rc4_key, aes128_key, aes256_key, self.strict)
+        str_crypt = self._get_crypt(self.StrF, rc4_key, aes128_key, aes256_key, self.strict)
+        ef_crypt = self._get_crypt(self.EFF, rc4_key, aes128_key, aes256_key, self.strict)
 
         return CryptFilter(stm_crypt, str_crypt, ef_crypt)
 
     @staticmethod
     def _get_crypt(
-        method: str, rc4_key: bytes, aes128_key: bytes, aes256_key: bytes
+        method: str, rc4_key: bytes, aes128_key: bytes, aes256_key: bytes, strict: bool = False
     ) -> CryptBase:
         if method == "/AESV2":
-            return CryptAES(aes128_key)
+            return CryptAES(aes128_key, strict)
         if method == "/AESV3":
-            return CryptAES(aes256_key)
+            return CryptAES(aes256_key, strict)
         if method == "/Identity":
             return CryptIdentity()
 
@@ -1098,7 +1100,9 @@ class Encryption:
         self.values.U = u_value
 
     @staticmethod
-    def read(encryption_entry: DictionaryObject, first_id_entry: bytes) -> "Encryption":
+    def read(
+        encryption_entry: DictionaryObject, first_id_entry: bytes, strict: bool = False
+    ) -> "Encryption":
         if encryption_entry.get("/Filter") != "/Standard":
             raise NotImplementedError(
                 "only Standard PDF encryption handler is available"
@@ -1164,6 +1168,7 @@ class Encryption:
             StmF=stm_filter,
             EFF=ef_filter,
             entry=encryption_entry,  # Dummy entry for the moment; will get removed
+            strict=strict,
         )
 
     @staticmethod

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -179,7 +179,7 @@ class PdfReader(PdfDocCommon):
         id_entry = self.trailer.get(TK.ID)
         id1_entry = id_entry[0].get_object().original_bytes if id_entry else b""
         encrypt_entry = cast(DictionaryObject, self.trailer[TK.ENCRYPT].get_object())
-        self._encryption = Encryption.read(encrypt_entry, id1_entry)
+        self._encryption = Encryption.read(encrypt_entry, id1_entry, strict=self.strict)
 
         # try empty password if no password provided
         pwd = password if password is not None else b""

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -381,7 +381,7 @@ def test_aes_decrypt__wrong_padding():
             continue
         with pytest.raises(ValueError, match=r"^(Invalid padding bytes|(PKCS#7 p|P)adding is incorrect)\.$"):
             aes.decrypt(broken)
-        
+
         # Should not raise
         aes_lenient.decrypt(broken)
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -363,7 +363,8 @@ def test_aes_decrypt__wrong_padding():
     # Use fixed values for reliability in testing these.
     # Depending on the input and values chosen during encryption, some cases might
     # not raise the desired exception, but this is out of our control.
-    aes = CryptAES(b"\xe8\xcd\xaeAG\xc8cMnLI\xaah\x97\x90@")
+    aes = CryptAES(b"\xe8\xcd\xaeAG\xc8cMnLI\xaah\x97\x90@", strict=True)
+    aes_lenient = CryptAES(b"\xe8\xcd\xaeAG\xc8cMnLI\xaah\x97\x90@", strict=False)
     original = b"\x9b\x9b%\x1a\ro\xf0\x17eI\xdc\x93\xbfp@\x05"
     encrypted = (
         b"L\x1f\xecj%\x00\x8dC\xb3%\xfc\x94\xf0\x14\x02\xcd\xa5\x06\x97\x86\x1e^\xfaSN"
@@ -371,6 +372,8 @@ def test_aes_decrypt__wrong_padding():
     )
 
     assert aes.decrypt(encrypted) == original
+    assert aes_lenient.decrypt(encrypted) == original
+
     for i in range(256):
         broken = encrypted[:-1] + bytes([i])
         if broken == encrypted:
@@ -378,6 +381,9 @@ def test_aes_decrypt__wrong_padding():
             continue
         with pytest.raises(ValueError, match=r"^(Invalid padding bytes|(PKCS#7 p|P)adding is incorrect)\.$"):
             aes.decrypt(broken)
+        
+        # Should not raise
+        aes_lenient.decrypt(broken)
 
 
 @pytest.mark.samples


### PR DESCRIPTION
Basically doing what I said [here](https://github.com/py-pdf/pypdf/issues/3725#issuecomment-4227767955). Again I'm no expert on the exact fix so all I'm doing is to catch the value error and fallback to the old logics.

The purpose is to immediately resolve the regression while still maintain the improvement introduced in 6.10.0. Feel free to close if the team decides there are more elegant way to do this.