### PR TITLE
STY: use placeholder-based logger_warning

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -453,7 +453,7 @@ def logger_error(message: str, *, source: str, **values: Any) -> None:
     logging.getLogger(source).error(message, values)
 
 
-def logger_warning(msg: str, src: str) -> None:
+def logger_warning(msg: str, src: str, **values: Any) -> None:
     """
     Use this instead of logger.warning directly.
 
@@ -469,7 +469,7 @@ def logger_warning(msg: str, src: str) -> None:
       pypdf could apply a robustness fix to still read it. This applies mainly
       to strict=False mode.
     """
-    logging.getLogger(src).warning(msg)
+    logging.getLogger(src).warning(msg, values)
 
 
 def rename_kwargs(


### PR DESCRIPTION
## Description

Changes `logger_warning` to use a placeholder-based approach instead of f-strings, following Python logging best practices.

## Changes

- Changed `logger_warning` signature to accept `**values` like `logger_error`
- Updated function to pass values to the logging call

This avoids evaluating f-strings when the log level would prevent the message from being logged.

## Related Issue

Partially addresses #3384

Follow-up PRs will convert existing f-string calls to the placeholder format.

## AI Assistance

This PR was created with AI code assistance (Claude 4.6 via Hermes Agent).
