### PR TITLE
MAINT: Use placeholder-based approach for logger_warning

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -212,7 +212,7 @@ def process_cm_line(
         try:
             multiline_rg = parse_bfrange(line, map_dict, int_entry, multiline_rg)
         except binascii.Error as error:
-            logger_warning(f"Skipping broken line {line!r}: {error}", __name__)
+            logger_warning("Skipping broken line %(line)r: %(error)s", source=__name__, line=line, error=error)
     elif process_char:
         parse_bfchar(line, map_dict, int_entry)
     return process_rg, process_char, multiline_rg
@@ -309,7 +309,12 @@ def parse_bfchar(line: bytes, map_dict: dict[Any, Any], int_entry: list[int]) ->
                     "charmap" if len(lst[1]) < 4 else "utf-16-be", "surrogatepass"
                 )  # join is here as some cases where the code was split
             except BinasciiError as exception:
-                logger_warning(f"Got invalid hex string: {exception!s} ({lst[1]!r})", __name__)
+                logger_warning(
+                    "Got invalid hex string: %(exception)s (%(lst_value)r)",
+                    source=__name__,
+                    exception=exception,
+                    lst_value=lst[1],
+                )
         map_dict[
             unhexlify(lst[0]).decode(
                 "charmap" if map_dict[-1] == 1 else "utf-16-be", "surrogatepass"

--- a/pypdf/_codecs/_codecs.py
+++ b/pypdf/_codecs/_codecs.py
@@ -267,7 +267,7 @@ class LzwCodec(Codec):
     def _add_entry_decode(self, old_string: bytes, new_char: int) -> None:
         new_string = old_string + bytes([new_char])
         if self._table_index > self.max_code_value:
-            logger_warning("Ignoring too large LZW table index.", __name__)
+            logger_warning("Ignoring too large LZW table index.", source=__name__)
             return
         self.decoding_table[self._table_index] = new_string
         self._table_index += 1

--- a/pypdf/_crypt_providers/_cryptography.py
+++ b/pypdf/_crypt_providers/_cryptography.py
@@ -81,7 +81,7 @@ class CryptAES(CryptBase):
             return data
 
         if not strict and len(data) % 16 != 0:
-            logger_warning("Adding missing padding.", src=__name__)
+            logger_warning("Adding missing padding.", source=__name__)
             padder = PKCS7(128).padder()
             data = padder.update(data) + padder.finalize()
 
@@ -99,7 +99,7 @@ class CryptAES(CryptBase):
         except ValueError as exception:
             if strict:
                 raise PdfStreamError(exception)
-            logger_warning(f"Ignoring padding error: {exception}", src=__name__)
+            logger_warning("Ignoring padding error: %(exception)s", source=__name__, exception=exception)
             return padded_data[: -padded_data[-1]]
 
 

--- a/pypdf/_crypt_providers/_pycryptodome.py
+++ b/pypdf/_crypt_providers/_pycryptodome.py
@@ -67,7 +67,7 @@ class CryptAES(CryptBase):
             return data
 
         if not strict and len(data) % 16 != 0:
-            logger_warning("Adding missing padding.", src=__name__)
+            logger_warning("Adding missing padding.", source=__name__)
             data = pad(data, 16)
 
         aes = AES.new(self.key, AES.MODE_CBC, iv)
@@ -82,7 +82,7 @@ class CryptAES(CryptBase):
         except ValueError as exception:
             if strict:
                 raise PdfStreamError(exception)
-            logger_warning(f"Ignoring padding error: {exception}", src=__name__)
+            logger_warning("Ignoring padding error: %(exception)s", source=__name__, exception=exception)
             return padded_data[: -padded_data[-1]]
 
 

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -634,7 +634,9 @@ class PdfDocCommon:
     ) -> None:
         if tree in stack:
             logger_warning(
-                f"{self._get_qualified_field_name(tree)} already parsed", __name__
+                "%(field_name)s already parsed",
+                source=__name__,
+                field_name=self._get_qualified_field_name(tree),
             )
             return
         stack.append(tree)
@@ -863,7 +865,7 @@ class PdfDocCommon:
         while True:
             node_id = id(node)
             if node_id in visited:
-                logger_warning(f"Detected cycle in outline structure for {node}", __name__)
+                logger_warning("Detected cycle in outline structure for %(node)s", source=__name__, node=node)
                 break
             visited.add(node_id)
 
@@ -966,7 +968,7 @@ class PdfDocCommon:
         try:
             return Destination(title, page, Fit(fit_type=typ, fit_args=array))  # type: ignore
         except PdfReadError:
-            logger_warning(f"Unknown destination: {title!r} {array}", __name__)
+            logger_warning("Unknown destination: %(title)r %(array)s", source=__name__, title=title, array=array)
             if self.strict:
                 raise
             # create a link to first Page
@@ -1022,8 +1024,9 @@ class PdfDocCommon:
             if self.strict:
                 raise PdfReadError(f"Unexpected destination {dest!r}")
             logger_warning(
-                f"Removed unexpected destination {dest!r} from destination",
-                __name__,
+                "Removed unexpected destination %(dest)r from destination",
+                source=__name__,
+                dest=dest,
             )
             outline_item = self._build_destination(title, None)
 
@@ -1243,7 +1246,7 @@ class PdfDocCommon:
         if isinstance(page, IndirectObject):
             p = page.get_object()
             if not isinstance(p, PageObject):
-                logger_warning("IndirectObject is not referencing a page", __name__)
+                logger_warning("IndirectObject is not referencing a page", source=__name__)
                 return
             page = p
 
@@ -1251,10 +1254,10 @@ class PdfDocCommon:
             try:
                 page = self.flattened_pages.index(page)
             except ValueError:
-                logger_warning("Cannot find page in pages", __name__)
+                logger_warning("Cannot find page in pages", source=__name__)
                 return
         if not (0 <= page < len(self.flattened_pages)):
-            logger_warning("Page number is out of range", __name__)
+            logger_warning("Page number is out of range", source=__name__)
             return
 
         ind = self.pages[page].indirect_reference

--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -1023,7 +1023,7 @@ class Encryption:
         # verify Perms
         self._are_permissions_valid = AlgV5.verify_perms(key, self.values.Perms, self.P, self.EncryptMetadata)
         if not self._are_permissions_valid:
-            logger_warning("ignore '/Perms' verify failed", __name__)
+            logger_warning("ignore '/Perms' verify failed", source=__name__)
         return key, rc
 
     def write_entry(

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -153,7 +153,11 @@ class Font:
             if not isinstance(w_entry, (int, float)):
                 # We should never get here due to skip_count above. But
                 # sometimes we do.
-                logger_warning(f"Expected numeric value for width, got {w_entry}. Ignoring it.", __name__)
+                logger_warning(
+                    "Expected numeric value for width, got %(w_entry)s. Ignoring it.",
+                    source=__name__,
+                    w_entry=w_entry,
+                )
                 continue
             # check for format (1): `int [int int int int ...]`
             w_next_entry = _w[idx + 1].get_object()
@@ -197,8 +201,9 @@ class Font:
                 # This handles the case of out of bounds (reaching the end of the width definitions
                 # while expecting more elements).
                 logger_warning(
-                    f"Invalid font width definition. Last element: {w_entry}.",
-                    __name__
+                    "Invalid font width definition. Last element: %(w_entry)s.",
+                    source=__name__,
+                    w_entry=w_entry,
                 )
 
     @staticmethod
@@ -264,7 +269,13 @@ class Font:
                     font_file = font_descriptor_obj[source_key].get_object()
                     font_descriptor_kwargs["font_file"] = font_file
                 except PdfReadError as e:
-                    logger_warning(f"Failed to get {source_key!r} in {font_descriptor_obj}: {e}", __name__)
+                    logger_warning(
+                        "Failed to get %(source_key)r in %(font_descriptor_obj)s: %(error)s",
+                        source=__name__,
+                        source_key=source_key,
+                        font_descriptor_obj=font_descriptor_obj,
+                        error=e,
+                    )
         return font_descriptor_kwargs
 
     @classmethod

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -106,7 +106,12 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
     if isinstance(retval, IndirectObject):
         retval = self.pdf.get_object(retval)
     if isinstance(retval, ArrayObject) and (length := len(retval)) > 4:
-        logger_warning(f"Expected four values, got {length}: {retval}", __name__)
+        logger_warning(
+            "Expected four values, got %(length)s: %(retval)s",
+            source=__name__,
+            length=length,
+            retval=retval,
+        )
         retval = RectangleObject(tuple(retval[:4]))
     else:
         retval = RectangleObject(retval)  # type: ignore
@@ -1812,8 +1817,10 @@ class PageObject(DictionaryObject):
                             )
                 except Exception as exception:
                     logger_warning(
-                        f"Impossible to decode XFormObject {operands[0]}: {exception}",
-                        __name__,
+                        "Impossible to decode XFormObject %(operand)s: %(exception)s",
+                        source=__name__,
+                        operand=operands[0],
+                        exception=exception,
                     )
                 finally:
                     extractor.text = ""
@@ -2009,8 +2016,9 @@ class PageObject(DictionaryObject):
             ):
                 if locals()[visitor]:
                     logger_warning(
-                        f"Argument {visitor} is ignored in layout mode",
-                        __name__,
+                        "Argument %(visitor)s is ignored in layout mode",
+                        source=__name__,
+                        visitor=visitor,
                     )
             return self._layout_mode_text(
                 space_vertically=kwargs.get("layout_mode_space_vertically", True),

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -107,7 +107,7 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
         retval = self.pdf.get_object(retval)
     if isinstance(retval, ArrayObject) and (length := len(retval)) > 4:
         logger_warning(
-            "Expected four values, got %(length)s: %(retval)s",
+            "Expected four values, got %(length)d: %(retval)s",
             source=__name__,
             length=length,
             retval=retval,

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -206,7 +206,7 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
                 # and continue with the fallback.
                 break
 
-    logger_warning(f"Could not reliably determine page label for {index}.", __name__)
+    logger_warning("Could not reliably determine page label for %(index)s.", source=__name__, index=index)
     return str(index + 1)  # Fallback if neither /Nums nor /Kids is in the number_tree
 
 

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -206,7 +206,7 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
                 # and continue with the fallback.
                 break
 
-    logger_warning("Could not reliably determine page label for %(index)s.", source=__name__, index=index)
+    logger_warning("Could not reliably determine page label for %(index)d.", source=__name__, index=index)
     return str(index + 1)  # Fallback if neither /Nums nor /Kids is in the number_tree
 
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -615,10 +615,10 @@ class PdfReader(PdfDocCommon):
         skip_over_comment(stream)
         extra = skip_over_whitespace(stream)
         stream.seek(-1, 1)
-        idnum = read_until_whitespace(stream)
+        idnum = int(read_until_whitespace(stream))
         extra |= skip_over_whitespace(stream)
         stream.seek(-1, 1)
-        generation = read_until_whitespace(stream)
+        generation = int(read_until_whitespace(stream))
         extra |= skip_over_whitespace(stream)
         stream.seek(-1, 1)
 
@@ -631,10 +631,10 @@ class PdfReader(PdfDocCommon):
             logger_warning(
                 "Superfluous whitespace found in object header %(idnum)d %(generation)d",
                 source=__name__,
-                idnum=int(idnum),
-                generation=int(generation),
+                idnum=idnum,
+                generation=generation,
             )
-        return int(idnum), int(generation)
+        return idnum, generation
 
     def cache_get_indirect_object(
         self, generation: int, idnum: int
@@ -649,9 +649,10 @@ class PdfReader(PdfDocCommon):
     ) -> Optional[PdfObject]:
         if (generation, idnum) in self.resolved_objects:
             msg = "Overwriting cache for %(generation)d %(idnum)d"
+            values = {"generation": generation, "idnum": idnum}
             if self.strict:
-                raise PdfReadError(msg % {"generation": generation, "idnum": idnum})
-            logger_warning(msg, source=__name__, generation=generation, idnum=idnum)
+                raise PdfReadError(msg % values)
+            logger_warning(msg, source=__name__, **values)
         self.resolved_objects[(generation, idnum)] = obj
         if obj is not None:
             obj.indirect_reference = IndirectObject(idnum, generation, self)

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -631,8 +631,8 @@ class PdfReader(PdfDocCommon):
             logger_warning(
                 "Superfluous whitespace found in object header %(idnum)d %(generation)d",
                 source=__name__,
-                idnum=idnum,
-                generation=generation,
+                idnum=int(idnum),
+                generation=int(generation),
             )
         return int(idnum), int(generation)
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -242,7 +242,11 @@ class PdfReader(PdfDocCommon):
                     obj = None
                 if isinstance(obj, DictionaryObject) and obj.get("/Type") == "/Catalog":
                     self._validated_root = obj
-                    logger_warning("Root found at %(obj_ref)r", source=__name__, obj_ref=obj.indirect_reference)
+                    logger_warning(
+                        "Root found at %(obj_reference)r",
+                        source=__name__,
+                        obj_reference=obj.indirect_reference,
+                    )
                     break
         if self._validated_root is None:
             if not is_null_or_none(root) and "/Pages" in cast(DictionaryObject, cast(PdfObject, root).get_object()):
@@ -371,7 +375,7 @@ class PdfReader(PdfDocCommon):
             if self.strict:
                 raise LimitReachedError(f"Value /N {n} for object {stmnum} exceeds maximum allowed value {max_n}.")
             logger_warning(
-                "Value /N %(n)s for object %(stmnum)s exceeds maximum allowed value %(max_n)s. Limiting to %(max_n)s.",
+                "Value /N %(n)d for object %(stmnum)d exceeds maximum allowed value %(max_n)d. Limiting to %(max_n)d.",
                 source=__name__,
                 n=n,
                 stmnum=stmnum,
@@ -416,7 +420,7 @@ class PdfReader(PdfDocCommon):
                 # Stream object cannot be read. Normally, a critical error, but
                 # Adobe Reader doesn't complain, so continue (in strict mode?)
                 logger_warning(
-                    "Invalid stream (index %(index)s) within object %(obj_num)s 0: %(exc)s",
+                    "Invalid stream (index %(index)d) within object %(obj_num)d 0: %(exc)s",
                     source=__name__,
                     index=i,
                     obj_num=obj_num,
@@ -491,7 +495,7 @@ class PdfReader(PdfDocCommon):
                 )
                 if m is not None:
                     logger_warning(
-                        "Object ID %(idnum)s,%(generation)s ref repaired",
+                        "Object ID %(idnum)d,%(generation)d ref repaired",
                         source=__name__,
                         idnum=indirect_reference.idnum,
                         generation=indirect_reference.generation,
@@ -554,7 +558,7 @@ class PdfReader(PdfDocCommon):
             )
             if m is not None:
                 logger_warning(
-                    "Object %(idnum)s %(generation)s found",
+                    "Object %(idnum)d %(generation)d found",
                     source=__name__,
                     idnum=indirect_reference.idnum,
                     generation=indirect_reference.generation,
@@ -582,7 +586,7 @@ class PdfReader(PdfDocCommon):
                     )
             else:
                 logger_warning(
-                    "Object %(idnum)s %(generation)s not defined.",
+                    "Object %(idnum)d %(generation)d not defined.",
                     source=__name__,
                     idnum=indirect_reference.idnum,
                     generation=indirect_reference.generation,
@@ -625,7 +629,7 @@ class PdfReader(PdfDocCommon):
         stream.seek(-1, 1)
         if extra and self.strict:
             logger_warning(
-                "Superfluous whitespace found in object header %(idnum)s %(generation)s",
+                "Superfluous whitespace found in object header %(idnum)d %(generation)d",
                 source=__name__,
                 idnum=idnum,
                 generation=generation,
@@ -644,7 +648,7 @@ class PdfReader(PdfDocCommon):
         self, generation: int, idnum: int, obj: Optional[PdfObject]
     ) -> Optional[PdfObject]:
         if (generation, idnum) in self.resolved_objects:
-            msg = "Overwriting cache for %(generation)s %(idnum)s"
+            msg = "Overwriting cache for %(generation)d %(idnum)d"
             if self.strict:
                 raise PdfReadError(msg % {"generation": generation, "idnum": idnum})
             logger_warning(msg, source=__name__, generation=generation, idnum=idnum)
@@ -682,7 +686,7 @@ class PdfReader(PdfDocCommon):
             if self.strict and xref_issue_nr:
                 raise PdfReadError("Broken xref table")
             logger_warning(
-                "incorrect startxref pointer(%(xref_issue_nr)s)",
+                "incorrect startxref pointer(%(xref_issue_nr)d)",
                 source=__name__,
                 xref_issue_nr=xref_issue_nr,
             )
@@ -727,7 +731,7 @@ class PdfReader(PdfDocCommon):
                         self.read_object_header(stream)
                     except ValueError:
                         logger_warning(
-                            "Ignoring wrong pointing object %(id)s %(gen)s (offset %(offset)s)",
+                            "Ignoring wrong pointing object %(id)d %(gen)d (offset %(offset)d)",
                             source=__name__,
                             id=id,
                             gen=gen,
@@ -888,7 +892,7 @@ class PdfReader(PdfDocCommon):
                     f = re.search(rf"{num}\s+(\d+)\s+obj".encode(), buf)
                     if f is None:
                         logger_warning(
-                            "entry %(num)s in Xref table invalid; object not found",
+                            "entry %(num)d in Xref table invalid; object not found",
                             source=__name__,
                             num=num,
                         )
@@ -897,7 +901,7 @@ class PdfReader(PdfDocCommon):
                         entry_type_b = b"f"
                     else:
                         logger_warning(
-                            "entry %(num)s in Xref table invalid but object found",
+                            "entry %(num)d in Xref table invalid but object found",
                             source=__name__,
                             num=num,
                         )
@@ -957,7 +961,7 @@ class PdfReader(PdfDocCommon):
             # Detect circular /Prev references in the xref chain
             if startxref in visited_xref_offsets:
                 logger_warning(
-                    "Circular xref chain detected at offset %(startxref)s, stopping",
+                    "Circular xref chain detected at offset %(startxref)d, stopping",
                     source=__name__,
                     startxref=startxref,
                 )
@@ -1026,9 +1030,9 @@ class PdfReader(PdfDocCommon):
                 self._read_pdf15_xref_stream(stream)
             except Exception:
                 logger_warning(
-                    "XRef object at %(xref_stm)s can not be read, some object may be missing",
+                    "XRef object at %(xref_stm)d can not be read, some object may be missing",
                     source=__name__,
-                    xref_stm=new_trailer["/XRefStm"],
+                    xref_stm=int(new_trailer["/XRefStm"]),
                 )
             stream.seek(p, 0)
         if "/Prev" in new_trailer:
@@ -1102,7 +1106,7 @@ class PdfReader(PdfDocCommon):
                         )
                     new_v = max(0, max_entries - total)
                     logger_warning(
-                        "Clamping XRef count from %(old_count)s to %(new_count)s to fit stream size.",
+                        "Clamping XRef count from %(old_count)d to %(new_count)d to fit stream size.",
                         source=__name__,
                         old_count=pair_value_int,
                         new_count=new_v,
@@ -1296,16 +1300,17 @@ class PdfReader(PdfDocCommon):
                         inner_generation_number = int(current)
                         self.xref_objStm[inner_object_number] = (object_number, inner_generation_number)
                         actual_count += 1
-                    if actual_count != obj.get("/N"):  # pragma: no cover
+                    expected_count = cast(int, obj["/N"])
+                    if actual_count != expected_count:  # pragma: no cover
                         logger_warning(  # pragma: no cover
-                            "found %(actual_count)s objects within "
-                            "Object(%(object_number)s,%(generation_number)s) "
-                            "whereas %(expected)s expected",
+                            "found %(actual_count)d objects within "
+                            "Object(%(object_number)d,%(generation_number)d) "
+                            "whereas %(expected)d expected",
                             source=__name__,
                             actual_count=actual_count,
                             object_number=object_number,
                             generation_number=generation_number,
-                            expected=obj.get("/N"),
+                            expected=expected_count,
                         )
                 except Exception:  # could be multiple causes
                     pass
@@ -1432,7 +1437,7 @@ class PdfReader(PdfDocCommon):
             obj = o.get_object()
             if "/Parent" in obj:
                 logger_warning(
-                    "Top Level Form Field %(obj_ref)s have a non-expected parent",
+                    "Top Level Form Field %(obj_ref)s has a non-expected parent",
                     source=__name__,
                     obj_ref=obj.indirect_reference,
                 )

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -161,7 +161,7 @@ class PdfReader(PdfDocCommon):
             logger_warning(
                 "PdfReader stream/file object is not in binary mode. "
                 "It may not be read correctly.",
-                __name__,
+                source=__name__,
             )
         self._stream_opened = False
         if isinstance(stream, (str, Path)):
@@ -220,7 +220,7 @@ class PdfReader(PdfDocCommon):
             return self._validated_root
         root = self.trailer.get(TK.ROOT)
         if is_null_or_none(root):
-            logger_warning('Cannot find "/Root" key in trailer', __name__)
+            logger_warning('Cannot find "/Root" key in trailer', source=__name__)
         elif (
             cast(DictionaryObject, cast(PdfObject, root).get_object()).get("/Type")
             == "/Catalog"
@@ -229,9 +229,9 @@ class PdfReader(PdfDocCommon):
                 DictionaryObject, cast(PdfObject, root).get_object()
             )
         else:
-            logger_warning("Invalid Root object in trailer", __name__)
+            logger_warning("Invalid Root object in trailer", source=__name__)
         if self._validated_root is None:
-            logger_warning('Searching object with "/Catalog" key', __name__)
+            logger_warning('Searching object with "/Catalog" key', source=__name__)
             number_of_objects = cast(int, self.trailer.get("/Size", 0))
             for i in range(number_of_objects):
                 if i >= self._root_object_recovery_limit:
@@ -242,13 +242,14 @@ class PdfReader(PdfDocCommon):
                     obj = None
                 if isinstance(obj, DictionaryObject) and obj.get("/Type") == "/Catalog":
                     self._validated_root = obj
-                    logger_warning(f"Root found at {obj.indirect_reference!r}", __name__)
+                    logger_warning("Root found at %(obj_ref)r", source=__name__, obj_ref=obj.indirect_reference)
                     break
         if self._validated_root is None:
             if not is_null_or_none(root) and "/Pages" in cast(DictionaryObject, cast(PdfObject, root).get_object()):
                 logger_warning(
-                    f"Possible root found at {cast(PdfObject, root).indirect_reference!r}, but missing /Catalog key",
-                    __name__
+                    "Possible root found at %(root_ref)r, but missing /Catalog key",
+                    source=__name__,
+                    root_ref=cast(PdfObject, root).indirect_reference,
                 )
                 self._validated_root = cast(
                     DictionaryObject, cast(PdfObject, root).get_object()
@@ -370,8 +371,11 @@ class PdfReader(PdfDocCommon):
             if self.strict:
                 raise LimitReachedError(f"Value /N {n} for object {stmnum} exceeds maximum allowed value {max_n}.")
             logger_warning(
-                f"Value /N {n} for object {stmnum} exceeds maximum allowed value {max_n}. Limiting to {max_n}.",
-                src=__name__
+                "Value /N %(n)s for object %(stmnum)s exceeds maximum allowed value %(max_n)s. Limiting to %(max_n)s.",
+                source=__name__,
+                n=n,
+                stmnum=stmnum,
+                max_n=max_n,
             )
             n = max_n
 
@@ -412,9 +416,11 @@ class PdfReader(PdfDocCommon):
                 # Stream object cannot be read. Normally, a critical error, but
                 # Adobe Reader doesn't complain, so continue (in strict mode?)
                 logger_warning(
-                    f"Invalid stream (index {i}) within object "
-                    f"{obj_num} 0: {exc}",
-                    __name__,
+                    "Invalid stream (index %(index)s) within object %(obj_num)s 0: %(exc)s",
+                    source=__name__,
+                    index=i,
+                    obj_num=obj_num,
+                    exc=exc,
                 )
                 if self.strict:  # pragma: no cover
                     raise PdfReadError(
@@ -485,8 +491,10 @@ class PdfReader(PdfDocCommon):
                 )
                 if m is not None:
                     logger_warning(
-                        f"Object ID {indirect_reference.idnum},{indirect_reference.generation} ref repaired",
-                        __name__,
+                        "Object ID %(idnum)s,%(generation)s ref repaired",
+                        source=__name__,
+                        idnum=indirect_reference.idnum,
+                        generation=indirect_reference.generation,
                     )
                     self.xref[indirect_reference.generation][
                         indirect_reference.idnum
@@ -546,8 +554,10 @@ class PdfReader(PdfDocCommon):
             )
             if m is not None:
                 logger_warning(
-                    f"Object {indirect_reference.idnum} {indirect_reference.generation} found",
-                    __name__,
+                    "Object %(idnum)s %(generation)s found",
+                    source=__name__,
+                    idnum=indirect_reference.idnum,
+                    generation=indirect_reference.generation,
                 )
                 if indirect_reference.generation not in self.xref:
                     self.xref[indirect_reference.generation] = {}
@@ -572,8 +582,10 @@ class PdfReader(PdfDocCommon):
                     )
             else:
                 logger_warning(
-                    f"Object {indirect_reference.idnum} {indirect_reference.generation} not defined.",
-                    __name__,
+                    "Object %(idnum)s %(generation)s not defined.",
+                    source=__name__,
+                    idnum=indirect_reference.idnum,
+                    generation=indirect_reference.generation,
                 )
                 if self.strict:
                     raise PdfReadError("Could not find object.")
@@ -613,8 +625,10 @@ class PdfReader(PdfDocCommon):
         stream.seek(-1, 1)
         if extra and self.strict:
             logger_warning(
-                f"Superfluous whitespace found in object header {idnum} {generation}",  # type: ignore
-                __name__,
+                "Superfluous whitespace found in object header %(idnum)s %(generation)s",
+                source=__name__,
+                idnum=idnum,
+                generation=generation,
             )
         return int(idnum), int(generation)
 
@@ -630,10 +644,10 @@ class PdfReader(PdfDocCommon):
         self, generation: int, idnum: int, obj: Optional[PdfObject]
     ) -> Optional[PdfObject]:
         if (generation, idnum) in self.resolved_objects:
-            msg = f"Overwriting cache for {generation} {idnum}"
+            msg = "Overwriting cache for %(generation)s %(idnum)s"
             if self.strict:
-                raise PdfReadError(msg)
-            logger_warning(msg, __name__)
+                raise PdfReadError(msg % {"generation": generation, "idnum": idnum})
+            logger_warning(msg, source=__name__, generation=generation, idnum=idnum)
         self.resolved_objects[(generation, idnum)] = obj
         if obj is not None:
             obj.indirect_reference = IndirectObject(idnum, generation, self)
@@ -667,7 +681,11 @@ class PdfReader(PdfDocCommon):
         if xref_issue_nr != 0:
             if self.strict and xref_issue_nr:
                 raise PdfReadError("Broken xref table")
-            logger_warning(f"incorrect startxref pointer({xref_issue_nr})", __name__)
+            logger_warning(
+                "incorrect startxref pointer(%(xref_issue_nr)s)",
+                source=__name__,
+                xref_issue_nr=xref_issue_nr,
+            )
 
         # read all cross-reference tables and their trailers
         self._read_xref_tables_and_trailers(stream, startxref, xref_issue_nr)
@@ -709,8 +727,11 @@ class PdfReader(PdfDocCommon):
                         self.read_object_header(stream)
                     except ValueError:
                         logger_warning(
-                            f"Ignoring wrong pointing object {id} {gen} (offset {xref_entry[id]})",
-                            __name__,
+                            "Ignoring wrong pointing object %(id)s %(gen)s (offset %(offset)s)",
+                            source=__name__,
+                            id=id,
+                            gen=gen,
+                            offset=xref_entry[id],
                         )
                         del xref_entry[id]  # we can delete the id, we are parsing ids
             stream.seek(loc, 0)  # return to where it was
@@ -730,7 +751,7 @@ class PdfReader(PdfDocCommon):
                     f"PDF starts with '{header_byte.decode('utf8')}', "
                     "but '%PDF-' expected"
                 )
-            logger_warning(f"invalid pdf header: {header_byte!r}", __name__)
+            logger_warning("invalid pdf header: %(header_byte)r", source=__name__, header_byte=header_byte)
         stream.seek(0, os.SEEK_END)
 
     def _find_eof_marker(self, stream: StreamType) -> None:
@@ -751,19 +772,19 @@ class PdfReader(PdfDocCommon):
                 ):
                     # Consider the file as truncated while
                     # having enough confidence to carry on.
-                    logger_warning("EOF marker seems truncated", __name__)
+                    logger_warning("EOF marker seems truncated", source=__name__)
                     break
                 first = False
             if b"startxref" in line:
                 logger_warning(
                     "CAUTION: startxref found while searching for %%EOF. "
                     "The file might be truncated and some data might not be read.",
-                    __name__,
+                    source=__name__,
                 )
             if stream.tell() < HEADER_SIZE:
                 if self.strict:
                     raise PdfReadError("EOF marker not found")
-                logger_warning("EOF marker not found", __name__)
+                logger_warning("EOF marker not found", source=__name__)
             line = read_previous_line(stream)
 
     def _find_startxref_pos(self, stream: StreamType) -> int:
@@ -785,7 +806,7 @@ class PdfReader(PdfDocCommon):
             if not line.startswith(b"startxref"):
                 raise PdfReadError("startxref not found")
             startxref = int(line[9:].strip())
-            logger_warning("startxref on same line as offset", __name__)
+            logger_warning("startxref on same line as offset", source=__name__)
         else:
             line = read_previous_line(stream)
             if not line.startswith(b"startxref"):
@@ -807,7 +828,7 @@ class PdfReader(PdfDocCommon):
                 if self.strict:
                     logger_warning(
                         "Xref table not zero-indexed. ID numbers for objects will be corrected.",
-                        __name__,
+                        source=__name__,
                     )
                     # if table not zero indexed, could be due to error from when PDF was created
                     # which will lead to mismatched indices later on, only warned and corrected if self.strict==True
@@ -818,7 +839,7 @@ class PdfReader(PdfDocCommon):
             if not isinstance(size, int):
                 logger_warning(
                     "Invalid/Truncated xref table. Rebuilding it.",
-                    __name__,
+                    source=__name__,
                 )
                 self._rebuild_xref_table(stream)
                 stream.read()
@@ -867,16 +888,18 @@ class PdfReader(PdfDocCommon):
                     f = re.search(rf"{num}\s+(\d+)\s+obj".encode(), buf)
                     if f is None:
                         logger_warning(
-                            f"entry {num} in Xref table invalid; object not found",
-                            __name__,
+                            "entry %(num)s in Xref table invalid; object not found",
+                            source=__name__,
+                            num=num,
                         )
                         generation = 65535
                         offset = -1
                         entry_type_b = b"f"
                     else:
                         logger_warning(
-                            f"entry {num} in Xref table invalid but object found",
-                            __name__,
+                            "entry %(num)s in Xref table invalid but object found",
+                            source=__name__,
+                            num=num,
                         )
                         generation = int(f.group(1))
                         offset = f.start()
@@ -934,8 +957,9 @@ class PdfReader(PdfDocCommon):
             # Detect circular /Prev references in the xref chain
             if startxref in visited_xref_offsets:
                 logger_warning(
-                    f"Circular xref chain detected at offset {startxref}, stopping",
-                    __name__,
+                    "Circular xref chain detected at offset %(startxref)s, stopping",
+                    source=__name__,
+                    startxref=startxref,
                 )
                 break
             visited_xref_offsets.add(startxref)
@@ -958,7 +982,9 @@ class PdfReader(PdfDocCommon):
                 except Exception as e:
                     if TK.ROOT in self.trailer:
                         logger_warning(
-                            f"Previous trailer cannot be read: {e.args}", __name__
+                            "Previous trailer cannot be read: %(args)s",
+                            source=__name__,
+                            args=e.args,
                         )
                         break
                     raise PdfReadError(f"Trailer cannot be read: {e!s}")
@@ -1000,8 +1026,9 @@ class PdfReader(PdfDocCommon):
                 self._read_pdf15_xref_stream(stream)
             except Exception:
                 logger_warning(
-                    f"XRef object at {new_trailer['/XRefStm']} can not be read, some object may be missing",
-                    __name__,
+                    "XRef object at %(xref_stm)s can not be read, some object may be missing",
+                    source=__name__,
+                    xref_stm=new_trailer["/XRefStm"],
                 )
             stream.seek(p, 0)
         if "/Prev" in new_trailer:
@@ -1019,7 +1046,7 @@ class PdfReader(PdfDocCommon):
                 )
             logger_warning(
                 "/Prev=0 in the trailer - assuming there is no previous xref table",
-                __name__,
+                source=__name__,
             )
             return None
         # bad xref character at startxref. Let's see if we can find
@@ -1041,7 +1068,7 @@ class PdfReader(PdfDocCommon):
         # no xref table found at specified location
         if "/Root" in self.trailer and not self.strict:
             # if Root has been already found, just raise warning
-            logger_warning("Invalid parent xref., rebuild xref", __name__)
+            logger_warning("Invalid parent xref., rebuild xref", source=__name__)
             try:
                 self._rebuild_xref_table(stream)
                 return None
@@ -1075,8 +1102,10 @@ class PdfReader(PdfDocCommon):
                         )
                     new_v = max(0, max_entries - total)
                     logger_warning(
-                        f"Clamping XRef count from {pair_value_int} to {new_v} to fit stream size.",
-                        src=__name__
+                        "Clamping XRef count from %(old_count)s to %(new_count)s to fit stream size.",
+                        source=__name__,
+                        old_count=pair_value_int,
+                        new_count=new_v,
                     )
                     pair_value_int = new_v
 
