### PR TITLE
MAINT: PEP8 further compliance (manual check) constants.py module

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -611,7 +611,7 @@ class PdfDocCommon:
         elif obj.get(FA.FT, "") == "/Btn" and obj.get(FA.Ff, 0) & FA.FfBits.Radio != 0:
             states: list[str] = []
             retval[key][NameObject("/_States_")] = ArrayObject(states)
-            for k in obj.get(FA.Kids, {}):
+            for k in obj.get(FA.KIDS, {}):
                 k = k.get_object()
                 for s in list(k["/AP"]["/N"].keys()):
                     if s not in states:
@@ -652,7 +652,7 @@ class PdfDocCommon:
 
         for attr in field_attributes_tuple:
             if attr in (
-                FA.Kids,
+                FA.KIDS,
                 FA.AA,
             ):
                 continue
@@ -668,7 +668,7 @@ class PdfDocCommon:
                     }
                     if field[attr] in types:
                         fileobj.write(f"{attr_name}: {types[field[attr]]}\n")
-                elif attr == FA.Parent:
+                elif attr == FA.PARENT:
                     # Let's just write the name of the parent
                     try:
                         name = field[attr][FA.TM]

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1536,8 +1536,8 @@ class PageObject(DictionaryObject):
             if isinstance(annotations, ArrayObject):
                 for annotation in annotations:
                     annotation_obj = annotation.get_object()
-                    if ADA.Rect in annotation_obj:
-                        rectangle = annotation_obj[ADA.Rect]
+                    if ADA.RECT in annotation_obj:
+                        rectangle = annotation_obj[ADA.RECT]
                         if isinstance(rectangle, ArrayObject):
                             rectangle[0] = FloatObject(float(rectangle[0]) * sx)
                             rectangle[1] = FloatObject(float(rectangle[1]) * sy)

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -584,7 +584,7 @@ class PdfWriter(PdfDocCommon):
                     NameObject(CatalogDictionary.ACRO_FORM)
                 ] = self._add_object(DictionaryObject())
 
-            need_appearances = NameObject(InteractiveFormDictEntries.NeedAppearances)
+            need_appearances = NameObject(InteractiveFormDictEntries.NEED_APPEARANCES)
             cast(DictionaryObject, self._root_object[CatalogDictionary.ACRO_FORM])[
                 need_appearances
             ] = BooleanObject(state)
@@ -992,7 +992,7 @@ class PdfWriter(PdfDocCommon):
         if CatalogDictionary.ACRO_FORM not in self._root_object:
             raise PyPdfError("No /AcroForm dictionary in PDF of PdfWriter Object")
         acro_form = cast(DictionaryObject, self._root_object[CatalogDictionary.ACRO_FORM])
-        if InteractiveFormDictEntries.Fields not in acro_form:
+        if InteractiveFormDictEntries.FIELDS not in acro_form:
             raise PyPdfError("No /Fields dictionary in PDF of PdfWriter Object")
         if isinstance(auto_regenerate, bool):
             self.set_need_appearances_writer(auto_regenerate)
@@ -1021,7 +1021,7 @@ class PdfWriter(PdfDocCommon):
                 ).get_object()
 
             for field, value in fields.items():
