### PR TITLE
STY: Import AnnotationDictionaryAttributes and ImageAttributes without using abbreviations

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -58,9 +58,12 @@ from ._utils import (
     logger_warning,
     matrix_multiply,
 )
-from .constants import _INLINE_IMAGE_KEY_MAPPING, _INLINE_IMAGE_VALUE_MAPPING
-from .constants import AnnotationDictionaryAttributes as ADA
-from .constants import ImageAttributes as IA
+from .constants import (
+    _INLINE_IMAGE_KEY_MAPPING,
+    _INLINE_IMAGE_VALUE_MAPPING,
+    AnnotationDictionaryAttributes,
+    ImageAttributes,
+)
 from .constants import PageAttributes as PG
 from .constants import Resources as RES
 from .errors import PageSizeNotDefinedError, PdfReadError
@@ -618,7 +621,7 @@ class PageObject(DictionaryObject):
         for o in x_object:
             if not isinstance(x_object[o], StreamObject):
                 continue
-            if x_object[o][IA.SUBTYPE] == "/Image":
+            if x_object[o][ImageAttributes.SUBTYPE] == "/Image":
                 lst.append(o if len(ancest) == 0 else [*ancest, o])
             else:  # is a form with possible images inside
                 lst.extend(self._get_ids_image(x_object[o], [*ancest, o], call_stack))
@@ -1536,8 +1539,8 @@ class PageObject(DictionaryObject):
             if isinstance(annotations, ArrayObject):
                 for annotation in annotations:
                     annotation_obj = annotation.get_object()
-                    if ADA.Rect in annotation_obj:
-                        rectangle = annotation_obj[ADA.Rect]
+                    if AnnotationDictionaryAttributes.Rect in annotation_obj:
+                        rectangle = annotation_obj[AnnotationDictionaryAttributes.Rect]
                         if isinstance(rectangle, ArrayObject):
                             rectangle[0] = FloatObject(float(rectangle[0]) * sx)
                             rectangle[1] = FloatObject(float(rectangle[1]) * sy)

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -60,12 +60,7 @@ from .constants import FilterTypeAbbreviations as FTA
 from .constants import FilterTypes as FT
 from .constants import ImageAttributes, StreamAttributes
 from .constants import LzwFilterParameters as LZW
-from .errors import (
-    DependencyError,
-    LimitReachedError,
-    PdfReadError,
-    PdfStreamError,
-)
+from .errors import DependencyError, LimitReachedError, PdfReadError, PdfStreamError
 from .generic import (
     ArrayObject,
     DictionaryObject,

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -58,9 +58,8 @@ from ._utils import (
 from .constants import CcittFaxDecodeParameters as CCITT
 from .constants import FilterTypeAbbreviations as FTA
 from .constants import FilterTypes as FT
-from .constants import ImageAttributes
+from .constants import ImageAttributes, StreamAttributes
 from .constants import LzwFilterParameters as LZW
-from .constants import StreamAttributes
 from .errors import (
     DependencyError,
     LimitReachedError,

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -58,10 +58,15 @@ from ._utils import (
 from .constants import CcittFaxDecodeParameters as CCITT
 from .constants import FilterTypeAbbreviations as FTA
 from .constants import FilterTypes as FT
-from .constants import ImageAttributes as IA
+from .constants import ImageAttributes
 from .constants import LzwFilterParameters as LZW
 from .constants import StreamAttributes
-from .errors import DependencyError, LimitReachedError, PdfReadError, PdfStreamError
+from .errors import (
+    DependencyError,
+    LimitReachedError,
+    PdfReadError,
+    PdfStreamError,
+)
 from .generic import (
     ArrayObject,
     DictionaryObject,
@@ -839,7 +844,7 @@ def decode_stream_data(stream: StreamObject) -> bytes:
             data = RunLengthDecode.decode(data)
         elif filter_name in (FT.CCITT_FAX_DECODE, FTA.CCF):
             _deprecate_inline_image_filters(filter_name=filter_name, old_name=FTA.CCF, new_name=FT.CCITT_FAX_DECODE)
-            height = stream.get(IA.HEIGHT, ())
+            height = stream.get(ImageAttributes.HEIGHT, ())
             data = CCITTFaxDecode.decode(data, params, height)
         elif filter_name in (FT.DCT_DECODE, FTA.DCT):
             _deprecate_inline_image_filters(filter_name=filter_name, old_name=FTA.DCT, new_name=FT.DCT_DECODE)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -12,7 +12,7 @@ import pytest
 from pypdf import PdfReader, PdfWriter
 from pypdf._crypt_providers import crypt_provider
 from pypdf._reader import convert_to_int
-from pypdf.constants import ImageAttributes as IA
+from pypdf.constants import ImageAttributes
 from pypdf.constants import PageAttributes as PG
 from pypdf.constants import UserAccessPermissions as UAP
 from pypdf.errors import (
@@ -172,7 +172,7 @@ def test_get_annotations(src):
         for page in reader.pages:
             if PG.ANNOTS in page:
                 for annot in page[PG.ANNOTS]:
-                    subtype = annot.get_object()[IA.SUBTYPE]
+                    subtype = annot.get_object()[ImageAttributes.SUBTYPE]
                     if subtype == "/Text":
                         annot.get_object()[PG.CONTENTS]
 
@@ -192,7 +192,7 @@ def test_get_attachments(src, nb_attachments):
         if PG.ANNOTS in page:
             for annotation in page[PG.ANNOTS]:
                 annotobj = annotation.get_object()
-                if annotobj[IA.SUBTYPE] == "/FileAttachment":
+                if annotobj[ImageAttributes.SUBTYPE] == "/FileAttachment":
                     fileobj = annotobj["/FS"]
                     attachments[fileobj["/F"]] = fileobj["/EF"]["/F"].get_data()
     assert len(attachments) == nb_attachments


### PR DESCRIPTION
Aids readability when infrequently used in the code.