@@ -1242,7 +1271,7 @@ class PdfReader(PdfDocCommon):
                 self.xref[generation_number] = {}
             self.xref[generation_number][object_number] = object_start
 
-        logger_warning("parsing for Object Streams", __name__)
+        logger_warning("parsing for Object Streams", source=__name__)
         for generation_number in self.xref:
             for object_number in self.xref[generation_number]:
                 # get_object in manual
@@ -1269,9 +1298,14 @@ class PdfReader(PdfDocCommon):
                         actual_count += 1
                     if actual_count != obj.get("/N"):  # pragma: no cover
                         logger_warning(  # pragma: no cover
-                            f"found {actual_count} objects within Object({object_number},{generation_number})"
-                            f" whereas {obj.get('/N')} expected",
-                            __name__,
+                            "found %(actual_count)s objects within "
+                            "Object(%(object_number)s,%(generation_number)s) "
+                            "whereas %(expected)s expected",
+                            source=__name__,
+                            actual_count=actual_count,
+                            object_number=object_number,
+                            generation_number=generation_number,
+                            expected=obj.get("/N"),
                         )
                 except Exception:  # could be multiple causes
                     pass
@@ -1398,8 +1432,9 @@ class PdfReader(PdfDocCommon):
             obj = o.get_object()
             if "/Parent" in obj:
                 logger_warning(
-                    f"Top Level Form Field {obj.indirect_reference} have a non-expected parent",
-                    __name__,
+                    "Top Level Form Field %(obj_ref)s have a non-expected parent",
+                    source=__name__,
+                    obj_ref=obj.indirect_reference,
                 )
             obj[NameObject("/Parent")] = interim.indirect_reference
         return interim

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -615,10 +615,10 @@ class PdfReader(PdfDocCommon):
         skip_over_comment(stream)
         extra = skip_over_whitespace(stream)
         stream.seek(-1, 1)