-                rectangle = cast(RectangleObject, annotation[AA.Rect])
+                rectangle = cast(RectangleObject, annotation[AA.RECT])
                 if not (
                     self._get_qualified_field_name(parent_annotation) == field
                     or parent_annotation.get("/T", None) == field
@@ -1119,10 +1119,10 @@ class PdfWriter(PdfDocCommon):
             af = DictionaryObject()
             self._root_object[NameObject(CatalogDictionary.ACRO_FORM)] = af
         try:
-            fields = cast(ArrayObject, af[InteractiveFormDictEntries.Fields])
+            fields = cast(ArrayObject, af[InteractiveFormDictEntries.FIELDS])
         except KeyError:
             fields = ArrayObject()
-            af[NameObject(InteractiveFormDictEntries.Fields)] = fields
+            af[NameObject(InteractiveFormDictEntries.FIELDS)] = fields
 
         if "/Annots" not in page:
             return lst
@@ -2322,12 +2322,12 @@ class PdfWriter(PdfDocCommon):
         lnk = DictionaryObject()
         lnk.update(
             {
-                NameObject(AA.Type): NameObject("/Annot"),
-                NameObject(AA.Subtype): NameObject("/Link"),
+                NameObject(AA.TYPE): NameObject("/Annot"),
+                NameObject(AA.SUBTYPE): NameObject("/Link"),
                 NameObject(AA.P): page_link,
-                NameObject(AA.Rect): rect,
+                NameObject(AA.RECT): rect,
                 NameObject("/H"): NameObject("/I"),
-                NameObject(AA.Border): ArrayObject(border_arr),
+                NameObject(AA.BORDER): ArrayObject(border_arr),
                 NameObject("/A"): lnk2,
             }
         )
@@ -3388,8 +3388,8 @@ def _create_outline_item(
     if italic or bold:
         format_flag = 0
         if italic:
-            format_flag += OutlineFontFlag.italic
+            format_flag += OutlineFontFlag.ITALIC
         if bold:
-            format_flag += OutlineFontFlag.bold
+            format_flag += OutlineFontFlag.BOLD
         outline_item.update({NameObject("/F"): NumberObject(format_flag)})
     return outline_item

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -393,7 +393,7 @@ class FieldDictionaryAttributes:
         * Choice (Ch) (Table 8.79 PDF 1.7 reference)
         """
 
-        Readonly = 1 << 0
+        ReadOnly = 1 << 0
         """common to Tx/Btn/Ch in Table 8.70"""
         Required = 1 << 1
         """common to Tx/Btn/Ch in Table 8.70"""

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -198,7 +198,7 @@ class PageAttributes:
 class FileSpecificationDictionaryEntries:
     """Table 3.41 Entries in a file specification dictionary."""
 
-    Type = "/Type"
+    TYPE = "/Type"
     FS = "/FS"  # The name of the file system to be used to interpret this file specification
     F = "/F"  # A file specification string of the form described in §3.10.1
     UF = "/UF"  # A Unicode string of the file as described in §3.10.1
@@ -335,10 +335,10 @@ class GoToActionArguments:
 class AnnotationDictionaryAttributes:
     """Table 8.15 Entries common to all annotation dictionaries."""
 
-    Type = "/Type"
-    Subtype = "/Subtype"
-    Rect = "/Rect"
-    Contents = "/Contents"
+    TYPE = "/Type"
+    SUBTYPE = "/Subtype"
+    RECT = "/Rect"
+    CONTENTS = "/Contents"
     P = "/P"
     NM = "/NM"
     M = "/M"
@@ -346,16 +346,16 @@ class AnnotationDictionaryAttributes:
     AP = "/AP"
     AS = "/AS"
     DA = "/DA"
-    Border = "/Border"
+    BORDER = "/Border"
     C = "/C"
-    StructParent = "/StructParent"
+    STRUCT_PARENT = "/StructParent"
     OC = "/OC"
 
 
 class InteractiveFormDictEntries:
-    Fields = "/Fields"
-    NeedAppearances = "/NeedAppearances"
-    SigFlags = "/SigFlags"
+    FIELDS = "/Fields"
+    NEED_APPEARANCES = "/NeedAppearances"
+    SIG_FLAGS = "/SigFlags"
     CO = "/CO"
     DR = "/DR"
     DA = "/DA"
@@ -372,8 +372,8 @@ class FieldDictionaryAttributes:
     """
 
     FT = "/FT"  # name, required for terminal fields
-    Parent = "/Parent"  # dictionary, required for children
-    Kids = "/Kids"  # array, sometimes required
+    PARENT = "/Parent"  # dictionary, required for children
+    KIDS = "/Kids"  # array, sometimes required
     T = "/T"  # text string, optional
     TU = "/TU"  # text string, optional
     TM = "/TM"  # text string, optional
@@ -393,7 +393,7 @@ class FieldDictionaryAttributes:
         * Choice (Ch) (Table 8.79 PDF 1.7 reference)
         """
 
-        ReadOnly = 1 << 0
+        Readonly = 1 << 0
         """common to Tx/Btn/Ch in Table 8.70"""
         Required = 1 << 1
         """common to Tx/Btn/Ch in Table 8.70"""
@@ -459,12 +459,12 @@ class FieldDictionaryAttributes:
             cls.TM,
             cls.T,
             cls.FT,
-            cls.Parent,
+            cls.PARENT,
             cls.TU,
             cls.Ff,
             cls.V,
             cls.DV,
-            cls.Kids,
+            cls.KIDS,
             cls.AA,
         )
 
@@ -485,7 +485,7 @@ class FieldDictionaryAttributes:
         """
         return {
             cls.FT: "Field Type",
-            cls.Parent: "Parent",
+            cls.PARENT: "Parent",
             cls.T: "Field Name",
             cls.TU: "Alternate Field Name",
             cls.TM: "Mapping Name",
@@ -498,7 +498,7 @@ class FieldDictionaryAttributes:
 class CheckboxRadioButtonAttributes:
     """Table 8.76 Field flags common to all field types."""
 
-    Opt = "/Opt"  # Options, Optional
+    OPT = "/Opt"  # Options, Optional
 
     @classmethod
     def attributes(cls) -> tuple[str, ...]:
@@ -514,7 +514,7 @@ class CheckboxRadioButtonAttributes:
             A tuple containing all the attribute constants.
 
         """
-        return (cls.Opt,)
+        return (cls.OPT,)
 
     @classmethod
     def attributes_dict(cls) -> dict[str, str]:
@@ -532,7 +532,7 @@ class CheckboxRadioButtonAttributes:
 
         """
         return {
-            cls.Opt: "Options",
+            cls.OPT: "Options",
         }
 
 
@@ -644,8 +644,8 @@ class CatalogDictionary:
 class OutlineFontFlag(IntFlag):
     """A class used as an enumerable flag for formatting an outline font."""
 
-    italic = 1
-    bold = 2
+    ITALIC = 1
+    BOLD = 2
 
 
 class PageLabelStyle:

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -485,7 +485,7 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         """
         # Calculate rectangle dimensions
-        _rectangle = cast(RectangleObject, annotation[AnnotationDictionaryAttributes.Rect])
+        _rectangle = cast(RectangleObject, annotation[AnnotationDictionaryAttributes.RECT])
         rectangle = RectangleObject((0, 0, abs(_rectangle[2] - _rectangle[0]), abs(_rectangle[3] - _rectangle[1])))
 
         # Get default appearance dictionary from annotation

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1567,12 +1567,12 @@ class Field(TreeObject):
     @property
     def parent(self) -> Optional[DictionaryObject]:
         """Read-only property accessing the parent of this field."""
-        return self.get(FieldDictionaryAttributes.Parent)
+        return self.get(FieldDictionaryAttributes.PARENT)
 
     @property
     def kids(self) -> Optional["ArrayObject"]:
         """Read-only property accessing the kids of this field."""
-        return self.get(FieldDictionaryAttributes.Kids)
+        return self.get(FieldDictionaryAttributes.KIDS)
 
     @property
     def name(self) -> Optional[str]:


### PR DESCRIPTION
This partially fixes the Issue 3231 by focusing on none public API inside the pypdf/constants.py module. 
[public API for constants module ](https://pypdf.readthedocs.io/en/stable/modules/constants.html)

In regards to constants.py line 586 ( op = "/op") and 602 (ca = "/ca"); they are being left in order to avoid breaking the test cases (test_constants.py::test_slash_prefix) line 36 which state the below 
```
 if cls == GraphicsStateParameters and attr in ["ca", "op"]:
                continue
```
The attribute is hardcoded so either we change the test case or ?
The reason is to keep PR into minium 
