### PR TITLE
refactor: use placeholder-based approach for logger_warning

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -212,7 +212,7 @@ def process_cm_line(
         try:
             multiline_rg = parse_bfrange(line, map_dict, int_entry, multiline_rg)
         except binascii.Error as error:
-            logger_warning(f"Skipping broken line {line!r}: {error}", __name__)
+            logger_warning("Skipping broken line %s: %s", __name__, error=error)
     elif process_char:
         parse_bfchar(line, map_dict, int_entry)
     return process_rg, process_char, multiline_rg

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -90,7 +90,7 @@ class CryptAES(CryptBase):
         except ValueError as exception:
             if strict:
                 raise PdfStreamError(exception)
-            logger_warning(f"Ignoring padding error: {exception}", src=__name__)
+            logger_warning("Ignoring padding error: %s", __name__, exception=exception)
             return padded_data[: -padded_data[-1]]
 
 

--- a/pypdf/_crypt_providers/_pycryptodome.py
+++ b/pypdf/_crypt_providers/_pycryptodome.py
@@ -73,7 +73,7 @@ class CryptAES(CryptBase):
         except ValueError as exception:
             if strict:
                 raise PdfStreamError(exception)
-            logger_warning(f"Ignoring padding error: {exception}", src=__name__)
+            logger_warning("Ignoring padding error: %s", __name__, exception=exception)
             return padded_data[: -padded_data[-1]]
 
 

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -863,7 +863,7 @@ class PdfDocCommon:
         while True:
             node_id = id(node)
             if node_id in visited:
-                logger_warning(f"Detected cycle in outline structure for {node}", __name__)
+                logger_warning("Detected cycle in outline structure for %s", __name__, node=node)
                 break
             visited.add(node_id)
 
@@ -966,7 +966,7 @@ class PdfDocCommon:
         try:
             return Destination(title, page, Fit(fit_type=typ, fit_args=array))  # type: ignore
         except PdfReadError:
-            logger_warning(f"Unknown destination: {title!r} {array}", __name__)
+            logger_warning("Unknown destination: %s %s", __name__, array=array)
             if self.strict:
                 raise
             # create a link to first Page

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -153,7 +153,7 @@ class Font:
             if not isinstance(w_entry, (int, float)):
                 # We should never get here due to skip_count above. But
                 # sometimes we do.
-                logger_warning(f"Expected numeric value for width, got {w_entry}. Ignoring it.", __name__)
+                logger_warning("Expected numeric value for width, got %s. Ignoring it.", __name__, w_entry=w_entry)
                 continue
             # check for format (1): `int [int int int int ...]`
             w_next_entry = _w[idx + 1].get_object()
@@ -264,7 +264,7 @@ class Font:
                     font_file = font_descriptor_obj[source_key].get_object()
                     font_descriptor_kwargs["font_file"] = font_file
                 except PdfReadError as e:
-                    logger_warning(f"Failed to get {source_key!r} in {font_descriptor_obj}: {e}", __name__)
+                    logger_warning("Failed to get %s in %s: %s", __name__, font_descriptor_obj=font_descriptor_obj, e=e)
         return font_descriptor_kwargs
 
     @classmethod

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -103,7 +103,7 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
     if isinstance(retval, IndirectObject):
         retval = self.pdf.get_object(retval)
     if isinstance(retval, ArrayObject) and (length := len(retval)) > 4:
-        logger_warning(f"Expected four values, got {length}: {retval}", __name__)
+        logger_warning("Expected four values, got %s: %s", __name__, length=length, retval=retval)
         retval = RectangleObject(tuple(retval[:4]))
     else:
         retval = RectangleObject(retval)  # type: ignore

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -206,7 +206,7 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
                 # and continue with the fallback.
                 break
 
-    logger_warning(f"Could not reliably determine page label for {index}.", __name__)
+    logger_warning("Could not reliably determine page label for %s.", __name__, index=index)
     return str(index + 1)  # Fallback if neither /Nums nor /Kids is in the number_tree
 
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -667,7 +667,7 @@ class PdfReader(PdfDocCommon):
         if xref_issue_nr != 0:
             if self.strict and xref_issue_nr:
                 raise PdfReadError("Broken xref table")
-            logger_warning(f"incorrect startxref pointer({xref_issue_nr})", __name__)
+            logger_warning("incorrect startxref pointer(%s)", __name__, xref_issue_nr=xref_issue_nr)
 
         # read all cross-reference tables and their trailers
         self._read_xref_tables_and_trailers(stream, startxref, xref_issue_nr)

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3002,7 +3002,7 @@ class PdfWriter(PdfDocCommon):
         if annots is None:
             return outlist
         if not isinstance(annots, list):
-            logger_warning(f"Expected list of annotations, got {annots} of type {annots.__class__.__name__}.", __name__)
+            logger_warning("Expected list of annotations, got %s of type %s.", __name__, annots=annots, annots___class_____name__=annots.__class__.__name__)
             return outlist
         for an in annots:
             ano = cast("DictionaryObject", an.get_object())

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -345,7 +345,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         if font_resource:
             font = Font.from_font_resource(font_resource)
         else:
-            logger_warning(f"Font dictionary for {font_name} not found; defaulting to Helvetica.", __name__)
+            logger_warning("Font dictionary for %s not found; defaulting to Helvetica.", __name__, font_name=font_name)
             font_name = "/Helv"
             core_font_metrics = CORE_FONT_METRICS["Helvetica"]
             font = Font(
@@ -440,7 +440,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         if is_null_or_none(font_resource):
             if font_name.removeprefix("/") not in CORE_FONT_METRICS:
                 # Default to Helvetica if we haven't found a font resource and cannot construct one ourselves.
-                logger_warning(f"Font dictionary for {font_name} not found; defaulting to Helvetica.", __name__)
+                logger_warning("Font dictionary for %s not found; defaulting to Helvetica.", __name__, font_name=font_name)
                 font_name = "/Helvetica"
             core_font_metrics = CORE_FONT_METRICS[font_name.removeprefix("/")]
             font_resource = Font(

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -552,7 +552,7 @@ class NumberObject(int, PdfObject):
         try:
             return int.__new__(cls, int(value))
         except ValueError:
-            logger_warning(f"NumberObject({value}) invalid; use 0 instead", __name__)
+            logger_warning("NumberObject(%s) invalid; use 0 instead", __name__, value=value)
             return int.__new__(cls, 0)
 
     def clone(

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -714,7 +714,7 @@ class TreeObject(DictionaryObject):
         while True:
             child_id = id(child)
             if child_id in visited:
-                logger_warning(f"Detected cycle in outline structure for {child}", __name__)
+                logger_warning("Detected cycle in outline structure for %s", __name__, child=child)
                 return
             visited.add(child_id)
 

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -260,7 +260,7 @@ def _handle_flate(
             else:
                 img = img.convert(conv)
                 if len(lookup) != (hival + 1) * nb:
-                    logger_warning(f"Invalid Lookup Table in {obj_as_text}", __name__)
+                    logger_warning("Invalid Lookup Table in %s", __name__, obj_as_text=obj_as_text)
                     lookup = None
                 elif mode == "L":
                     # gray lookup does not work: it is converted to a similar RGB lookup
@@ -585,6 +585,6 @@ def _xobj_to_image(
     try:  # temporary try/except until other fixes of images
         img = Image.open(BytesIO(data))
     except Exception as exception:
-        logger_warning(f"Failed loading image: {exception}", __name__)
+        logger_warning("Failed loading image: %s", __name__, exception=exception)
         img = None  # type: ignore[assignment,unused-ignore]  # TODO: Remove unused-ignore on Python 3.10
     return extension, data, img


### PR DESCRIPTION
## Description

This PR converts `logger_warning` to use a placeholder-based approach instead of f-strings, following Python logging best practices.

## Changes

- Changed `logger_warning` signature to accept `**values` like `logger_error`
- Converted all `logger_warning` calls from f-strings to placeholder-based format
- This avoids evaluating f-strings when the log level would prevent the message from being logged

## Related Issue

Fixes #3384

## AI Assistance

This PR was created with AI code assistance (Claude 4.6 via Hermes Agent).