-        idnum = int(read_until_whitespace(stream))
+        idnum = read_until_whitespace(stream)
         extra |= skip_over_whitespace(stream)
         stream.seek(-1, 1)
-        generation = int(read_until_whitespace(stream))
+        generation = read_until_whitespace(stream)
         extra |= skip_over_whitespace(stream)
         stream.seek(-1, 1)
 
@@ -629,12 +629,12 @@ class PdfReader(PdfDocCommon):
         stream.seek(-1, 1)
         if extra and self.strict:
             logger_warning(
-                "Superfluous whitespace found in object header %(idnum)d %(generation)d",
+                "Superfluous whitespace found in object header %(idnum)r %(generation)r",
                 source=__name__,
                 idnum=idnum,
                 generation=generation,
             )
-        return idnum, generation
+        return int(idnum), int(generation)
 
     def cache_get_indirect_object(
         self, generation: int, idnum: int

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1304,9 +1304,11 @@ class PdfReader(PdfDocCommon):
                     expected_count = cast(int, obj["/N"])
                     if actual_count != expected_count:  # pragma: no cover
                         logger_warning(  # pragma: no cover
-                            "found %(actual_count)d objects within "
-                            "Object(%(object_number)d,%(generation_number)d) "
-                            "whereas %(expected)d expected",
+                            (
+                                "found %(actual_count)d objects within "
+                                "Object(%(object_number)d,%(generation_number)d) "
+                                "whereas %(expected)d expected"
+                            ),
                             source=__name__,
                             actual_count=actual_count,
                             object_number=object_number,

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -199,8 +199,9 @@ def recurs_to_target_op(
             text_state_mgr.set_state_param(op, operands)
     else:
         logger_warning(
-            f"Unbalanced target operations, expected {end_target!r}.",
-            __name__,
+            "Unbalanced target operations, expected %(end_target)r.",
+            source=__name__,
+            end_target=end_target,
         )
     return bt_groups, tj_ops
 
@@ -290,15 +291,15 @@ def text_show_operations(
     if any(tj.rotated for tj in tj_ops):
         if strip_rotated:
             logger_warning(
-                "Rotated text discovered. Output will be incomplete.", __name__
+                "Rotated text discovered. Output will be incomplete.", source=__name__
             )
         else:
             logger_warning(
-                "Rotated text discovered. Layout will be degraded.", __name__
+                "Rotated text discovered. Layout will be degraded.", source=__name__
             )
     if not all(tj.font.interpretable for tj in tj_ops):
         logger_warning(
-            "PDF contains an uninterpretable font. Output will be incomplete.", __name__
+            "PDF contains an uninterpretable font. Output will be incomplete.", source=__name__
         )
 
     # left align the data, i.e. decrement all tx values by min(tx)

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -450,7 +450,10 @@ def logger_error(message: str, *, source: str, **values: Any) -> None:
     See the docs on when to use which:
     https://pypdf.readthedocs.io/en/latest/user/suppress-warnings.html
     """
-    logging.getLogger(source).error(message, values)
+    if values:
+        logging.getLogger(source).error(message, values)
+    else:
+        logging.getLogger(source).error(message)
 
 
 def logger_warning(message: str, *, source: str, **values: Any) -> None:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -453,7 +453,7 @@ def logger_error(message: str, *, source: str, **values: Any) -> None:
     logging.getLogger(source).error(message, values)
 
 
-def logger_warning(msg: str, src: str) -> None:
+def logger_warning(message: str, *, source: str, **values: Any) -> None:
     """
     Use this instead of logger.warning directly.
 
@@ -469,7 +469,12 @@ def logger_warning(msg: str, src: str) -> None:
       pypdf could apply a robustness fix to still read it. This applies mainly
       to strict=False mode.
     """
-    logging.getLogger(src).warning(msg)
+    if values:
+        logging.getLogger(source).warning(message, values)
+    else:
+        # Passing an empty dict to logging is not equivalent to passing no args:
+        # plain messages would fail while being formatted.
+        logging.getLogger(source).warning(message)
 
 
 def rename_kwargs(

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -475,6 +475,7 @@ def logger_warning(message: str, *, source: str, **values: Any) -> None:
     if values:
         logging.getLogger(source).warning(message, values)
     else:
+        # Keep parity with logger_error and support plain warning messages.
         # Passing an empty dict to logging is not equivalent to passing no args:
         # plain messages would fail while being formatted.
         logging.getLogger(source).warning(message)

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -590,7 +590,10 @@ class PdfWriter(PdfDocCommon):
             ] = BooleanObject(state)
         except Exception as exc:  # pragma: no cover
             logger_warning(
-                f"set_need_appearances_writer({state}) catch : {exc}", __name__
+                "set_need_appearances_writer(%(state)s) catch : %(exc)s",
+                source=__name__,
+                state=state,
+                exc=exc,
             )
 
     def create_viewer_preferences(self) -> ViewerPreferences:
@@ -942,8 +945,9 @@ class PdfWriter(PdfDocCommon):
             pg_xo_res[xobject_name] = xobject_ref
         else:
             logger_warning(
-                f"XObject {xobject_name!r} already added to page resources. This might be an issue.",
-                __name__
+                "XObject %(xobject_name)r already added to page resources. This might be an issue.",
+                source=__name__,
+                xobject_name=xobject_name,
             )
         xobject_cm = Transformation().translate(x_offset, y_offset)
         xobject_drawing_commands = f"q\n{xobject_cm._to_cm()}\n{xobject_name} Do\nQ".encode()
@@ -1005,7 +1009,7 @@ class PdfWriter(PdfDocCommon):
                     self.update_page_form_field_values(p, fields, flags, None, flatten=flatten)
             return
         if PG.ANNOTS not in page:
-            logger_warning("No fields to update on this page", __name__)
+            logger_warning("No fields to update on this page", source=__name__)
             return
         appearance_stream_obj: Optional[StreamObject] = None
 
@@ -1088,7 +1092,7 @@ class PdfWriter(PdfDocCommon):
                 elif (
                     annotation.get(FA.FT) == "/Sig"
                 ):  # deprecated  # not implemented yet
-                    logger_warning("Signature forms not implemented yet", __name__)
+                    logger_warning("Signature forms not implemented yet", source=__name__)
                 if flatten and appearance_stream_obj is not None:
                     self._add_apstream_object(page, appearance_stream_obj, field, rectangle[0], rectangle[1])
 
@@ -1193,8 +1197,10 @@ class PdfWriter(PdfDocCommon):
                     f"Object count {len(self._objects)} exceeds defined trailer size {reader.trailer['/Size']}"
                 )
             logger_warning(
-                f"Object count {len(self._objects)} exceeds defined trailer size {reader.trailer['/Size']}",
-                __name__
+                "Object count %(object_count)s exceeds defined trailer size %(trailer_size)s",
+                source=__name__,
+                object_count=len(self._objects),
+                trailer_size=reader.trailer["/Size"],
             )
 
         # must be done here before rewriting
@@ -1367,9 +1373,10 @@ class PdfWriter(PdfDocCommon):
     def write_stream(self, stream: StreamType) -> None:
         if hasattr(stream, "mode") and "b" not in stream.mode:
             logger_warning(
-                f"File <{stream.name}> to write to is not in binary mode. "
+                "File <%(stream_name)s> to write to is not in binary mode. "
                 "It may not be written to correctly.",
-                __name__,
+                source=__name__,
+                stream_name=stream.name,
             )
         self._resolve_links()
 
@@ -1881,8 +1888,9 @@ class PdfWriter(PdfDocCommon):
                     page_ref = NumberObject(page_number)
             if page_ref is None:
                 logger_warning(
-                    f"can not find reference of page {page_number}",
-                    __name__,
+                    "can not find reference of page %(page_number)s",
+                    source=__name__,
+                    page_number=page_number,
                 )
                 page_ref = NullObject()
             dest = Destination(
@@ -2383,8 +2391,9 @@ class PdfWriter(PdfDocCommon):
         if not isinstance(layout, NameObject):
             if layout not in self._valid_layouts:
                 logger_warning(
-                    f"Layout should be one of: {'', ''.join(self._valid_layouts)}",
-                    __name__,
+                    "Layout should be one of: %(layouts)s",
+                    source=__name__,
+                    layouts={"", "".join(self._valid_layouts)},
                 )
             layout = NameObject(layout)
         self._root_object.update({NameObject("/PageLayout"): layout})
@@ -2491,7 +2500,9 @@ class PdfWriter(PdfDocCommon):
         else:
             if mode not in self._valid_modes:
                 logger_warning(
-                    f"Mode should be one of: {', '.join(self._valid_modes)}", __name__
+                    "Mode should be one of: %(modes)s",
+                    source=__name__,
+                    modes=", ".join(self._valid_modes),
                 )
             mode_name = NameObject(mode)
         self._root_object.update({NameObject("/PageMode"): mode_name})
@@ -3002,7 +3013,12 @@ class PdfWriter(PdfDocCommon):
         if annots is None:
             return outlist
         if not isinstance(annots, list):
-            logger_warning(f"Expected list of annotations, got {annots} of type {annots.__class__.__name__}.", __name__)
+            logger_warning(
+                "Expected list of annotations, got %(annots)s of type %(annots_type)s.",
+                source=__name__,
+                annots=annots,
+                annots_type=annots.__class__.__name__,
+            )
             return outlist
         for an in annots:
             ano = cast("DictionaryObject", an.get_object())

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1191,16 +1191,17 @@ class PdfWriter(PdfDocCommon):
         self._root_object = reader.root_object.clone(self)
         self._pages = self._root_object.raw_get("/Pages")
 
-        if len(self._objects) > cast(int, reader.trailer["/Size"]):
+        trailer_size = cast(int, reader.trailer["/Size"])
+        if len(self._objects) > trailer_size:
             if self.strict:
                 raise PdfReadError(
-                    f"Object count {len(self._objects)} exceeds defined trailer size {reader.trailer['/Size']}"
+                    f"Object count {len(self._objects)} exceeds defined trailer size {trailer_size}"
                 )
             logger_warning(
-                "Object count %(object_count)s exceeds defined trailer size %(trailer_size)s",
+                "Object count %(object_count)d exceeds defined trailer size %(trailer_size)d",
                 source=__name__,
                 object_count=len(self._objects),
-                trailer_size=reader.trailer["/Size"],
+                trailer_size=trailer_size,
             )
 
         # must be done here before rewriting

--- a/pypdf/annotations/_non_markup_annotations.py
+++ b/pypdf/annotations/_non_markup_annotations.py
@@ -102,5 +102,5 @@ class Popup(AnnotationDictionary):
 
                 logger_warning(
                     "Unregistered Parent object : No Parent field set",
-                    __name__,
+                    source=__name__,
                 )

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -163,7 +163,7 @@ def decompress(data: bytes) -> bytes:
                 error_str = str(error)
                 if error_str in known_errors:
                     continue
-                logger_warning(error_str, __name__)
+                logger_warning(error_str, source=__name__)
                 known_errors.add(error_str)
         return result_str
 
@@ -259,7 +259,7 @@ class FlateDecode:
     def _decode_png_prediction(data: bytes, columns: int, row_length: int) -> bytes:
         # PNG prediction can vary from row to row
         if (remainder := len(data) % row_length) != 0:
-            logger_warning("Image data is not rectangular. Adding padding.", __name__)
+            logger_warning("Image data is not rectangular. Adding padding.", source=__name__)
             data += b"\x00" * (row_length - remainder)
             assert len(data) % row_length == 0
         output = []
@@ -371,7 +371,7 @@ class ASCIIHexDecode:
         if eod == -1:
             logger_warning(
                 "missing EOD in ASCIIHexDecode, check if output is OK",
-                __name__,
+                source=__name__,
             )
             hex_data = data
         else:
@@ -428,7 +428,7 @@ class RunLengthDecode:
         while True:
             if index >= data_length:
                 logger_warning(
-                    "missing EOD in RunLengthDecode, check if output is OK", __name__
+                    "missing EOD in RunLengthDecode, check if output is OK", source=__name__
                 )
                 break  # Reached end of string without an EOD
             length = data[index]
@@ -440,14 +440,14 @@ class RunLengthDecode:
                     # We will just ignore the last byte and raise a warning ...
                     if (index == data_length - 1) and (data[index : index + 1] == b"\n"):
                         logger_warning(
-                            "Found trailing newline in stream data, check if output is OK", __name__
+                            "Found trailing newline in stream data, check if output is OK", source=__name__
                         )
                         break
                     # Raising an exception here breaks all image extraction for this file, which might
                     # not be desirable. For this reason, indicate that the output is most likely wrong,
                     # as processing stopped after the first EOD marker. See issue #3517.
                     logger_warning(
-                        "Early EOD in RunLengthDecode, check if output is OK", __name__
+                        "Early EOD in RunLengthDecode, check if output is OK", source=__name__
                     )
                 break
             if length < 128:
@@ -525,7 +525,7 @@ class ASCII85Decode:
             return a85decode(data, adobe=True, ignorechars=WHITESPACES_AS_BYTES)
         except ValueError as error:
             if error.args[0] == "Ascii85 encoded byte sequences must end with b'~>'":
-                logger_warning("Ignoring missing Ascii85 end marker.", __name__)
+                logger_warning("Ignoring missing Ascii85 end marker.", source=__name__)
                 return a85decode(data, adobe=False, ignorechars=WHITESPACES_AS_BYTES)
             raise
 
@@ -759,7 +759,7 @@ class JBIG2Decode:
                 )
             if result.stderr:
                 for line in result.stderr.decode("utf-8").splitlines():
-                    logger_warning(line, __name__)
+                    logger_warning(line, source=__name__)
             if result.returncode != 0:
                 raise PdfStreamError(f"Unable to decode JBIG2 data. Exit code: {result.returncode}")
         return result.stdout

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -219,9 +219,12 @@ class TextStreamAppearance(BaseStreamAppearance):
                 lines = [(text_width_unscaled * font_size, text)]
         elif is_comb:
             if max_length and len(text) > max_length:
-                logger_warning (
-                    f"Length of text {text} exceeds maximum length ({max_length}) of field, input truncated.",
-                    source=__name__
+                logger_warning(
+                    "Length of text %(text)s exceeds maximum length (%(max_length)d) "
+                    "of field, input truncated.",
+                    source=__name__,
+                    text=text,
+                    max_length=max_length,
                 )
             # We act as if each character is one line, because we draw it separately later on
             lines = [(

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -221,7 +221,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             if max_length and len(text) > max_length:
                 logger_warning (
                     f"Length of text {text} exceeds maximum length ({max_length}) of field, input truncated.",
-                    __name__
+                    source=__name__
                 )
             # We act as if each character is one line, because we draw it separately later on
             lines = [(
@@ -345,7 +345,11 @@ class TextStreamAppearance(BaseStreamAppearance):
         if font_resource:
             font = Font.from_font_resource(font_resource)
         else:
-            logger_warning(f"Font dictionary for {font_name} not found; defaulting to Helvetica.", __name__)
+            logger_warning(
+                "Font dictionary for %(font_name)s not found; defaulting to Helvetica.",
+                source=__name__,
+                font_name=font_name,
+            )
             font_name = "/Helv"
             core_font_metrics = CORE_FONT_METRICS["Helvetica"]
             font = Font(
@@ -376,10 +380,11 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         if not encodable:
             logger_warning(
-                f"Text string '{text}' contains characters not supported by font encoding. "
+                "Text string '%(text)s' contains characters not supported by font encoding. "
                 "This may result in text corruption. "
                 "Consider calling writer.update_page_form_field_values with auto_regenerate=True.",
-                __name__
+                source=__name__,
+                text=text,
             )
 
         font_glyph_byte_map: dict[str, bytes]
@@ -440,7 +445,11 @@ class TextStreamAppearance(BaseStreamAppearance):
         if is_null_or_none(font_resource):
             if font_name.removeprefix("/") not in CORE_FONT_METRICS:
                 # Default to Helvetica if we haven't found a font resource and cannot construct one ourselves.
-                logger_warning(f"Font dictionary for {font_name} not found; defaulting to Helvetica.", __name__)
+                logger_warning(
+                    "Font dictionary for %(font_name)s not found; defaulting to Helvetica.",
+                    source=__name__,
+                    font_name=font_name,
+                )
                 font_name = "/Helvetica"
             core_font_metrics = CORE_FONT_METRICS[font_name.removeprefix("/")]
             font_resource = Font(

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -220,8 +220,10 @@ class TextStreamAppearance(BaseStreamAppearance):
         elif is_comb:
             if max_length and len(text) > max_length:
                 logger_warning(
-                    "Length of text %(text)s exceeds maximum length (%(max_length)d) "
-                    "of field, input truncated.",
+                    (
+                        "Length of text %(text)s exceeds maximum length (%(max_length)d) "
+                        "of field, input truncated."
+                    ),
                     source=__name__,
                     text=text,
                     max_length=max_length,

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -692,7 +692,7 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
                 text_string_object = str.__new__(cls, original_bytes.decode("utf-16"))
             except UnicodeDecodeError as exception:
                 logger_warning(
-                    "%(exception)s\ninitial string:%(initial_string)r",
+                    "%(exception)s; initial string: %(initial_string)r",
                     source=__name__,
                     exception=exception,
                     initial_string=exception.object,

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -497,7 +497,10 @@ class FloatObject(float, PdfObject):
             # If this isn't a valid decimal (happens in malformed PDFs)
             # fallback to 0
             logger_warning(
-                f"{e} : FloatObject ({value}) invalid; use 0.0 instead", __name__
+                "%(error)s : FloatObject (%(value)s) invalid; use 0.0 instead",
+                source=__name__,
+                error=e,
+                value=value,
             )
             return float.__new__(cls, 0.0)
 
@@ -552,7 +555,7 @@ class NumberObject(int, PdfObject):
         try:
             return int.__new__(cls, int(value))
         except ValueError:
-            logger_warning(f"NumberObject({value}) invalid; use 0 instead", __name__)
+            logger_warning("NumberObject(%(value)s) invalid; use 0 instead", source=__name__, value=value)
             return int.__new__(cls, 0)
 
     def clone(
@@ -689,8 +692,10 @@ class TextStringObject(str, PdfObject):  # noqa: SLOT000
                 text_string_object = str.__new__(cls, original_bytes.decode("utf-16"))
             except UnicodeDecodeError as exception:
                 logger_warning(
-                    f"{exception!s}\ninitial string:{exception.object!r}",
-                    __name__,
+                    "%(exception)s\ninitial string:%(initial_string)r",
+                    source=__name__,
+                    exception=exception,
+                    initial_string=exception.object,
                 )
                 text_string_object = str.__new__(cls, exception.object[: exception.start].decode("utf-16"))
             text_string_object._original_bytes = original_bytes
@@ -917,9 +922,10 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
         except (UnicodeEncodeError, UnicodeDecodeError) as e:
             if not pdf.strict:
                 logger_warning(
-                    f"Illegal character in NameObject ({name!r}), "
+                    "Illegal character in NameObject (%(name)r), "
                     "you may need to adjust NameObject.CHARSETS",
-                    __name__,
+                    source=__name__,
+                    name=name,
                 )
                 return NameObject(name.decode("charmap"))
             raise PdfReadError(

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -922,8 +922,7 @@ class NameObject(str, PdfObject):  # noqa: SLOT000
         except (UnicodeEncodeError, UnicodeDecodeError) as e:
             if not pdf.strict:
                 logger_warning(
-                    "Illegal character in NameObject (%(name)r), "
-                    "you may need to adjust NameObject.CHARSETS",
+                    "Illegal character in NameObject (%(name)r), you may need to adjust NameObject.CHARSETS",
                     source=__name__,
                     name=name,
                 )

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -591,7 +591,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 except PdfReadError as exc:
                     if pdf is not None and pdf.strict:
                         raise
-                    logger_warning(exc.__repr__(), source=__name__)
+                    logger_warning("%(exception)r", source=__name__, exception=exc)
                     continue
                 tok = read_non_whitespace(stream)
                 stream.seek(-1, 1)
@@ -601,7 +601,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             except Exception as exc:
                 if pdf is not None and pdf.strict:
                     raise PdfReadError(exc.__repr__())
-                logger_warning(exc.__repr__(), source=__name__)
+                logger_warning("%(exception)r", source=__name__, exception=exc)
                 retval = DictionaryObject()
                 retval.update(data)
                 return retval  # return partial data
@@ -614,9 +614,10 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                     "Multiple definitions in dictionary at byte "
                     "%(position)s for key %(key)s"
                 )
+                values = {"position": hex(stream.tell()), "key": key}
                 if pdf is not None and pdf.strict:
-                    raise PdfReadError(msg % {"position": hex(stream.tell()), "key": key})
-                logger_warning(msg, source=__name__, position=hex(stream.tell()), key=key)
+                    raise PdfReadError(msg % values)
+                logger_warning(msg, source=__name__, **values)
 
         pos = stream.tell()
         s = read_non_whitespace(stream)
@@ -635,7 +636,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 if pdf is not None and pdf.strict:
                     raise PdfStreamError("Stream length not defined")
                 logger_warning(
-                    "Stream length not defined @pos=%(position)s",
+                    "Stream length not defined @pos=%(position)d",
                     source=__name__,
                     position=stream.tell(),
                 )

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -591,7 +591,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 except PdfReadError as exc:
                     if pdf is not None and pdf.strict:
                         raise
-                    logger_warning(exc.__repr__(), __name__)
+                    logger_warning(exc.__repr__(), source=__name__)
                     continue
                 tok = read_non_whitespace(stream)
                 stream.seek(-1, 1)
@@ -601,7 +601,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             except Exception as exc:
                 if pdf is not None and pdf.strict:
                     raise PdfReadError(exc.__repr__())
-                logger_warning(exc.__repr__(), __name__)
+                logger_warning(exc.__repr__(), source=__name__)
                 retval = DictionaryObject()
                 retval.update(data)
                 return retval  # return partial data
@@ -611,12 +611,12 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             else:
                 # multiple definitions of key not permitted
                 msg = (
-                    f"Multiple definitions in dictionary at byte "
-                    f"{hex(stream.tell())} for key {key}"
+                    "Multiple definitions in dictionary at byte "
+                    "%(position)s for key %(key)s"
                 )
                 if pdf is not None and pdf.strict:
-                    raise PdfReadError(msg)
-                logger_warning(msg, __name__)
+                    raise PdfReadError(msg % {"position": hex(stream.tell()), "key": key})
+                logger_warning(msg, source=__name__, position=hex(stream.tell()), key=key)
 
         pos = stream.tell()
         s = read_non_whitespace(stream)
@@ -635,7 +635,9 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 if pdf is not None and pdf.strict:
                     raise PdfStreamError("Stream length not defined")
                 logger_warning(
-                    f"Stream length not defined @pos={stream.tell()}", __name__
+                    "Stream length not defined @pos=%(position)s",
+                    source=__name__,
+                    position=stream.tell(),
                 )
                 data[NameObject(StreamAttributes.LENGTH)] = NumberObject(-1)
             length = data[StreamAttributes.LENGTH]
@@ -714,7 +716,7 @@ class TreeObject(DictionaryObject):
         while True:
             child_id = id(child)
             if child_id in visited:
-                logger_warning(f"Detected cycle in outline structure for {child}", __name__)
+                logger_warning("Detected cycle in outline structure for %(child)s", source=__name__, child=child)
                 return
             visited.add(child_id)
 
@@ -1093,10 +1095,17 @@ class StreamObject(DictionaryObject):
 
         if self.get("/Subtype", "") != "/Image":
             try:
-                msg = f"{self.indirect_reference} does not seem to be an Image"  # pragma: no cover
+                logger_warning(
+                    "%(indirect_reference)s does not seem to be an Image",  # pragma: no cover
+                    source=__name__,
+                    indirect_reference=self.indirect_reference,
+                )
             except AttributeError:
-                msg = f"{self.__repr__()} object does not seem to be an Image"  # pragma: no cover
-            logger_warning(msg, __name__)
+                logger_warning(
+                    "%(object_repr)s object does not seem to be an Image",  # pragma: no cover
+                    source=__name__,
+                    object_repr=self.__repr__(),
+                )
         extension, _, img = _xobj_to_image(self, pillow_parameters)
         if extension is None:
             return None  # pragma: no cover
@@ -1202,8 +1211,9 @@ class ContentStream(DecodedStreamObject):
                         # No need to emit an exception here for now - the PDF structure
                         # seems to already be broken beforehand in these cases.
                         logger_warning(
-                            f"Expected StreamObject, got {type(s_resolved).__name__} instead. Data might be wrong.",
-                            __name__
+                            "Expected StreamObject, got %(type_name)s instead. Data might be wrong.",
+                            source=__name__,
+                            type_name=type(s_resolved).__name__,
                         )
                     else:
                         new_data = s_resolved.get_data()

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1096,14 +1096,14 @@ class StreamObject(DictionaryObject):
 
         if self.get("/Subtype", "") != "/Image":
             try:
-                logger_warning(
-                    "%(indirect_reference)s does not seem to be an Image",  # pragma: no cover
+                logger_warning(  # pragma: no cover
+                    "%(indirect_reference)s does not seem to be an Image",
                     source=__name__,
                     indirect_reference=self.indirect_reference,
                 )
             except AttributeError:
-                logger_warning(
-                    "%(object_repr)s object does not seem to be an Image",  # pragma: no cover
+                logger_warning(  # pragma: no cover
+                    "%(object_repr)s object does not seem to be an Image",
                     source=__name__,
                     object_repr=self.__repr__(),
                 )

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1103,9 +1103,9 @@ class StreamObject(DictionaryObject):
                 )
             except AttributeError:
                 logger_warning(  # pragma: no cover
-                    "%(object_repr)s object does not seem to be an Image",
+                    "%(obj)r object does not seem to be an Image",
                     source=__name__,
-                    object_repr=self.__repr__(),
+                    obj=self,
                 )
         extension, _, img = _xobj_to_image(self, pillow_parameters)
         if extension is None:

--- a/pypdf/generic/_image_inline.py
+++ b/pypdf/generic/_image_inline.py
@@ -146,7 +146,7 @@ def extract_inline__run_length_decode(stream: StreamType) -> bytes:
                 data_out += data_buffered[: pos_tok + 1]
                 stream.seek(-len(data_buffered) + pos_tok + 1, 1)
             else:
-                logger_warning("Early EOD in RunLengthDecode of inline image, using fallback.", __name__)
+                logger_warning("Early EOD in RunLengthDecode of inline image, using fallback.", source=__name__)
                 ei_marker = data_buffered.find(b"EI")
                 if ei_marker > 0:
                     data_out += data_buffered[: ei_marker]

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -227,7 +227,7 @@ def _handle_flate(
             }[_get_image_mode(base, 0, "")[0]]
         except KeyError:  # pragma: no cover
             logger_warning(
-                "Base %(base)s not coded please share the pdf file with pypdf dev team",
+                "Base %(base)s not coded. Please share PDF with pypdf dev team",
                 source=__name__,
                 base=base,
             )
@@ -240,7 +240,7 @@ def _handle_flate(
                 if actual_count != expected_count:
                     if actual_count < expected_count:
                         logger_warning(
-                            "Not enough lookup values: Expected %(expected_count)s, got %(actual_count)s.",
+                            "Not enough lookup values: Expected %(expected_count)d, got %(actual_count)d.",
                             source=__name__,
                             expected_count=expected_count,
                             actual_count=actual_count,
@@ -248,7 +248,7 @@ def _handle_flate(
                         lookup += bytes([0] * (expected_count - actual_count))
                     elif not check_if_whitespace_only(lookup[expected_count:]):
                         logger_warning(
-                            "Too many lookup values: Expected %(expected_count)s, got %(actual_count)s.",
+                            "Too many lookup values: Expected %(expected_count)d, got %(actual_count)d.",
                             source=__name__,
                             expected_count=expected_count,
                             actual_count=actual_count,

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -93,8 +93,9 @@ def _get_image_mode(
         if color_space_str == "/DeviceCMYK" and color_components == 1:
             if original_color_space[1][0] != "/Black":
                 logger_warning(
-                    f"Color {original_color_space[1][0]} converted to Gray. Please share PDF with pypdf dev team",
-                    __name__,
+                    "Color %(color)s converted to Gray. Please share PDF with pypdf dev team",
+                    source=__name__,
+                    color=original_color_space[1][0],
                 )
             return "L", True
         mode, invert_color = _get_image_mode(
@@ -226,8 +227,9 @@ def _handle_flate(
             }[_get_image_mode(base, 0, "")[0]]
         except KeyError:  # pragma: no cover
             logger_warning(
-                f"Base {base} not coded please share the pdf file with pypdf dev team",
-                __name__,
+                "Base %(base)s not coded please share the pdf file with pypdf dev team",
+                source=__name__,
+                base=base,
             )
             lookup = None
         else:
@@ -238,14 +240,18 @@ def _handle_flate(
                 if actual_count != expected_count:
                     if actual_count < expected_count:
                         logger_warning(
-                            f"Not enough lookup values: Expected {expected_count}, got {actual_count}.",
-                            __name__
+                            "Not enough lookup values: Expected %(expected_count)s, got %(actual_count)s.",
+                            source=__name__,
+                            expected_count=expected_count,
+                            actual_count=actual_count,
                         )
                         lookup += bytes([0] * (expected_count - actual_count))
                     elif not check_if_whitespace_only(lookup[expected_count:]):
                         logger_warning(
-                            f"Too many lookup values: Expected {expected_count}, got {actual_count}.",
-                            __name__
+                            "Too many lookup values: Expected %(expected_count)s, got %(actual_count)s.",
+                            source=__name__,
+                            expected_count=expected_count,
+                            actual_count=actual_count,
                         )
                     lookup = lookup[:expected_count]
                 colors_arr = [lookup[:nb], lookup[nb:]]
@@ -260,7 +266,7 @@ def _handle_flate(
             else:
                 img = img.convert(conv)
                 if len(lookup) != (hival + 1) * nb:
-                    logger_warning(f"Invalid Lookup Table in {obj_as_text}", __name__)
+                    logger_warning("Invalid Lookup Table in %(obj_as_text)s", source=__name__, obj_as_text=obj_as_text)
                     lookup = None
                 elif mode == "L":
                     # gray lookup does not work: it is converted to a similar RGB lookup
@@ -439,7 +445,9 @@ def _xobj_to_image(
             alpha = _xobj_to_image(x_object[IA.S_MASK])[2]
             if img.size != alpha.size:
                 logger_warning(
-                    f"image and mask size not matching: {obj_as_text}", __name__
+                    "image and mask size not matching: %(obj_as_text)s",
+                    source=__name__,
+                    obj_as_text=obj_as_text,
                 )
             else:
                 # TODO: implement mask
@@ -585,6 +593,6 @@ def _xobj_to_image(
     try:  # temporary try/except until other fixes of images
         img = Image.open(BytesIO(data))
     except Exception as exception:
-        logger_warning(f"Failed loading image: {exception}", __name__)
+        logger_warning("Failed loading image: %(exception)s", source=__name__, exception=exception)
         img = None  # type: ignore[assignment,unused-ignore]  # TODO: Remove unused-ignore on Python 3.10
     return extension, data, img

--- a/pypdf/generic/_link.py
+++ b/pypdf/generic/_link.py
@@ -91,8 +91,10 @@ def extract_links(new_page: "PageObject", old_page: "PageObject") -> list[tuple[
         old_annotations = ArrayObject()
     if not isinstance(new_annotations, ArrayObject) or not isinstance(old_annotations, ArrayObject):
         logger_warning(
-            f"Expected annotation arrays: {old_annotations} {new_annotations}. Ignoring annotations.",
-            __name__
+            "Expected annotation arrays: %(old_annotations)s %(new_annotations)s. Ignoring annotations.",
+            source=__name__,
+            old_annotations=old_annotations,
+            new_annotations=new_annotations,
         )
         return []
     new_links = [
@@ -108,8 +110,10 @@ def extract_links(new_page: "PageObject", old_page: "PageObject") -> list[tuple[
 
     if len(new_links) != len(old_links):
         logger_warning(
-            f"Annotation sizes differ: {old_links} vs. {new_links}",
-            __name__,
+            "Annotation sizes differ: %(old_links)s vs. %(new_links)s",
+            source=__name__,
+            old_links=old_links,
+            new_links=new_links,
         )
 
     return list(zip(new_links, old_links))

--- a/pypdf/generic/_link.py
+++ b/pypdf/generic/_link.py
@@ -110,10 +110,10 @@ def extract_links(new_page: "PageObject", old_page: "PageObject") -> list[tuple[
 
     if len(new_links) != len(old_links):
         logger_warning(
-            "Annotation sizes differ: %(old_links)s vs. %(new_links)s",
+            "Annotation sizes differ: %(old_count)d vs. %(new_count)d",
             source=__name__,
-            old_links=old_links,
-            new_links=new_links,
+            old_count=len(old_links),
+            new_count=len(new_links),
         )
 
     return list(zip(new_links, old_links))

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -113,8 +113,11 @@ def read_string_from_stream(
                     # Then don't add anything to the actual string, since this
                     # line break was escaped:
                     continue
-                msg = f"Unexpected escaped string: {tok.decode('utf-8', 'ignore')}"
-                logger_warning(msg, __name__)
+                logger_warning(
+                    "Unexpected escaped string: %(token)s",
+                    source=__name__,
+                    token=tok.decode("utf-8", "ignore"),
+                )
                 txt.append(__BACKSLASH_CODE__)
         txt.append(ord(tok))
     return create_string_object(bytes(txt), forced_encoding)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -315,7 +315,7 @@ for page in reader.pages:
     assert result.stdout == b""
     assert (
         result.stderr.replace(b"\r", b"")
-        == b"Superfluous whitespace found in object header b'4' b'0'\n"
+        == b"Superfluous whitespace found in object header 4 0\n"
     )
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -315,7 +315,7 @@ for page in reader.pages:
     assert result.stdout == b""
     assert (
         result.stderr.replace(b"\r", b"")
-        == b"Superfluous whitespace found in object header 4 0\n"
+        == b"Superfluous whitespace found in object header b'4' b'0'\n"
     )
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2017,6 +2017,14 @@ def test_find_pdf_trailers(data: bytes, expected: list[int]):
     assert result == expected
 
 
+def test_cache_indirect_object_strict_overwrite_error():
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf", strict=True)
+    reader.resolved_objects[(99, 12345)] = None
+
+    with pytest.raises(PdfReadError, match=r"^Overwriting cache for 99 12345$"):
+        reader.cache_indirect_object(99, 12345, None)
+
+
 def test_objstm_batch_parse_caches_all_objects():
     """Resolving one ObjStm object should batch-cache all siblings."""
     reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -971,7 +971,7 @@ def test_form_topname_with_and_without_acroform(caplog):
         NameObject("/Parent")
     ] = DictionaryObject()
     r.add_form_topname("top")
-    assert "have a non-expected parent" in caplog.text
+    assert "has a non-expected parent" in caplog.text
 
 
 @pytest.mark.enable_socket

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -201,7 +201,7 @@ def test_layout_mode_indirect_sequence_font_widths(caplog):
     name = "2788_example_malformed.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     reader.pages[0].extract_text(extraction_mode="layout")
-    assert "Invalid font width definition" in caplog.text
+    assert any("Invalid font width definition" in message for message in caplog.messages)
 
 
 def dummy_visitor_text(text, ctm, tm, fd, fs):

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -7,7 +7,6 @@ The tested code might be in _page.py.
 import re
 from dataclasses import asdict
 from io import BytesIO
-from unittest.mock import patch
 
 import pytest
 
@@ -152,17 +151,13 @@ def test_font_class_to_dict():
 
 
 @pytest.mark.enable_socket
-@patch("pypdf._text_extraction._layout_mode._fixed_width_page.logger_warning")
-def test_uninterpretable_type3_font(mock_logger_warning):
+def test_uninterpretable_type3_font(caplog):
     url = "https://github.com/user-attachments/files/18551904/UninterpretableType3Font.pdf"
     name = "UninterpretableType3Font.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
     page = reader.pages[0]
     assert page.extract_text(extraction_mode="layout") == ""
-    mock_logger_warning.assert_called_with(
-        "PDF contains an uninterpretable font. Output will be incomplete.",
-        source="pypdf._text_extraction._layout_mode._fixed_width_page",
-    )
+    assert "PDF contains an uninterpretable font. Output will be incomplete." in caplog.messages
 
 
 @pytest.mark.enable_socket
@@ -219,16 +214,10 @@ def test_layout_mode_warnings(caplog):
     page = reader.pages[0]
     expected = "Argument visitor_text is ignored in layout mode"
 
-    def has_expected_warning() -> bool:
-        return any(
-            record.name == "pypdf._page" and record.getMessage() == expected
-            for record in caplog.records
-        )
-
     page.extract_text(extraction_mode="plain", visitor_text=dummy_visitor_text)
-    assert not has_expected_warning()
+    assert expected not in caplog.messages
     page.extract_text(extraction_mode="layout", visitor_text=dummy_visitor_text)
-    assert has_expected_warning()
+    assert expected in caplog.messages
 
 
 @pytest.mark.enable_socket

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -161,7 +161,7 @@ def test_uninterpretable_type3_font(mock_logger_warning):
     assert page.extract_text(extraction_mode="layout") == ""
     mock_logger_warning.assert_called_with(
         "PDF contains an uninterpretable font. Output will be incomplete.",
-        "pypdf._text_extraction._layout_mode._fixed_width_page"
+        source="pypdf._text_extraction._layout_mode._fixed_width_page",
     )
 
 
@@ -213,17 +213,22 @@ def dummy_visitor_text(text, ctm, tm, fd, fs):
     pass
 
 
-@patch("pypdf._page.logger_warning")
-def test_layout_mode_warnings(mock_logger_warning):
+def test_layout_mode_warnings(caplog):
     # Check that a warning is issued when an argument is ignored
     reader = PdfReader(RESOURCE_ROOT / "hello-world.pdf")
     page = reader.pages[0]
+    expected = "Argument visitor_text is ignored in layout mode"
+
+    def has_expected_warning() -> bool:
+        return any(
+            record.name == "pypdf._page" and record.getMessage() == expected
+            for record in caplog.records
+        )
+
     page.extract_text(extraction_mode="plain", visitor_text=dummy_visitor_text)
-    mock_logger_warning.assert_not_called()
+    assert not has_expected_warning()
     page.extract_text(extraction_mode="layout", visitor_text=dummy_visitor_text)
-    mock_logger_warning.assert_called_with(
-        "Argument visitor_text is ignored in layout mode", "pypdf._page"
-    )
+    assert has_expected_warning()
 
 
 @pytest.mark.enable_socket
@@ -403,7 +408,7 @@ def test_layout_mode_warns_on_malformed_content_stream(op, msg, caplog):
     """Ensures that imbalanced q/Q or EB/ET is handled gracefully."""
     text_show_operations(ops=iter([([], op)]), fonts={})
     assert caplog.records
-    assert caplog.records[-1].msg == msg
+    assert caplog.records[-1].getMessage() == msg
 
 
 def test_process_operation__cm_multiplication_issue():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ from pypdf._utils import (
     deprecation_no_replacement,
     format_iso8824_date,
     logger_error,
+    logger_warning,
     mark_location,
     matrix_multiply,
     parse_iso8824_date,
@@ -342,6 +343,18 @@ def test_logger_error(caplog):
     message = "Advanced encoding %(encoding)s not implemented yet"
     logger_error(message, source=__name__, encoding=encoding)
     assert "Advanced encoding {'/key': 'value'} not implemented yet" in caplog.text
+
+
+def test_logger_warning(caplog):
+    line = b"beginbfrange"
+    error = Exception("odd length string")
+    message = "Skipping broken line %(line)r: %(error)s"
+    logger_warning(message, source=__name__, line=line, error=error)
+    assert "Skipping broken line b'beginbfrange': odd length string" in caplog.text
+
+    caplog.clear()
+    logger_warning("No fields to update on this page", source=__name__)
+    assert "No fields to update on this page" in caplog.text
 
 
 def test_rename_kwargs():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -344,6 +344,10 @@ def test_logger_error(caplog):
     logger_error(message, source=__name__, encoding=encoding)
     assert "Advanced encoding {'/key': 'value'} not implemented yet" in caplog.text
 
+    caplog.clear()
+    logger_error("No fields to update on this page", source=__name__)
+    assert "No fields to update on this page" in caplog.text
+
 
 def test_logger_warning(caplog):
     line = b"beginbfrange"


### PR DESCRIPTION
## Summary

This is the follow-up PR for #3384 that covers `logger_warning`.

It updates `logger_warning` to support placeholder-based logging without breaking warning messages that do not interpolate values, and converts `logger_warning` call sites away from f-strings / preformatted warning messages.

## Changes

- update `logger_warning` to accept `message, source, **values`
- avoid passing an empty mapping when the warning has no placeholders
- convert `logger_warning` call sites to `%(name)s` / `%(name)r` placeholder style
- update direct mock expectations for the new placeholder-based call shape
- add regression coverage for placeholder and no-placeholder `logger_warning` usage

## Validation

Local validation completed:

- `ruff check .`
- `python3 -m py_compile pypdf/__init__.py tests/test_utils.py tests/test_text_extraction.py`
- `.venv/bin/python -m pytest tests/test_utils.py tests/test_encryption.py::test_aes_decrypt__wrong_padding tests/test_reader.py::test_read_pdf15_xref_stream__size_limit tests/test_reader.py::test_get_object_from_stream__size_limit tests/test_text_extraction.py::test_layout_mode_warnings tests/generic/test_data_structures.py::test_tree_object__cyclic_reference tests/generic/test_image_xobject.py tests/test_filters.py::test_ascii_hex_decode_missing_eod -q`

Note: a broader local run in this checkout hits missing sample/pdf_cache artifacts that are environment-specific here; the focused warning-related coverage above passed, and CI will exercise the full project matrix.

## Related issue

Fixes #3384

## AI assistance

Created with AI coding assistance via Hermes Agent.
