### PR TITLE
MAINT: Make get_data_from_url keyword-only

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,8 +41,7 @@ def _get_data_from_url(url: str) -> bytes:
     raise ValueError(f"Unknown error handling {url}")
 
 
-# TODO: Make keyword-only and drop name being optional.
-def get_data_from_url(url: Optional[str] = None, name: Optional[str] = None) -> bytes:
+def get_data_from_url(*, url: Optional[str] = None, name: str) -> bytes:
     """
     Download a File from a URL and return its contents.
 
@@ -58,9 +57,6 @@ def get_data_from_url(url: Optional[str] = None, name: Optional[str] = None) -> 
         Read File as bytes
 
     """
-    if name is None:
-        raise ValueError("A name must always be specified")
-
     if os.getenv("GITHUB_JOB", None) is not None:
         cache_dir = Path("tests", "pdf_cache").resolve()
     else:
@@ -135,7 +131,7 @@ def download_test_pdfs() -> None:
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
         futures = [
-            executor.submit(get_data_from_url, pdf["url"], name=pdf["local_filename"])
+            executor.submit(get_data_from_url, url=pdf["url"], name=pdf["local_filename"])
             for pdf in pdfs
         ]
         concurrent.futures.wait(futures)

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -217,7 +217,7 @@ def image_new_property(data):
 def test_image_new_property_performance(benchmark):
     url = "https://github.com/py-pdf/pypdf/files/11219022/pdf_font_garbled.pdf"
     name = "pdf_font_garbled.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
 
     benchmark(image_new_property, data)
 
@@ -230,5 +230,5 @@ def image_extraction(data):
 @pytest.mark.enable_socket
 def test_large_compressed_image_performance(benchmark):
     url = "https://github.com/py-pdf/pypdf/files/15306199/file_with_large_compressed_image.pdf"
-    data = BytesIO(get_data_from_url(url, name="file_with_large_compressed_image.pdf"))
+    data = BytesIO(get_data_from_url(url=url, name="file_with_large_compressed_image.pdf"))
     benchmark(image_extraction, data)

--- a/tests/generic/test_base.py
+++ b/tests/generic/test_base.py
@@ -25,7 +25,7 @@ def test_text_string_object__looks_like_bom(source: bytes, expected: str) -> Non
 def test_text_string_object__wrongly_detected_bom() -> None:
     url = "https://github.com/user-attachments/files/24401507/minimal.pdf"
     name = "issue3587.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader_page = reader.pages[0]
 
     writer = PdfWriter()

--- a/tests/generic/test_files.py
+++ b/tests/generic/test_files.py
@@ -101,7 +101,7 @@ def test_embedded_file__kids() -> None:
     #   * The input PDF file has been the `002-trivial-libre-office-writer.pdf` file.
     url = "https://github.com/user-attachments/files/18691309/embedded_files_kids.pdf"
     name = "embedded_files_kids.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     attachments = list(EmbeddedFile._load(reader.root_object))
     assert len(attachments) == 1
     attachment = attachments[0]
@@ -144,7 +144,7 @@ def test_embedded_file__kids() -> None:
 def test_embedded_file__ensure_params__existing_params() -> None:
     url = "https://github.com/user-attachments/files/18691309/embedded_files_kids.pdf"
     name = "embedded_files_kids.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     attachments = list(EmbeddedFile._load(reader.root_object))
     assert len(attachments) == 1
     attachment = attachments[0]
@@ -468,7 +468,7 @@ def test_embedded_file__create__kids_based_name_tree() -> None:
     """Test for issue #3473."""
     url = "https://github.com/user-attachments/files/18691309/embedded_files_kids.pdf"
     name = "embedded_files_kids.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
 
     writer.add_attachment("test.pdf", b"content")
 

--- a/tests/generic/test_image_inline.py
+++ b/tests/generic/test_image_inline.py
@@ -70,7 +70,7 @@ def test_is_followed_by_binary_data() -> None:
 def test_extract_inline_dct__early_end_of_file() -> None:
     url = "https://github.com/user-attachments/files/23056988/inline_dct__early_eof.pdf"
     name = "inline_dct__early_eof.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
 
     with pytest.raises(
@@ -85,7 +85,7 @@ def test_extract_inline_dct__early_end_of_file() -> None:
 def test_extract_inline_dct__multiple_eod() -> None:
     url = "https://github.com/user-attachments/files/23900687/cedolini_esempio-1.pdf"
     name = "issue3517.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     for page in reader.pages:
         for image in page.images:

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -23,7 +23,7 @@ def test_get_imagemode_recursion_depth() -> None:
     name = "issue2240.pdf"
     # Simple example: Just let the color space object reference itself.
     # The alternative would be to generate a chain of referencing objects.
-    content = get_data_from_url(url, name=name)
+    content = get_data_from_url(url=url, name=name)
     source = b"\n10 0 obj\n[ /DeviceN [ /HKS#2044#20K /Magenta /Yellow /Black ] 7 0 R 11 0 R 12 0 R ]\nendobj\n"
     target = b"\n10 0 obj\n[ /DeviceN [ /HKS#2044#20K /Magenta /Yellow /Black ] 10 0 R 11 0 R 12 0 R ]\nendobj\n"
     reader = PdfReader(BytesIO(content.replace(source, target)))
@@ -159,7 +159,7 @@ def test_handle_flate__autodesk_indexed() -> None:
 def test_get_mode_and_invert_color() -> None:
     url = "https://github.com/user-attachments/files/18381726/tika-957721.pdf"
     name = "tika-957721.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[12]
     for _name, image in page.images.items():  # noqa: PERF102
         assert image.image is not None
@@ -170,7 +170,7 @@ def test_get_mode_and_invert_color() -> None:
 def test_get_imagemode__empty_array() -> None:
     url = "https://github.com/user-attachments/files/23050451/poc.pdf"
     name = "issue3499.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
 
     with pytest.raises(expected_exception=PdfReadError, match=r"^ColorSpace field not found in .+"):
@@ -224,7 +224,7 @@ def test_p_image_with_alpha_mask() -> None:
 def test_handle_flate__icc_based__image_mode_1() -> None:
     url = "https://github.com/user-attachments/files/23756943/pypdf_bug_3534_iccbased.pdf"
     name = "issue3534.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
 
     image = page.images[0].image

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -52,7 +52,7 @@ from . import RESOURCE_ROOT, get_data_from_url
     ],
 )
 def test_text_extraction_slow(caplog, url: str, name: str, strict: bool):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)), strict=strict)
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)), strict=strict)
     for page in reader.pages:
         page.extract_text()
     assert caplog.text == ""
@@ -89,7 +89,7 @@ def test_text_extraction_slow(caplog, url: str, name: str, strict: bool):
 )
 def test_text_extraction_fast(caplog, url: str, name: str, strict: bool):
     """Text extraction runs without exceptions or warnings"""
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)), strict=strict)
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)), strict=strict)
     for page in reader.pages:
         page.extract_text()
     assert caplog.text == ""
@@ -133,7 +133,7 @@ def test_ascii_charset():
 def test_text_extraction_of_specific_pages(
     url: str, name: str, page_nb: int, within_text
 ):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert within_text in reader.pages[page_nb].extract_text()
 
 
@@ -168,7 +168,7 @@ def test_iss1533():
     ],
 )
 def test_cmap_encodings(caplog, url, name, page_index, within_text, caplog_text):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     extracted = reader.pages[page_index].extract_text()  # no error
     for contained in within_text:
         assert contained in extracted
@@ -256,7 +256,7 @@ def test_unigb_utf16():
         "https://github.com/user-attachments/files/16767536/W020240105322424121296.pdf"
     )
     name = "iss2812.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert "《中国能源展望 2060（2024 年版）》编写委员会" in reader.pages[1].extract_text()
 
 
@@ -267,7 +267,7 @@ def test_too_many_differences():
         "https://github.com/user-attachments/files/16911741/dumb_extract_text_crash.pdf"
     )
     name = "iss2836.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.pages[0].extract_text() == ""
 
 
@@ -277,7 +277,7 @@ def test_iss2925():
         "https://github.com/user-attachments/files/17621508/2305.09315.pdf"
     )
     name = "iss2925.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert "slicing on the PDG to extract the relevant contextual" in reader.pages[3].extract_text()
 
 
@@ -288,7 +288,7 @@ def test_iss2966():
         "https://github.com/user-attachments/files/17904233/repro_out.pdf"
     )
     name = "iss2966.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert "Lorem ipsum dolor sit amet" in reader.pages[0].extract_text()
 
 
@@ -297,7 +297,7 @@ def test_binascii_odd_length_string(caplog):
     """Tests for #2216"""
     url = "https://github.com/user-attachments/files/18199642/iss2216.pdf"
     name = "iss2216.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     page = reader.pages[0]
     assert "\n(Many other theorems may\n" in page.extract_text()
@@ -309,7 +309,7 @@ def test_standard_encoding(caplog):
     """Tests for #3156"""
     url = "https://github.com/user-attachments/files/18983503/standard-encoding.pdf"
     name = "issue3156.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     page = reader.pages[0]
     assert page.extract_text() == "Lorem ipsum"
@@ -321,7 +321,7 @@ def test_function_in_font_widths(caplog):
     """Tests for #3153"""
     url = "https://github.com/user-attachments/files/18945709/Marseille_pypdf_level_0.2._compressed.pdf"
     name = "issue3153.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     page = reader.pages[455]
     assert "La vulnérabilité correspond aux conséquences potentielles" in page.extract_text()

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -83,7 +83,7 @@ def test_lzw_decoder_large_stream_performance(caplog):
 def test_lzw_decoder__output_limit():
     url = "https://github.com/user-attachments/files/23057035/lzw__output_limit.pdf"
     name = "lzw__output_limit.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
 
     with pytest.raises(

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -513,7 +513,7 @@ def test_aes256_decrypt_does_not_call_md5(monkeypatch):
 def test_reader__decryption_error_handling(caplog) -> None:
     url = "https://github.com/user-attachments/files/26631168/757.pdf"
     name = "issue3725.pdf"
-    data = get_data_from_url(url, name=name)
+    data = get_data_from_url(url=url, name=name)
 
     reader = PdfReader(BytesIO(data), strict=False)
     assert len(reader.pages) == 7

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -489,7 +489,7 @@ def test_2bits_image():
     reader = PdfReader(BytesIO(get_data_from_url(name="paid.pdf")))
     url_png = "https://user-images.githubusercontent.com/4083478/253568117-ca95cc85-9dea-4145-a5e0-032f1c1aa322.png"
     name_png = "Paid.png"
-    refimg = BytesIO(get_data_from_url(url_png, name=name_png))
+    refimg = BytesIO(get_data_from_url(url=url_png, name=name_png))
     data = reader.pages[0].images[0]
     assert image_similarity(data.image, refimg) > 0.99
 
@@ -502,10 +502,10 @@ def test_gray_devicen_cmyk():
     """
     url = "https://github.com/py-pdf/pypdf/files/12080338/example_121.pdf"
     name = "gray_cmyk.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url_png = "https://user-images.githubusercontent.com/4083478/254545494-42df4949-1557-4f2d-acca-6be6e8de1122.png"
     name_png = "velo.png"
-    refimg = BytesIO(get_data_from_url(url_png, name=name_png))
+    refimg = BytesIO(get_data_from_url(url=url_png, name=name_png))
     data = reader.pages[0].images[0]
     assert data.image.mode == "L"
     assert image_similarity(data.image, refimg) > 0.999
@@ -516,15 +516,15 @@ def test_runlengthdecode():
     """From #1954, test with 2bits image. TODO: 4bits also"""
     url = "https://github.com/py-pdf/pypdf/files/12159941/out.pdf"
     name = "RunLengthDecode.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url_png = "https://user-images.githubusercontent.com/4083478/255940800-6d63972e-a3d6-4cf9-aa6f-0793af24cded.png"
     name_png = "RunLengthDecode.png"
-    refimg = BytesIO(get_data_from_url(url_png, name=name_png))
+    refimg = BytesIO(get_data_from_url(url=url_png, name=name_png))
     data = reader.pages[0].images[0]
     assert image_similarity(data.image, refimg) > 0.999
     url = "https://github.com/py-pdf/pypdf/files/12162905/out.pdf"
     name = "FailedRLE1.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].images[0]
     url = "https://github.com/py-pdf/pypdf/files/12162926/out.pdf"
     name = "FailedRLE2.pdf"
@@ -539,10 +539,10 @@ def test_gray_separation_cmyk():
     """
     url = "https://github.com/py-pdf/pypdf/files/12143372/tt.pdf"
     name = "TestWithSeparationBlack.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url_png = "https://user-images.githubusercontent.com/4083478/254545494-42df4949-1557-4f2d-acca-6be6e8de1122.png"
     name_png = "velo.png"  # reused
-    refimg = BytesIO(get_data_from_url(url_png, name=name_png))
+    refimg = BytesIO(get_data_from_url(url=url_png, name=name_png))
     data = reader.pages[0].images[0]
     assert data.image.mode == "L"
     assert image_similarity(data.image, refimg) > 0.999
@@ -553,7 +553,7 @@ def test_singleton_device():
     """From #2023"""
     url = "https://github.com/py-pdf/pypdf/files/12177287/tt.pdf"
     name = "pypdf_with_arr_deviceRGB.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].images[0]
 
 
@@ -562,7 +562,7 @@ def test_jpx_no_spacecode():
     """From #2061"""
     url = "https://github.com/py-pdf/pypdf/files/12253581/tt2.pdf"
     name = "jpx_no_spacecode.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     im = reader.pages[0].images[0]
     # create an object without filter and without colorspace
     # just for coverage
@@ -577,7 +577,7 @@ def test_encodedstream_lookup():
     """From #2124"""
     url = "https://github.com/py-pdf/pypdf/files/12455580/10.pdf"
     name = "iss2124.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[12].images[0]
 
 
@@ -586,7 +586,7 @@ def test_convert_1_to_la():
     """From #2165"""
     url = "https://github.com/py-pdf/pypdf/files/12543290/whitepaper.WBT.token.blockchain.whitepaper.pdf"
     name = "iss2165.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for i in reader.pages[13].images:
         _ = i
 
@@ -596,7 +596,7 @@ def test_nested_device_n_color_space():
     """From #2240"""
     url = "https://github.com/py-pdf/pypdf/files/12814018/out1.pdf"
     name = "issue2240.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].images[0]
 
 
@@ -606,7 +606,7 @@ def test_flate_decode_with_image_mode_1():
     """From #2248"""
     url = "https://github.com/py-pdf/pypdf/files/12847339/Prototype-Declaration-VDE4110-HYD-5000-20000-ZSS-DE.pdf"
     name = "issue2248.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for image in reader.pages[7].images:
         _ = image
 
@@ -616,7 +616,7 @@ def test_flate_decode_with_image_mode_1__whitespace_at_end_of_lookup():
     """From #2331"""
     url = "https://github.com/py-pdf/pypdf/files/13611048/out1.pdf"
     name = "issue2331.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].images[0]
 
 
@@ -625,7 +625,7 @@ def test_ascii85decode__invalid_end__recoverable(caplog):
     """From #2996"""
     url = "https://github.com/user-attachments/files/18050808/1af7d56a-5c8c-4914-85b3-b2536a5525cd.pdf"
     name = "issue2996.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     page = reader.pages[1]
     assert page.extract_text() == ""
@@ -657,7 +657,7 @@ def test_ascii85decode__ignore_whitespaces(caplog):
 def test_ccitt_fax_decode__black_is_1():
     url = "https://github.com/user-attachments/files/19288881/imagemagick-CCITTFaxDecode_BlackIs1-true.pdf"
     name = "issue3193.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     other_reader = PdfReader(RESOURCE_ROOT / "imagemagick-CCITTFaxDecode.pdf")
 
     actual_image = reader.pages[0].images[0].image
@@ -667,7 +667,7 @@ def test_ccitt_fax_decode__black_is_1():
     assert expected_pixels == actual_pixels
 
     # AttributeError: 'NullObject' object has no attribute 'get'
-    data_modified = get_data_from_url(url, name=name).replace(
+    data_modified = get_data_from_url(url=url, name=name).replace(
         b"/DecodeParms [ << /K -1 /BlackIs1 true /Columns 16 /Rows 16 >> ]",
         b"/DecodeParms [ null ]"
     )
@@ -681,7 +681,7 @@ def test_flate_decode__image_is_none_due_to_size_limit(caplog):
     name = "issue3220.pdf"
 
     with mock.patch("pypdf.filters.ZLIB_MAX_OUTPUT_LENGTH", 0):
-        reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+        reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
         images = reader.pages[0].images
         assert len(images) == 1
         image = images[0]
@@ -698,7 +698,7 @@ def test_flate_decode__image_is_none_due_to_size_limit(caplog):
 def test_flate_decode__not_rectangular(caplog):
     url = "https://github.com/user-attachments/files/19663603/issue3241_compressed.txt"
     name = "issue3241.txt"
-    data = get_data_from_url(url, name=name)
+    data = get_data_from_url(url=url, name=name)
     decode_parms = DictionaryObject()
     decode_parms[NameObject("/Predictor")] = NumberObject(15)
     decode_parms[NameObject("/Columns")] = NumberObject(4881)
@@ -707,7 +707,7 @@ def test_flate_decode__not_rectangular(caplog):
 
     url = "https://github.com/user-attachments/assets/c5695850-c076-4255-ab72-7c86851a4a04"
     name = "issue3241.png"
-    expected_data = BytesIO(get_data_from_url(url, name=name))
+    expected_data = BytesIO(get_data_from_url(url=url, name=name))
     assert image_similarity(expected_data, actual_image) == 1
     assert caplog.messages == ["Image data is not rectangular. Adding padding."]
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -12,7 +12,7 @@ from tests import get_data_from_url
 def test_form_button__v_value_should_be_name_object():
     url = "https://github.com/user-attachments/files/18736500/blank-form.pdf"
     name = "issue3115.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter(clone_from=reader)
     writer.update_page_form_field_values(
         writer.pages[0],

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -730,7 +730,7 @@ def test_insert_child_before_last_with_multiple_existing():
     ],
 )
 def test_extract_text(caplog, url: str, name: str, caplog_content: str):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for page in reader.pages:
         page.extract_text()
     if caplog_content == "":
@@ -745,7 +745,7 @@ def test_text_string_write_to_stream():
     url = "https://github.com/user-attachments/files/18381698/tika-924562.pdf"
     name = "tika-924562.pdf"
 
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
     for page in writer.pages:
@@ -757,7 +757,7 @@ def test_bool_repr(tmp_path):
     url = "https://github.com/user-attachments/files/18381703/tika-932449.pdf"
     name = "tika-932449.pdf"
 
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     write_path = tmp_path / "tmp-fields-report.txt"
     with open(write_path, "w") as fp:
         fields = reader.get_fields(fileobj=fp)
@@ -781,14 +781,14 @@ def test_issue_997(pdf_file_path):
     name = "gh-issue-997.pdf"
 
     merger = PdfWriter()
-    merger.append(BytesIO(get_data_from_url(url, name=name)))  # here the error raises
+    merger.append(BytesIO(get_data_from_url(url=url, name=name)))  # here the error raises
     with open(pdf_file_path, "wb") as f:
         merger.write(f)
     merger.close()
 
     # Strict
     merger = PdfWriter()
-    merger.append(BytesIO(get_data_from_url(url, name=name)))  # here the error raises
+    merger.append(BytesIO(get_data_from_url(url=url, name=name)))  # here the error raises
     with open(pdf_file_path, "wb") as f:
         merger.write(f)
     merger.close()
@@ -1018,7 +1018,7 @@ def test_append_with_indirectobject_not_pointing(caplog):
     """
     url = "https://github.com/py-pdf/pypdf/files/10729142/document.pdf"
     name = "tst_iss1631.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=False)
     writer = PdfWriter()
     writer.append(reader)
@@ -1034,7 +1034,7 @@ def test_iss1615_1673():
     # #1615
     url = "https://github.com/py-pdf/pypdf/files/10671366/graph_letter.pdf"
     name = "graph_letter.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
     assert (
@@ -1046,7 +1046,7 @@ def test_iss1615_1673():
     # #1673
     url = "https://github.com/py-pdf/pypdf/files/10848750/budgeting-loan-form-sf500.pdf"
     name = "budgeting-loan-form-sf500.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
 
@@ -1056,7 +1056,7 @@ def test_destination_withoutzoom():
     """Cf issue #1832"""
     url = "https://github.com/user-attachments/files/15605648/2021_book_security.pdf"
     name = "2021_book_security.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.outline
 
     out = BytesIO()
@@ -1110,7 +1110,7 @@ def test_set_data_2():
     """
     url = "https://github.com/user-attachments/files/16796095/f5471sm-2.pdf"
     name = "iss2780.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.root_object["/AcroForm"]["/XFA"][7].set_data(b"test")
     assert writer.root_object["/AcroForm"]["/XFA"][7].get_object()["/Filter"] == [
         "/FlateDecode"
@@ -1123,7 +1123,7 @@ def test_calling_indirect_objects():
     """Cope with cases where attributes/items are called from indirectObject"""
     url = "https://github.com/user-attachments/files/15605648/2021_book_security.pdf"
     name = "2021_book_security.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.trailer.get("/Info")["/Creator"]
     reader.pages[0]["/Contents"][0].get_data()
     writer = PdfWriter(clone_from=reader)
@@ -1142,7 +1142,7 @@ def test_calling_indirect_objects():
 def test_indirect_object_page_dimensions():
     url = "https://github.com/py-pdf/pypdf/files/13302338/Zymeworks_Corporate.Presentation_FINAL1101.pdf.pdf"
     name = "issue2287.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=False)
     mediabox = reader.pages[0].mediabox
     assert mediabox == RectangleObject((0, 0, 792, 612))
@@ -1366,7 +1366,7 @@ def test_dictionaryobject__length_0_stream():
     """Test for issue #3052."""
     url = "https://github.com/user-attachments/files/18734105/correct.pdf"
     name = "issue3052.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     output = BytesIO()
     writer.write(output)
     assert b"\n8 0 obj\n<<\n/Length 0\n>>\nstream\n\nendstream\nendobj\n" in output.getvalue()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -269,14 +269,14 @@ def test_devicen_cmyk_black_only():
     """Cf #2321"""
     url = "https://github.com/py-pdf/pypdf/files/13501846/Addressing_Adversarial_Attacks.pdf"
     name = "iss2321.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/cc2dabc1-86e6-4179-a8a4-2b0efea124be"
     name = "iss2321_img0.pdf"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[5].images[0].image, img) >= 0.99
     url = "https://github.com/py-pdf/pypdf/assets/4083478/6b64a949-42be-40d5-9eea-95707f350d89"
     name = "iss2321_img1.pdf"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[10].images[0].image, img) >= 0.99
 
 
@@ -285,7 +285,7 @@ def test_bi_in_text():
     """Cf #2456"""
     url = "https://github.com/py-pdf/pypdf/files/14322910/BI_text_with_one_image.pdf"
     name = "BI_text_with_one_image.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.pages[0].images.keys() == ["~0~"]
     assert reader.pages[0].images[0].name == "~0~.png"
 
@@ -295,7 +295,7 @@ def test_cmyk_no_filter():
     """Cf #2522"""
     url = "https://github.com/py-pdf/pypdf/files/14614887/out3.pdf"
     name = "iss2522.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].images[0].image
 
 
@@ -304,10 +304,10 @@ def test_separation_1byte_to_rgb_inverted():
     """Cf #2343"""
     url = "https://github.com/py-pdf/pypdf/files/13679585/test2_P038-038.pdf"
     name = "iss2343.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/b7f41897-96ef-4ea6-b165-5ef307a92b87"
     name = "iss2343.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[0].images[0].image, img) >= 0.99
     obj = reader.pages[0].images[0].indirect_reference.get_object()
     obj.set_data(obj.get_data() + b"\x00")
@@ -320,10 +320,10 @@ def test_data_with_lf():
     """Cf #2343"""
     url = "https://github.com/py-pdf/pypdf/files/13946477/panda.pdf"
     name = "iss2343b.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/1120b0cf-a67a-403f-aa1a-9a191cbc087f"
     name = "iss2343b0.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[8].images[9].image, img) == 1.0
 
 
@@ -332,7 +332,7 @@ def test_oserror():
     """Cf #2265"""
     url = "https://github.com/py-pdf/pypdf/files/13127130/Binance.discovery.responses.2.gov.uscourts.dcd.256060.140.1.pdf"
     name = "iss2265.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[2].images[1]
     # Due to errors in translation in pillow we may not get
     # the correct image. Therefore we cannot use `image_similarity`.
@@ -374,11 +374,11 @@ def test_corrupted_jpeg_iss2266(pdf, pdf_name, images, images_name, filtr):
     """
     url = pdf
     name = pdf_name
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = images
     name = images_name
     print(pdf_name, images_name)  # noqa: T201
-    with ZipFile(BytesIO(get_data_from_url(url, name=name)), "r") as zf:
+    with ZipFile(BytesIO(get_data_from_url(url=url, name=name)), "r") as zf:
         for fn in zf.namelist():
             sp = fn.split("_")
             p, i = int(sp[1]), int(sp[2])
@@ -394,7 +394,7 @@ def test_corrupted_jpeg_iss2266(pdf, pdf_name, images, images_name, filtr):
 def test_large_compressed_image():
     url = "https://github.com/py-pdf/pypdf/files/15306199/file_with_large_compressed_image.pdf"
     reader = PdfReader(
-        BytesIO(get_data_from_url(url, name="file_with_large_compressed_image.pdf"))
+        BytesIO(get_data_from_url(url=url, name="file_with_large_compressed_image.pdf"))
     )
     list(reader.pages[0].images)
 
@@ -404,13 +404,13 @@ def test_ff_fe_starting_lut():
     """Cf issue #2660"""
     url = "https://github.com/py-pdf/pypdf/files/15385628/original_before_merge.pdf"
     name = "iss2660.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     b = BytesIO()
     writer.write(b)
     reader = PdfReader(b)
     url = "https://github.com/py-pdf/pypdf/assets/4083478/6150700d-87fd-43a2-8695-c2c05a44838c"
     name = "iss2660.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(writer.pages[1].images[0].image, img) == 1.0
     assert image_similarity(reader.pages[1].images[0].image, img) == 1.0
 
@@ -420,7 +420,7 @@ def test_inline_image_extraction():
     """Cf #2598"""
     url = "https://github.com/py-pdf/pypdf/files/14982414/lebo102.pdf"
     name = "iss2598.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # there is no error because images are correctly extracted
     reader.pages[1].extract_text()
     reader.pages[2].extract_text()
@@ -428,16 +428,16 @@ def test_inline_image_extraction():
 
     url = "https://github.com/py-pdf/pypdf/files/15210011/Pages.62.73.from.0560-22_WSP.Plan_July.2022_Version.1.pdf"
     name = "iss2598a.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].extract_text()
     reader.pages[1].extract_text()
 
     url = "https://github.com/mozilla/pdf.js/raw/master/test/pdfs/issue14256.pdf"
     name = "iss2598b.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/71bc5053-cfc7-44ba-b7be-8e2333e2c749"
     name = "iss2598b.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     for i in range(8):
         assert image_similarity(writer.pages[0].images[i].image, img) == 1
     writer.pages[0].extract_text()
@@ -469,18 +469,18 @@ def test_inline_image_extraction():
 
     url = "https://github.com/py-pdf/pypdf/files/15233597/bug1065245.pdf"
     name = "iss2598c.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/bfb221be-11bd-46fe-8129-55a58088a4b6"
     name = "iss2598c.jpg"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[0].images[0].image, img) >= 0.99
 
     url = "https://github.com/py-pdf/pypdf/files/15282904/tt.pdf"
     name = "iss2598d.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/1a770e1b-9ad2-4125-89ae-6069992dda23"
     name = "iss2598d.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[0].images[0].image, img) == 1
 
 
@@ -488,7 +488,7 @@ def test_inline_image_extraction():
 def test_extract_image_from_object(caplog):
     url = "https://github.com/py-pdf/pypdf/files/15176076/B2.pdf"
     name = "iss2613.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     image = reader.pages[0]["/Resources"]["/Pattern"]["/P1"]["/Resources"]["/XObject"][
         "/X1"
     ].decode_as_image()
@@ -521,10 +521,10 @@ def test_extract_jpeg_with_explicit_quality():
 def test_4bits_images(caplog):
     url = "https://github.com/user-attachments/files/16624406/tt.pdf"
     name = "iss2411.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/user-attachments/assets/53058564-9a28-4e4a-818f-a6528013d7dc"
     name = "iss2411.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert image_similarity(reader.pages[0].images[1].image, img) == 1.0
 
 
@@ -533,7 +533,7 @@ def test_no_filter_with_colorspace_as_list():
     """Tests for #2998"""
     url = "https://github.com/user-attachments/files/18058571/9bf7a2e2-72c8-4ac1-b8ae-164df16c8cef.pdf"
     name = "iss2998.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     page = reader.pages[0]
     page.images.items()
@@ -575,7 +575,7 @@ AAAAAAAA^B
 EI\nQ\n""".encode("latin1")  # noqa: E501
     url = "https://github.com/user-attachments/files/18943249/testing.pdf"
     name = "issue3107.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter(clone_from=reader)
     for page in writer.pages:
         page.transfer_rotation_to_content()
@@ -590,7 +590,7 @@ def test_jbig2decode():
     url = "https://github.com/py-pdf/pypdf/files/12090692/New.Jersey.Coinbase.staking.securities.charges.2023-0606_Coinbase-Penalty-and-C-D.pdf"
     name = "jbig2.pdf"
 
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
     image = next(iter(page.images))
     assert image.image.size == (5138, 6630)
@@ -599,7 +599,7 @@ def test_jbig2decode():
 
     url = "https://github.com/user-attachments/assets/d6f88c80-a2e0-4ea9-b1e0-34442041d004"
     name = "jbig2.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
 
     assert image_similarity(image.image, img) >= 0.999
 
@@ -610,7 +610,7 @@ def test_jbig2decode__jbig2globals():
     url = "https://github.com/user-attachments/files/20119148/out.pdf"
     name = "jbig2_globals.pdf"
 
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
     image = next(iter(page.images))
     assert image.image.size == (1067, 1067)
@@ -619,7 +619,7 @@ def test_jbig2decode__jbig2globals():
 
     url = "https://github.com/user-attachments/assets/7ac41ee3-9c13-44cf-aa74-8f106287e354"
     name = "jbig2_globals.png"
-    img = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
 
     # Wrong image: 0.9618265964800714
     assert image_similarity(image.image, img) >= 0.999
@@ -645,7 +645,7 @@ def test_jbig2decode__memory_limit():
     ]
 
     with mock.patch("pypdf.filters.JBIG2_MAX_OUTPUT_LENGTH", 5_000_000):
-        reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+        reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
         page = reader.pages[0]
         with pytest.raises(expected_exception=LimitReachedError, match=rf"({'|'.join(error_messages)})"):
             _ = next(iter(page.images))
@@ -655,6 +655,6 @@ def test_jbig2decode__memory_limit():
 def test_get_ids_image__resources_is_none():
     url = "https://github.com/user-attachments/files/18381726/tika-957721.pdf"
     name = "tika-957721.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[2]
     assert list(page.images.items()) == []

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -219,7 +219,7 @@ def test_merge_write_closed_fh_with_writer(pdf_file_path):
 def test_trim_outline_list_with_writer(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381771/tika-995175.pdf"
     name = "tika-995175.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.add_outline_item_dict(merger.outline[0])
@@ -231,7 +231,7 @@ def test_trim_outline_list_with_writer(pdf_file_path):
 def test_zoom_with_writer(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381769/tika-994759.pdf"
     name = "tika-994759.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -243,7 +243,7 @@ def test_zoom_with_writer(pdf_file_path):
 def test_zoom_xyz_no_left_with_add_page(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381704/tika-933322.pdf"
     name = "tika-933322.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     for p in reader.pages:
         merger.add_page(p)
@@ -255,7 +255,7 @@ def test_zoom_xyz_no_left_with_add_page(pdf_file_path):
 def test_zoom_xyz_no_left_with_writer(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381704/tika-933322.pdf"
     name = "tika-933322.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -267,7 +267,7 @@ def test_zoom_xyz_no_left_with_writer(pdf_file_path):
 def test_outline_item_with_writer(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381773/tika-997511.pdf"
     name = "tika-997511.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -279,7 +279,7 @@ def test_outline_item_with_writer(pdf_file_path):
 def test_trim_outline_with_writer(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381759/tika-982336.pdf"
     name = "tika-982336.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -291,7 +291,7 @@ def test_trim_outline_with_writer(pdf_file_path):
 def test1_with_writer(pdf_file_path):
     url = "https://github.com/user-attachments/files/18381696/tika-923621.pdf"
     name = "tika-923621.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -304,7 +304,7 @@ def test_sweep_recursion1_with_writer(pdf_file_path):
     # TODO: This test looks like an infinite loop.
     url = "https://github.com/user-attachments/files/18381697/tika-924546.pdf"
     name = "tika-924546.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -331,7 +331,7 @@ def test_sweep_recursion1_with_writer(pdf_file_path):
     ],
 )
 def test_sweep_recursion2_with_writer(url, name, pdf_file_path):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -345,7 +345,7 @@ def test_sweep_recursion2_with_writer(url, name, pdf_file_path):
 def test_sweep_indirect_list_newobj_is_none_with_writer(caplog, pdf_file_path):
     url = "https://github.com/user-attachments/files/18381681/tika-906769.pdf"
     name = "tika-906769.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -362,7 +362,7 @@ def test_iss1145_with_writer():
     url = "https://github.com/py-pdf/pypdf/files/9164743/file-0.pdf"
     name = "iss1145.pdf"
     merger = PdfWriter()
-    merger.append(PdfReader(BytesIO(get_data_from_url(url, name=name))))
+    merger.append(PdfReader(BytesIO(get_data_from_url(url=url, name=name))))
     merger.close()
 
 
@@ -371,7 +371,7 @@ def test_iss1344_with_writer(caplog):
     url = "https://github.com/py-pdf/pypdf/files/9549001/input.pdf"
     name = "iss1344.pdf"
     m = PdfWriter()
-    m.append(PdfReader(BytesIO(get_data_from_url(url, name=name))))
+    m.append(PdfReader(BytesIO(get_data_from_url(url=url, name=name))))
     b = BytesIO()
     m.write(b)
     p = PdfReader(b).pages[0]
@@ -384,7 +384,7 @@ def test_articles_with_writer(caplog):
     url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "924666.pdf"
     m = PdfWriter()
-    m.append(PdfReader(BytesIO(get_data_from_url(url, name=name))), (2, 10))
+    m.append(PdfReader(BytesIO(get_data_from_url(url=url, name=name))), (2, 10))
     b = BytesIO()
     m.write(b)
     r = PdfReader(b)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -94,7 +94,7 @@ def test_page_operations(pdf_path, password):
     is as expected.
     """
     if pdf_path.startswith("http"):
-        pdf_path = BytesIO(get_data_from_url(pdf_path, pdf_path.split("/")[-1]))
+        pdf_path = BytesIO(get_data_from_url(url=pdf_path, name=pdf_path.split("/")[-1]))
     else:
         pdf_path = RESOURCE_ROOT / pdf_path
     reader = PdfReader(pdf_path)
@@ -386,7 +386,7 @@ def test_iss_1142():
     # check fix for problem of context save/restore (q/Q)
     url = "https://github.com/py-pdf/pypdf/files/9150656/ST.2019.PDF"
     name = "st2019.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     txt = reader.pages[3].extract_text()
     # The following text is contained in two different cells:
     assert txt.find("有限公司") > 0
@@ -440,7 +440,7 @@ def test_iss_1142():
     ],
 )
 def test_extract_text(url, name):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for page in reader.pages:
         page.extract_text()
 
@@ -450,7 +450,7 @@ def test_extract_text(url, name):
 def test_extract_text_page_pdf_impossible_decode_xform(caplog):
     url = "https://github.com/user-attachments/files/18381748/tika-972962.pdf"
     name = "tika-972962.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for page in reader.pages:
         page.extract_text()
     warn_msgs = normalize_warnings(caplog.text)
@@ -462,7 +462,7 @@ def test_extract_text_page_pdf_impossible_decode_xform(caplog):
 def test_extract_text_operator_t_star():  # L1266, L1267
     url = "https://github.com/user-attachments/files/18381740/tika-967943.pdf"
     name = "tika-967943.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for page in reader.pages:
         page.extract_text()
 
@@ -632,7 +632,7 @@ def test_get_fonts(pdf_path, password, embedded, unembedded):
 def test_get_fonts2():
     url = "https://github.com/py-pdf/pypdf/files/12618104/WS_T.483.8-2016.pdf"
     name = "WS_T.483.8-2016.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.pages[1]._get_fonts() == (
         {
             "/E-HZ9-PK7483a5-Identity-H",
@@ -772,7 +772,7 @@ def test_annotation_setter(pdf_file_path):
 def test_text_extraction_issue_1091():
     url = "https://github.com/user-attachments/files/18381737/tika-966635.pdf"
     name = "tika-966635.pdf"
-    stream = BytesIO(get_data_from_url(url, name=name))
+    stream = BytesIO(get_data_from_url(url=url, name=name))
     with pytest.warns(PdfReadWarning):
         reader = PdfReader(stream)
     for page in reader.pages:
@@ -783,7 +783,7 @@ def test_text_extraction_issue_1091():
 def test_empyt_password_1088():
     url = "https://github.com/user-attachments/files/18381712/tika-941536.pdf"
     name = "tika-941536.pdf"
-    stream = BytesIO(get_data_from_url(url, name=name))
+    stream = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(stream)
     len(reader.pages)
 
@@ -832,7 +832,7 @@ def test_read_link_annotation():
 def test_no_resources():
     url = "https://github.com/py-pdf/pypdf/files/9572045/108.pdf"
     name = "108.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     page_one = writer.pages[0]
     page_two = writer.pages[0]
     page_one.merge_page(page_two)
@@ -1024,10 +1024,10 @@ def test_merge_page_resources_smoke_test():
 def test_merge_transformed_page_into_blank():
     url = "https://github.com/py-pdf/pypdf/files/10768334/badges_3vjrh_7LXDZ_1-1.pdf"
     name = "badges_3vjrh_7LXDZ_1.pdf"
-    r1 = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    r1 = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/files/10768335/badges_3vjrh_7LXDZ_2-1.pdf"
     name = "badges_3vjrh_7LXDZ_2.pdf"
-    r2 = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    r2 = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.add_blank_page(100, 100)
     writer.pages[0].merge_translated_page(r1.pages[0], 0, 0, True, True)
@@ -1071,7 +1071,7 @@ def test_pages_printing():
 def test_del_pages():
     url = "https://github.com/user-attachments/files/18381712/tika-941536.pdf"
     name = "tika-941536.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     ll = len(writer.pages)
     pp = writer.pages[1].indirect_reference
     del writer.pages[1]
@@ -1092,7 +1092,7 @@ def test_del_pages():
     for p in pp:
         assert p not in pages["/Kids"]
     # del whole arborescence
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # error case
     pp = reader.pages[2]
     i = pp["/Parent"].get_object()["/Kids"].index(pp.indirect_reference)
@@ -1102,7 +1102,7 @@ def test_del_pages():
 
     url = "https://github.com/py-pdf/pypdf/files/13946477/panda.pdf"
     name = "iss2343b.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)), incremental=True)
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)), incremental=True)
     node, idx = writer._get_page_in_node(53)
     assert (node.indirect_reference.idnum, idx) == (11776, 1)
     node, idx = writer._get_page_in_node(10000)
@@ -1131,7 +1131,7 @@ def test_merge_with_stream_wrapped_in_save_restore():
     """Test for issue #2587"""
     url = "https://github.com/py-pdf/pypdf/files/14895914/blank_portrait.pdf"
     name = "blank_portrait.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     page_one = writer.pages[0]
     assert page_one.get_contents().get_data() == b"q Q"
     page_two = writer.pages[0]
@@ -1203,7 +1203,7 @@ def test_pos_text_in_textvisitor():
     """See #2200"""
     url = "https://github.com/py-pdf/pypdf/files/12675974/page_178.pdf"
     name = "test_text_pos.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     p = ()
 
     def visitor_body2(text, cm, tm, fontdict, fontsize) -> None:
@@ -1221,7 +1221,7 @@ def test_pos_text_in_textvisitor2():
     """See #2075"""
     url = "https://github.com/py-pdf/pypdf/files/12318042/LegIndex-page6.pdf"
     name = "LegIndex-page6.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     x_lvl = 26
     lst = []
 
@@ -1281,7 +1281,7 @@ def test_missing_basefont_in_type3():
     """Cf #2289"""
     url = "https://github.com/py-pdf/pypdf/files/13307713/missing-base-font.pdf"
     name = "missing-base-font.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0]._get_fonts()
 
 
@@ -1360,7 +1360,7 @@ def test_scale_by():
     """Tests for #3487"""
     url = "https://github.com/user-attachments/files/22685841/input.pdf"
     name = "issue3487.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
 
     original_box = RectangleObject((0, 0, 595.275604, 841.88974))
     expected_box = RectangleObject((0.0, 0.0, 297.637802, 420.94487))
@@ -1385,7 +1385,7 @@ def test_box_rendering(tmp_path):
     """Tests for issue #3487."""
     url = "https://github.com/user-attachments/files/22685841/input.pdf"
     name = "issue3487.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
 
     for page in writer.pages:
         page.scale_by(0.5)
@@ -1393,7 +1393,7 @@ def test_box_rendering(tmp_path):
     target_png_path = tmp_path / "target.png"
     url = "https://github.com/user-attachments/assets/e9c2271c-bfc3-4a6f-8c91-ffefa24502e2"
     name = "issue3487.png"
-    target_png_path.write_bytes(get_data_from_url(url, name=name))
+    target_png_path.write_bytes(get_data_from_url(url=url, name=name))
 
     pdf_path = tmp_path / "out.pdf"
     writer.write(pdf_path)
@@ -1447,7 +1447,7 @@ def test_replace_contents_on_reader():
 def test_replace_contents_on_reader__indirect_reference():
     url = "https://github.com/user-attachments/files/24195534/test.pdf"
     name = "issue3568.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
 
     lhs = reader.get_page(3)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -453,7 +453,7 @@ def test_get_form(src, expected, expected_get_fields, txt_file_path):
 def test_reading_choice_field_without_opt_key():
     """Tests reading a choice field in a PDF without an /Opt key."""
     url = "https://github.com/user-attachments/files/23853677/Musterservicevertrag-HNRAGB_Okt2022-Blanko.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="Musterservicevertrag-HNRAGB_Okt2022-Blanko.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="Musterservicevertrag-HNRAGB_Okt2022-Blanko.pdf")))
     fields = reader.get_fields()
 
     tn_anrede = fields.get("TN_Anrede")
@@ -882,7 +882,7 @@ def test_convert_to_int_error():
 @pytest.mark.enable_socket
 def test_iss925():
     url = "https://github.com/py-pdf/pypdf/files/8796328/1.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="iss925.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="iss925.pdf")))
 
     for page_sliced in reader.pages:
         page_object = page_sliced.get_object()
@@ -941,7 +941,7 @@ def test_read_form_416():
     url = (
         "https://www.fda.gov/downloads/AboutFDA/ReportsManualsForms/Forms/UCM074728.pdf"
     )
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="issue_416.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="issue_416.pdf")))
     fields = reader.get_form_text_fields()
     assert len(fields) > 0
 
@@ -982,7 +982,7 @@ def test_extract_text_xref_issue_2(caplog):
         "incorrect startxref pointer(2)",
         "parsing for Object Streams",
     ]
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="tika-981961.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="tika-981961.pdf")))
     for page in reader.pages:
         page.extract_text()
     assert normalize_warnings(caplog.text) == msg
@@ -996,7 +996,7 @@ def test_extract_text_xref_issue_3(caplog):
     msg = [
         "incorrect startxref pointer(3)",
     ]
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="tika-977774.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="tika-977774.pdf")))
     for page in reader.pages:
         page.extract_text()
     assert normalize_warnings(caplog.text) == msg
@@ -1006,7 +1006,7 @@ def test_extract_text_xref_issue_3(caplog):
 def test_extract_text_pdf15():
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
     url = "https://github.com/user-attachments/files/18381751/tika-976030.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="tika-976030.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="tika-976030.pdf")))
     for page in reader.pages:
         page.extract_text()
 
@@ -1015,7 +1015,7 @@ def test_extract_text_pdf15():
 def test_extract_text_xref_table_21_bytes_clrf():
     # pdf/0264cf510015b2a4b395a15cb23c001e.pdf
     url = "https://github.com/user-attachments/files/18381723/tika-956939.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name="tika-956939.pdf")))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name="tika-956939.pdf")))
     for page in reader.pages:
         page.extract_text()
 
@@ -1024,7 +1024,7 @@ def test_extract_text_xref_table_21_bytes_clrf():
 def test_get_fields():
     url = "https://github.com/user-attachments/files/18381747/tika-972486.pdf"
     name = "tika-972486.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     fields = reader.get_fields()
     assert fields is not None
     assert "c1-1" in fields
@@ -1037,7 +1037,7 @@ def test_get_fields():
 def test_get_full_qualified_fields():
     url = "https://github.com/py-pdf/pypdf/files/10142389/fields_with_dots.pdf"
     name = "fields_with_dots.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     fields = reader.get_form_text_fields(True)
     assert fields is not None
     assert "customer.name" in fields
@@ -1059,14 +1059,14 @@ def test_get_fields_read_else_block():
     # covers also issue 1089
     url = "https://github.com/user-attachments/files/18381705/tika-934771.pdf"
     name = "tika-934771.pdf"
-    PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
 
 @pytest.mark.enable_socket
 def test_get_fields_read_else_block2():
     url = "https://github.com/user-attachments/files/18381689/tika-914902.pdf"
     name = "tika-914902.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     fields = reader.get_fields()
     assert fields is None
 
@@ -1076,14 +1076,14 @@ def test_get_fields_read_else_block2():
 def test_get_fields_read_else_block3():
     url = "https://github.com/user-attachments/files/18381726/tika-957721.pdf"
     name = "tika-957721.pdf"
-    PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
 
 @pytest.mark.enable_socket
 def test_metadata_is_none():
     url = "https://github.com/user-attachments/files/18381735/tika-963692.pdf"
     name = "tika-963692.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.metadata is None
 
 
@@ -1091,7 +1091,7 @@ def test_metadata_is_none():
 def test_get_fields_read_write_report(txt_file_path):
     url = "https://github.com/user-attachments/files/18381683/tika-909655.pdf"
     name = "tika-909655.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     with open(txt_file_path, "w") as fp:
         fields = reader.get_fields(fileobj=fp)
     assert fields
@@ -1113,7 +1113,7 @@ def test_xfa(src):
 def test_xfa_non_empty():
     url = "https://github.com/user-attachments/files/18381713/tika-942050.pdf"
     name = "tika-942050.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert list(reader.xfa.keys()) == [
         "preamble",
         "config",
@@ -1287,7 +1287,7 @@ def test_outline_missing_title(caplog):
     ids=["stored_directly", "dest_below_names_with_kids"],
 )
 def test_named_destination(url, name):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert len(reader.named_destinations) > 0
 
 
@@ -1295,7 +1295,7 @@ def test_named_destination(url, name):
 def test_outline_with_missing_named_destination():
     url = "https://github.com/user-attachments/files/18381686/tika-913678.pdf"
     name = "tika-913678.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # outline items in document reference a named destination that is not defined
     assert reader.outline[1][0].title.startswith("Report for 2002AZ3B: Microbial")
 
@@ -1304,7 +1304,7 @@ def test_outline_with_missing_named_destination():
 def test_outline_with_empty_action():
     url = "https://github.com/user-attachments/files/18381697/tika-924546.pdf"
     name = "tika-924546.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # outline items (entitled Tables and Figures) utilize an empty action (/A)
     # that has no type or destination
     assert reader.outline[-4].title == "Tables"
@@ -1322,7 +1322,7 @@ def test_pdfreader_multiple_definitions(caplog):
     """iss325"""
     url = "https://github.com/py-pdf/pypdf/files/9176644/multipledefs.pdf"
     name = "multipledefs.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].extract_text()
     assert normalize_warnings(caplog.text) == [
         "Multiple definitions in dictionary at byte 0xb5 for key /Group"
@@ -1348,11 +1348,11 @@ def test_corrupted_xref_table():
     # issue #1292
     url = "https://github.com/py-pdf/pypdf/files/9444747/BreezeManual.orig.pdf"
     name = "BreezeMan1.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].extract_text()
     url = "https://github.com/py-pdf/pypdf/files/9444748/BreezeManual.failed.pdf"
     name = "BreezeMan2.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].extract_text()
 
 
@@ -1361,7 +1361,7 @@ def test_reader(caplog):
     # iss #1273
     url = "https://github.com/py-pdf/pypdf/files/9464742/shiv_resume.pdf"
     name = "shiv_resume.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert "Previous trailer cannot be read" in caplog.text
     caplog.clear()
     # first call requires some reparations...
@@ -1380,7 +1380,7 @@ def test_zeroing_xref():
         "UTA_OSHA_3115_Fall_Protection_Training_09162021_.pdf"
     )
     name = "UTA_OSHA.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     len(reader.pages)
 
 
@@ -1391,11 +1391,11 @@ def test_thread():
         "UTA_OSHA_3115_Fall_Protection_Training_09162021_.pdf"
     )
     name = "UTA_OSHA.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.threads is None
     url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert isinstance(reader.threads, ArrayObject)
     assert len(reader.threads) >= 1
 
@@ -1404,7 +1404,7 @@ def test_thread():
 def test_build_outline_item(caplog):
     url = "https://github.com/py-pdf/pypdf/files/9464742/shiv_resume.pdf"
     name = "shiv_resume.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     outline = reader._build_outline_item(
         DictionaryObject(
             {
@@ -1456,7 +1456,7 @@ def test_page_labels(src, page_labels):
 def test_iss1559():
     url = "https://github.com/py-pdf/pypdf/files/10441992/default.pdf"
     name = "iss1559.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for p in reader.pages:
         p.extract_text()
 
@@ -1466,7 +1466,7 @@ def test_iss1652():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10818844/tt.pdf"
     name = "invalidNamesDest.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.named_destinations
 
 
@@ -1474,7 +1474,7 @@ def test_iss1652():
 def test_iss1689():
     url = "https://github.com/py-pdf/pypdf/files/10948283/error_file_without_data.pdf"
     name = "iss1689.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0]
 
 
@@ -1482,7 +1482,7 @@ def test_iss1689():
 def test_iss1710():
     url = "https://github.com/py-pdf/pypdf/files/15234776/irbookonlinereading.pdf"
     name = "irbookonlinereading.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.outline
 
 
@@ -1524,7 +1524,7 @@ def test_broken_file_header():
 def test_iss1756():
     url = "https://github.com/py-pdf/pypdf/files/11105591/641-Attachment-B-Pediatric-Cardiac-Arrest-8-1-2019.pdf"
     name = "iss1756.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.trailer["/ID"]
     # removed to cope with missing cryptodome during commit check : len(reader.pages)
 
@@ -1534,7 +1534,7 @@ def test_iss1756():
 def test_iss1825():
     url = "https://github.com/py-pdf/pypdf/files/11367871/MiFO_LFO_FEIS_NOA_Published.3.pdf"
     name = "iss1825.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
     page.extract_text()
 
@@ -1543,7 +1543,7 @@ def test_iss1825():
 def test_iss2082():
     url = "https://github.com/py-pdf/pypdf/files/12317939/test.pdf"
     name = "iss2082.pdf"
-    b = get_data_from_url(url, name=name)
+    b = get_data_from_url(url=url, name=name)
     reader = PdfReader(BytesIO(b))
     reader.pages[0].extract_text()
 
@@ -1557,7 +1557,7 @@ def test_iss2082():
 def test_issue_140():
     url = "https://github.com/py-pdf/pypdf/files/12168578/bad_pdf_example.pdf"
     name = "issue-140.pdf"
-    b = get_data_from_url(url, name=name)
+    b = get_data_from_url(url=url, name=name)
     reader = PdfReader(BytesIO(b))
     assert len(reader.pages) == 54
 
@@ -1567,7 +1567,7 @@ def test_xyz_with_missing_param():
     """Cf #2236"""
     url = "https://github.com/py-pdf/pypdf/files/12795356/tt1.pdf"
     name = "issue2236.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.outline[0]["/Left"] == 820
     assert reader.outline[0]["/Top"] == 0
     assert reader.outline[1]["/Left"] == 0
@@ -1578,7 +1578,7 @@ def test_xyz_with_missing_param():
 def test_corrupted_xref():
     url = "https://github.com/py-pdf/pypdf/files/14628314/iss2516.pdf"
     name = "iss2516.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.root_object["/Type"] == "/Catalog"
 
 
@@ -1586,7 +1586,7 @@ def test_corrupted_xref():
 def test_truncated_xref(caplog):
     url = "https://github.com/py-pdf/pypdf/files/14843553/002-trivial-libre-office-writer-broken.pdf"
     name = "iss2575.pdf"
-    PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert "Invalid/Truncated xref table. Rebuilding it." in caplog.text
 
 
@@ -1594,9 +1594,9 @@ def test_truncated_xref(caplog):
 def test_damaged_pdf():
     url = "https://github.com/py-pdf/pypdf/files/15186107/malformed_pdf.pdf"
     name = "malformed_pdf.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)), strict=False)
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)), strict=False)
     len(reader.pages)
-    strict_reader = PdfReader(BytesIO(get_data_from_url(url, name=name)), strict=True)
+    strict_reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)), strict=True)
     with pytest.raises(PdfReadError) as exc:
         len(strict_reader.pages)
     assert (
@@ -1610,7 +1610,7 @@ def test_looping_form(caplog):
     """Cf iss 2643"""
     url = "https://github.com/py-pdf/pypdf/files/15306053/inheritance.pdf"
     name = "iss2643.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)), strict=False)
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)), strict=False)
     flds = reader.get_fields()
     assert all(
         x in flds
@@ -1671,7 +1671,7 @@ def test_context_manager_with_stream():
 def test_iss2761():
     url = "https://github.com/user-attachments/files/16312198/crash-b26d05712a29b241ac6f9dc7fff57428ba2d1a04.pdf"
     name = "iss2761.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)), strict=False)
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)), strict=False)
     with pytest.raises(PdfReadError):
         reader.pages[0].extract_text()
 
@@ -1681,7 +1681,7 @@ def test_iss2817():
     """Test for rebuiling Xref_ObjStm"""
     url = "https://github.com/user-attachments/files/16764070/crash-7e1356f1179b4198337f282304cb611aea26a199.pdf"
     name = "iss2817.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert (
         reader.pages[0]["/Annots"][0].get_object()["/Contents"]
         == "A\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0 B"
@@ -1693,7 +1693,7 @@ def test_truncated_files(caplog):
     """Cf #2853"""
     url = "https://github.com/user-attachments/files/16796095/f5471sm-2.pdf"
     name = "iss2780.pdf"  # reused
-    b = get_data_from_url(url, name=name)
+    b = get_data_from_url(url=url, name=name)
     reader = PdfReader(BytesIO(b))
     assert caplog.text == ""
     # remove \n at end of file : invisible
@@ -1717,7 +1717,7 @@ def test_comments_in_array(caplog):
     """Cf #2843: this deals with comments"""
     url = "https://github.com/user-attachments/files/16992416/crash-2347912aa2a6f0fab5df4ebc8a424735d5d0d128.pdf"
     name = "iss2843.pdf"  # reused
-    b = get_data_from_url(url, name=name)
+    b = get_data_from_url(url=url, name=name)
     reader = PdfReader(BytesIO(b))
     reader.pages[0]
     assert caplog.text == ""
@@ -1735,7 +1735,7 @@ def test_space_in_names_to_continue_processing(caplog):
     """
     url = "https://github.com/user-attachments/files/17095516/crash-e108c4f677040b61e12fa9f1cfde025d704c9b0d.pdf"
     name = "iss2866.pdf"  # reused
-    b = get_data_from_url(url, name=name)
+    b = get_data_from_url(url=url, name=name)
     reader = PdfReader(BytesIO(b))
     obj = reader.get_object(70)
     assert all(
@@ -1778,7 +1778,7 @@ def test_unbalanced_brackets_in_dictionary_object(caplog):
     """Cf #2877"""
     url = "https://github.com/user-attachments/files/17162634/7f40cb209fb97d1782bffcefc5e7be40.pdf"
     name = "iss2877.pdf"  # reused
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert len(reader.pages) == 43  # note:  /Count = 46 but 3 kids are None
 
 
@@ -1788,7 +1788,7 @@ def test_repair_root(caplog):
     url = "https://github.com/user-attachments/files/17162216/crash-6620e8b1abfe3da639b654595da859b87f985748.pdf"
     name = "iss2875.pdf"
 
-    b = get_data_from_url(url, name=name)
+    b = get_data_from_url(url=url, name=name)
     reader = PdfReader(BytesIO(b))
     assert len(reader.pages) == 1
     assert all(
@@ -1868,7 +1868,7 @@ def test_issue3151(caplog):
     """Tests for #3151"""
     url = "https://github.com/user-attachments/files/18941494/bible.pdf"
     name = "issue3151.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert len(reader.pages) == 742
 
 
@@ -1879,7 +1879,7 @@ def test_issue2886(caplog):
     name = "issue2886.pdf"
 
     with pytest.raises(PdfReadError, match=r"Unexpected empty line in Xref table\."):
-        _ = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+        _ = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
 
 @pytest.mark.enable_socket
@@ -1888,7 +1888,7 @@ def test_infinite_loop_for_length_value():
     url = "https://github.com/user-attachments/files/19106009/Special.n.15.du.jeudi.22.fevrier.2024.pdf"
     name = "issue3112.pdf"
 
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     with pytest.raises(
             LimitReachedError, match=r"^Detected loop with self reference for IndirectObject\(165, 0, \d+\)\.$"
@@ -1925,7 +1925,7 @@ def test_read_standard_xref_table__two_whitespace_characters_between_offset_and_
     url = "https://github.com/user-attachments/files/22591813/helloworld.pdf"
     name = "issue3482.pdf"
 
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert len(reader.pages) == 1
     assert reader.pages[0].extract_text() == "Hello World!"
 
@@ -1934,7 +1934,7 @@ def test_read_standard_xref_table__two_whitespace_characters_between_offset_and_
 def test_root_object_recovery_limit(caplog):
     url = "https://github.com/user-attachments/files/24525509/root_object_recovery_limit.pdf"
     name = "root_object_recovery_limit.pdf"
-    data = get_data_from_url(url, name=name)
+    data = get_data_from_url(url=url, name=name)
 
     # Default limit.
     reader = PdfReader(BytesIO(data))

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -156,7 +156,7 @@ def test_font_class_to_dict():
 def test_uninterpretable_type3_font(mock_logger_warning):
     url = "https://github.com/user-attachments/files/18551904/UninterpretableType3Font.pdf"
     name = "UninterpretableType3Font.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
     assert page.extract_text(extraction_mode="layout") == ""
     mock_logger_warning.assert_called_with(
@@ -169,7 +169,7 @@ def test_uninterpretable_type3_font(mock_logger_warning):
 def test_layout_mode_epic_page_fonts():
     url = "https://github.com/py-pdf/pypdf/files/13836944/Epic.Page.PDF"
     name = "Epic Page.PDF"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     expected = (RESOURCE_ROOT / "Epic.Page.layout.txt").read_text(encoding="utf-8")
     assert expected == reader.pages[0].extract_text(extraction_mode="layout")
 
@@ -187,7 +187,7 @@ def test_layout_mode_type0_font_widths():
     # /DescendantFonts /W array entries.
     url = "https://github.com/py-pdf/pypdf/files/13533204/Claim.Maker.Alerts.Guide_pg2.PDF"
     name = "Claim Maker Alerts Guide_pg2.PDF"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     expected = (RESOURCE_ROOT / "Claim Maker Alerts Guide_pg2.layout.txt").read_text(
         encoding="utf-8"
     )
@@ -200,11 +200,11 @@ def test_layout_mode_indirect_sequence_font_widths(caplog):
     # https://github.com/py-pdf/pypdf/pull/2788
     url = "https://github.com/user-attachments/files/16491621/2788_example.pdf"
     name = "2788_example.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.pages[0].extract_text(extraction_mode="layout") == ""
     url = "https://github.com/user-attachments/files/16491619/2788_example_malformed.pdf"
     name = "2788_example_malformed.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader.pages[0].extract_text(extraction_mode="layout")
     assert "Invalid font width definition" in caplog.text
 
@@ -231,7 +231,7 @@ def test_space_with_one_unit_smaller_than_font_width():
     """Tests for #1328"""
     url = "https://github.com/py-pdf/pypdf/files/9498481/0004.pdf"
     name = "iss1328.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[0]
     extracted = page.extract_text()
     assert "Reporting crude oil leak.\n" in extracted
@@ -242,7 +242,7 @@ def test_space_position_calculation():
     """Tests for #1153"""
     url = "https://github.com/py-pdf/pypdf/files/9164743/file-0.pdf"
     name = "iss1153.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     page = reader.pages[3]
     extracted = page.extract_text()
     assert "Shortly after the Geneva BOF session, the" in extracted
@@ -296,7 +296,7 @@ def test_infinite_loop_arrays():
     """Tests for #2928"""
     url = "https://github.com/user-attachments/files/17576546/arrayabruptending.pdf"
     name = "arrayabruptending.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     page = reader.pages[0]
     extracted = page.extract_text()
@@ -308,7 +308,7 @@ def test_content_stream_is_dictionary_object(caplog):
     """Tests for #2995"""
     url = "https://github.com/user-attachments/files/18049322/6fa5fd46-5f98-4a67-800d-5e2362b0164f.pdf"
     name = "iss2995.pdf"
-    data = get_data_from_url(url, name=name)
+    data = get_data_from_url(url=url, name=name)
 
     reader = PdfReader(BytesIO(data))
     page = reader.pages[0]
@@ -331,7 +331,7 @@ def test_tz_with_no_operands():
     """Tests for #2975"""
     url = "https://github.com/user-attachments/files/17974120/9E5E080E-C8DB-4A6B-822B-9A67DC04E526-120438.pdf"
     name = "iss2975.pdf"
-    data = get_data_from_url(url, name=name)
+    data = get_data_from_url(url=url, name=name)
 
     reader = PdfReader(BytesIO(data))
     page = reader.pages[1]
@@ -343,7 +343,7 @@ def test_iss3060():
     """Test for not throwing 'font not set: is PDF missing a Tf operator'"""
     url = "https://github.com/user-attachments/files/18482531/test-anon.pdf"
     name = "iss3060.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # pypdf.errors.PdfReadError: font not set: is PDF missing a Tf operator?
     txt = reader.pages[0].extract_text(extraction_mode="layout")
     assert txt.startswith(" *******")
@@ -354,7 +354,7 @@ def test_iss3074():
     """Test for not throwing 'ZeroDivisionError: float division by zero'"""
     url = "https://github.com/user-attachments/files/18533211/test-anon.pdf"
     name = "iss3074.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # pypdf.errors.PdfReadError: ZeroDivisionError: float division by zero
     txt = reader.pages[0].extract_text(extraction_mode="layout")
     assert txt.strip().startswith("AAAAAA")
@@ -366,11 +366,11 @@ def test_layout_mode_text_state():
     # Get the PDF from issue #3212
     url = "https://github.com/user-attachments/files/19396790/garbled.pdf"
     name = "garbled-font.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # Get the txt from issue #3212 and normalize line endings
     txt_url = "https://github.com/user-attachments/files/19510731/garbled-font.layout.txt"
     txt_name = "garbled-font.layout.txt"
-    expected = get_data_from_url(txt_url, name=txt_name).decode("utf-8").replace("\r\n", "\n")
+    expected = get_data_from_url(url=txt_url, name=txt_name).decode("utf-8").replace("\r\n", "\n")
     # Ignore differences in rendering of spaces to work around older differences between the
     # old layout mode Font code and the new Font class in calculating and dealing with the
     # fallback width for a character that has no width defined in character_widths.
@@ -383,11 +383,11 @@ def test_rotated_line_wrap():
     # Get the PDF from issue #3247
     url = "https://github.com/user-attachments/files/19696918/link16-line-wrap.sanitized.pdf"
     name = "link16-line-wrap.sanitized.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     # Get the txt from issue #3247 and normalize line endings
     txt_url = "https://github.com/user-attachments/files/19696917/link16-line-wrap.sanitized.expected.txt"
     txt_name = "link16-line-wrap.sanitized.expected.txt"
-    expected = get_data_from_url(txt_url, name=txt_name).decode("utf-8").replace("\r\n", "\n")
+    expected = get_data_from_url(url=txt_url, name=txt_name).decode("utf-8").replace("\r\n", "\n")
 
     assert expected == reader.pages[0].extract_text()
 
@@ -423,7 +423,7 @@ def test_rotated_layout_mode(caplog):
     """Ensures text extraction of rotated pages, as in issue #3270."""
     url = "https://github.com/user-attachments/files/19981120/rotated-page.pdf"
     name = "rotated-page.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     page = writer.pages[0]
 
     page.transfer_rotation_to_content()
@@ -439,7 +439,7 @@ def test_rotated_layout_mode(caplog):
 def test_extract_text__none_objects():
     url = "https://github.com/user-attachments/files/18381726/tika-957721.pdf"
     name = "tika-957721.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     reader.pages[0].extract_text()
     reader.pages[8].extract_text()
@@ -452,7 +452,7 @@ def test_extract_text__with_visitor_text():
 
     url = "https://github.com/user-attachments/files/18381718/tika-952016.pdf"
     name = "tika-952016.pdf"
-    stream = BytesIO(get_data_from_url(url, name=name))
+    stream = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(stream)
     page = reader.pages[0]
     page.extract_text(visitor_text=visitor_text)
@@ -466,7 +466,7 @@ def test_extract_text__with_visitor_text():
 def test_extract_text__restore_cm_stack_pop_error():
     url = "https://github.com/user-attachments/files/18381737/tika-966635.pdf"
     name = "tika-966635.pdf"
-    stream = BytesIO(get_data_from_url(url, name=name))
+    stream = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(stream)
     page = reader.pages[10]
 
@@ -482,7 +482,7 @@ def test_slow_huge_string():
     """Tests for #3541"""
     url = "https://github.com/user-attachments/files/23855795/file.pdf"
     name = "issue-3541.pdf"
-    stream = BytesIO(get_data_from_url(url, name=name))
+    stream = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(stream)
     page = reader.pages[0]
 
@@ -493,7 +493,7 @@ def test_slow_huge_string():
 def test_extract_text_with_missing_font_bbox():
     url = "https://github.com/user-attachments/files/24611650/bbox_bug_emoji.pdf"
     name = "issue-3599.pdf"
-    stream = BytesIO(get_data_from_url(url, name=name))
+    stream = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(stream)
     page = reader.pages[0]
     text = page.extract_text()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -250,7 +250,7 @@ def test_extract_textbench(enable, url, pages):
         return
     print_result = False
     try:
-        reader = PdfReader(BytesIO(get_data_from_url(url, url.split("/")[-1])))
+        reader = PdfReader(BytesIO(get_data_from_url(url=url, name=url.split("/")[-1])))
         for page_number in pages:
             if print_result:
                 print(f"**************** {url} / page {page_number} ****************")
@@ -329,7 +329,7 @@ def test_orientations():
 )
 def test_overlay(pdf_file_path, base_path, overlay_path):
     if base_path.startswith("http"):
-        base_path = BytesIO(get_data_from_url(base_path, name="tika-935981.pdf"))
+        base_path = BytesIO(get_data_from_url(url=base_path, name="tika-935981.pdf"))
     else:
         base_path = PROJECT_ROOT / base_path
     writer = PdfWriter(clone_from=base_path)
@@ -356,7 +356,7 @@ def test_overlay(pdf_file_path, base_path, overlay_path):
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_merge_with_warning(tmp_path, url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     merger = PdfWriter()
     merger.append(reader)
@@ -376,7 +376,7 @@ def test_merge_with_warning(tmp_path, url, name):
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_merge(tmp_path, url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     merger = PdfWriter()
     merger.append(reader)
@@ -403,7 +403,7 @@ def test_merge(tmp_path, url, name):
     ],
 )
 def test_get_metadata(url, name, expected_metadata):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     data = reader.metadata
     assert expected_metadata == data
@@ -482,7 +482,7 @@ def test_get_metadata(url, name, expected_metadata):
     ],
 )
 def test_extract_text(url, name, strict, exception):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=strict)
     if not exception:
         for page in reader.pages:
@@ -522,7 +522,7 @@ def test_extract_text(url, name, strict, exception):
     ],
 )
 def test_compress_raised(url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
@@ -542,7 +542,7 @@ def test_compress_raised(url, name):
     ],
 )
 def test_get_fields_warns(tmp_path, caplog, url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     write_path = tmp_path / "tmp.txt"
     with open(write_path, "w") as fp:
@@ -567,7 +567,7 @@ def test_get_fields_warns(tmp_path, caplog, url, name):
     ],
 )
 def test_get_fields_no_warning(tmp_path, url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     write_path = tmp_path / "tmp.txt"
     with open(write_path, "w") as fp:
@@ -580,7 +580,7 @@ def test_get_fields_no_warning(tmp_path, url, name):
 def test_scale_rectangle_indirect_object():
     url = "https://github.com/user-attachments/files/18381778/tika-999944.pdf"
     name = "tika-999944.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     writer = PdfWriter(clone_from=data)
 
     for page in writer.pages:
@@ -663,7 +663,7 @@ def test_merge_output(caplog):
     ],
 )
 def test_image_extraction(url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
 
     images_extracted = []
@@ -692,7 +692,7 @@ def test_image_extraction_strict():
     # Emits log messages
     url = "https://github.com/user-attachments/files/18381687/tika-914102.pdf"
     name = "tika-914102.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=True)
 
     images_extracted = []
@@ -726,7 +726,7 @@ def test_image_extraction_strict():
     ],
 )
 def test_image_extraction2(url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
 
     images_extracted = []
@@ -764,7 +764,7 @@ def test_image_extraction2(url, name):
     ],
 )
 def test_get_outline(url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     reader.outline
 
@@ -784,7 +784,7 @@ def test_get_outline(url, name):
     ],
 )
 def test_get_xfa(url, name):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data)
     reader.xfa
 
@@ -816,7 +816,7 @@ def test_get_xfa(url, name):
     ],
 )
 def test_get_fonts(url, name, strict):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=strict)
     for page in reader.pages:
         page._get_fonts()
@@ -849,7 +849,7 @@ def test_get_fonts(url, name, strict):
     ],
 )
 def test_get_xmp(url, name, strict):
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=strict)
     xmp_info = reader.xmp_metadata
     if xmp_info:
@@ -884,7 +884,7 @@ def test_get_xmp(url, name, strict):
 def test_tounicode_is_identity():
     url = "https://github.com/py-pdf/pypdf/files/9998335/FP_Thesis.pdf"
     name = "FP_Thesis.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=False)
     reader.pages[0].extract_text()
 
@@ -896,13 +896,13 @@ def test_append_forms():
 
     url = "https://github.com/py-pdf/pypdf/files/10367412/pdfa.pdf"
     name = "form_a.pdf"
-    reader1 = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader1 = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader1.add_form_topname("form_a")
     writer.append(reader1)
 
     url = "https://github.com/py-pdf/pypdf/files/10367413/pdfb.pdf"
     name = "form_b.pdf"
-    reader2 = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader2 = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     reader2.add_form_topname("form_b")
     writer.append(reader2)
 
@@ -918,7 +918,7 @@ def test_append_forms():
 def test_extra_test_iss1541():
     url = "https://github.com/py-pdf/pypdf/files/10418158/tst_iss1541.pdf"
     name = "tst_iss1541.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=False)
     reader.pages[0].extract_text()
 
@@ -950,7 +950,7 @@ def test_fields_returning_stream():
     """This problem was reported in #424"""
     url = "https://github.com/mstamy2/PyPDF2/files/1948267/Simple.form.pdf"
     name = "tst_iss424.pdf"
-    data = BytesIO(get_data_from_url(url, name=name))
+    data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(data, strict=False)
     assert "BtchIssQATit_time" in reader.get_form_text_fields()["TimeStampData"]
 
@@ -1004,10 +1004,10 @@ def test_inline_images():
     """This problem was reported in #424"""
     url = "https://arxiv.org/pdf/2201.00151.pdf"
     name = "2201.00151.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/assets/4083478/28e8b87c-be2c-40d9-9c86-15c7819021bf"
     name = "inline4.png"
-    img_ref = Image.open(BytesIO(get_data_from_url(url, name=name)))
+    img_ref = Image.open(BytesIO(get_data_from_url(url=url, name=name)))
     assert get_image_data(reader.pages[1].images[4].image) == get_image_data(img_ref)
     with pytest.raises(KeyError):
         reader.pages[0].images["~999~"]
@@ -1033,7 +1033,7 @@ def test_inline_images():
 
     url = "https://github.com/py-pdf/pypdf/files/15233597/bug1065245.pdf"
     name = "iss2598c.pdf"  # test data also used in test_images.py/test_inline_image_extraction()
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert len(reader.pages[0].images) == 3
 
 
@@ -1041,7 +1041,7 @@ def test_inline_images():
 def test_issue1899():
     url = "https://github.com/py-pdf/pypdf/files/11801077/lv2018tconv.pdf"
     name = "lv2018tconv.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     for i, page in enumerate(reader.pages):
         print(i)
         page.extract_text()
@@ -1052,7 +1052,7 @@ def test_cr_with_cm_operation():
     """Issue #2138"""
     url = "https://github.com/py-pdf/pypdf/files/12483807/AEO.1172.pdf"
     name = "iss2138.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert (
         """STATUS: FNL
 STYLE: 1172 1172 KNIT SHORTIE SUMMER-B 2023
@@ -1141,7 +1141,7 @@ def test_get_page_showing_field():
     """
     url = "https://github.com/py-pdf/pypdf/files/14031491/Form_Structure_v50.pdf"
     name = "iss2452.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter(clone_from=reader)
 
     # validate with Field:  only works on Reader (no get_fields on writer yet)
@@ -1295,7 +1295,7 @@ def test_extract_empty_page():
     """Cf #2533"""
     url = "https://github.com/py-pdf/pypdf/files/14718318/test.pdf"
     name = "iss2533.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.pages[1].extract_text(extraction_mode="layout") == ""
 
 
@@ -1304,5 +1304,5 @@ def test_iss2815():
     """Cf #2815"""
     url = "https://github.com/user-attachments/files/16760725/crash-c1920c7a064649e1191d7879952ec252473fc7e6.pdf"
     name = "iss2815.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     assert reader.pages[0].extract_text() == "test command with wrong number of args"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -464,7 +464,7 @@ def test_remove_images_sub_level():
     """Cf #2035"""
     url = "https://github.com/py-pdf/pypdf/files/12394781/2210.03142-1.pdf"
     name = "iss2103.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     writer.remove_images()
     assert (
         len(
@@ -952,7 +952,7 @@ def test_sweep_indirect_references_nullobject_exception(pdf_file_path):
     # TODO: Check this more closely... this looks weird
     url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -976,7 +976,7 @@ def test_sweep_indirect_references_nullobject_exception(pdf_file_path):
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_some_appends(pdf_file_path, url, name):
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     merger = PdfWriter()
     merger.append(reader)
     merger.write(pdf_file_path)
@@ -1144,7 +1144,7 @@ def test_startup_dest():
 def test_iss471():
     url = "https://github.com/py-pdf/pypdf/files/9139245/book.pdf"
     name = "book_471.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     writer = PdfWriter()
     writer.append(reader, excluded_fields=[])
@@ -1157,7 +1157,7 @@ def test_iss471():
 def test_reset_translation():
     url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader, (0, 10))
     nb = len(writer._objects)
@@ -1195,7 +1195,7 @@ def test_threads_empty():
 def test_append_without_annots_and_articles():
     url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader, None, (0, 10), True, ["/B"])
     writer.reset_translation()
@@ -1214,7 +1214,7 @@ def test_append_without_annots_and_articles():
 def test_append_multiple():
     url = "https://github.com/user-attachments/files/18381699/tika-924666.pdf"
     name = "tika-924666.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(
         reader, [0, 0, 0]
@@ -1364,7 +1364,7 @@ def test_set_page_label(pdf_file_path):
 def test_iss1601():
     url = "https://github.com/py-pdf/pypdf/files/10579503/badges-38.pdf"
     name = "badge-38.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     original_cs_operations = ContentStream(
         reader.pages[0].get_contents(), reader
     ).operations
@@ -1434,13 +1434,13 @@ def test_iss1614():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10669995/broke.pdf"
     name = "iss1614.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
     # test for 2nd error case reported in #1614
     url = "https://github.com/py-pdf/pypdf/files/10696390/broken.pdf"
     name = "iss1614.2.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer.append(reader)
 
 
@@ -1449,7 +1449,7 @@ def test_new_removes():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/10807951/tt.pdf"
     name = "iss1650.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
@@ -1507,7 +1507,7 @@ def test_new_removes():
 
     url = "https://github.com/py-pdf/pypdf/files/10832029/tt2.pdf"
     name = "GeoBaseWithComments.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer.append(reader)
     writer.remove_objects_from_page(writer.pages[0], [ObjectDeletionFlag.LINKS])
     assert "/Links" not in [
@@ -1536,7 +1536,7 @@ def test_new_removes():
 def test_late_iss1654():
     url = "https://github.com/py-pdf/pypdf/files/10935632/bid1.pdf"
     name = "bid1.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.clone_document_from_reader(reader)
     for p in writer.pages:
@@ -1550,7 +1550,7 @@ def test_iss1723():
     # test of an annotation(link) directly stored in the /Annots in the page
     url = "https://github.com/py-pdf/pypdf/files/11015242/inputFile.pdf"
     name = "iss1723.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader, (3, 5))
 
@@ -1562,7 +1562,7 @@ def test_iss1767():
     # cloning
     url = "https://github.com/py-pdf/pypdf/files/11138472/test.pdf"
     name = "iss1767.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     PdfWriter(clone_from=reader)
 
 
@@ -1576,10 +1576,10 @@ def test_named_dest_page_number():
     name = "central.pdf"
     writer = PdfWriter()
     writer.add_blank_page(100, 100)
-    writer.append(BytesIO(get_data_from_url(url, name=name)), pages=[0, 1, 2])
+    writer.append(BytesIO(get_data_from_url(url=url, name=name)), pages=[0, 1, 2])
     assert len(writer.root_object["/Names"]["/Dests"]["/Names"]) == 2
     assert writer.root_object["/Names"]["/Dests"]["/Names"][-1][0] == (1 + 1)
-    writer.append(BytesIO(get_data_from_url(url, name=name)))
+    writer.append(BytesIO(get_data_from_url(url=url, name=name)))
     assert len(writer.root_object["/Names"]["/Dests"]["/Names"]) == 6
     writer2 = PdfWriter()
     writer2.add_blank_page(100, 100)
@@ -1779,7 +1779,7 @@ def test_update_form_fields2(caplog):
 
     for file in my_files:
         reader = PdfReader(
-            BytesIO(get_data_from_url(my_files[file]["url"], name=my_files[file]["path"]))
+            BytesIO(get_data_from_url(url=my_files[file]["url"], name=my_files[file]["path"]))
         )
         reader.add_form_topname(file)
         writer = PdfWriter(clone_from=reader)
@@ -1822,7 +1822,7 @@ def test_iss1862():
     url = "https://github.com/py-pdf/pypdf/files/11708801/intro.pdf"
     name = "iss1862.pdf"
     writer = PdfWriter()
-    writer.append(BytesIO(get_data_from_url(url, name=name)))
+    writer.append(BytesIO(get_data_from_url(url=url, name=name)))
     # check that "/B" is in the font
     writer.pages[0]["/Resources"]["/Font"]["/F1"]["/CharProcs"]["/B"].get_data()
 
@@ -1845,10 +1845,10 @@ def test_empty_objects_before_cloning():
 def test_watermark():
     url = "https://github.com/py-pdf/pypdf/files/11985889/bg.pdf"
     name = "bgwatermark.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://github.com/py-pdf/pypdf/files/11985888/source.pdf"
     name = "srcwatermark.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     for p in writer.pages:
         p.merge_page(reader.pages[0], over=False)
 
@@ -1865,10 +1865,10 @@ def test_watermark():
 def test_watermarking_speed():
     url = "https://github.com/py-pdf/pypdf/files/11985889/bg.pdf"
     name = "bgwatermark.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     url = "https://arxiv.org/pdf/2201.00214.pdf"
     name = "2201.00214.pdf"
-    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(clone_from=BytesIO(get_data_from_url(url=url, name=name)))
     for p in writer.pages:
         p.merge_page(reader.pages[0], over=False)
     out_pdf_bytesio = BytesIO()
@@ -1883,10 +1883,10 @@ def test_watermark_rendering(tmp_path):
     """Ensure the visual appearance of watermarking stays correct."""
     url = "https://github.com/py-pdf/pypdf/files/11985889/bg.pdf"
     name = "bgwatermark.pdf"
-    watermark = PdfReader(BytesIO(get_data_from_url(url, name=name))).pages[0]
+    watermark = PdfReader(BytesIO(get_data_from_url(url=url, name=name))).pages[0]
     url = "https://github.com/py-pdf/pypdf/files/11985888/source.pdf"
     name = "srcwatermark.pdf"
-    page = PdfReader(BytesIO(get_data_from_url(url, name=name))).pages[0]
+    page = PdfReader(BytesIO(get_data_from_url(url=url, name=name))).pages[0]
     writer = PdfWriter()
     page = writer.add_page(page)
     page.merge_page(watermark, over=False)
@@ -1894,7 +1894,7 @@ def test_watermark_rendering(tmp_path):
     target_png_path = tmp_path / "target.png"
     url = "https://github.com/py-pdf/pypdf/assets/96178532/d5c72d0e-7047-4504-bbf6-bc591c80d7c0"
     name = "dstwatermark.png"
-    target_png_path.write_bytes(get_data_from_url(url, name=name))
+    target_png_path.write_bytes(get_data_from_url(url=url, name=name))
 
     pdf_path = tmp_path / "out.pdf"
     png_path = tmp_path / "out.png"
@@ -1957,7 +1957,7 @@ def test_watermarking_reportlab_rendering(tmp_path):
 def test_da_missing_in_annot():
     url = "https://github.com/py-pdf/pypdf/files/12136285/Building.Division.Permit.Application.pdf"
     name = "BuildingDivisionPermitApplication.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter(clone_from=reader)
     writer.update_page_form_field_values(
         writer.pages[0], {"PCN-1": "0"}, auto_regenerate=False
@@ -2041,7 +2041,7 @@ def test_germanfields():
     """Cf #2035"""
     url = "https://github.com/py-pdf/pypdf/files/12194195/test.pdf"
     name = "germanfields.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter(clone_from=reader)
     form_fields = {"Text Box 1": "test æ ø å"}
     writer.update_page_form_field_values(
@@ -2064,7 +2064,7 @@ def test_no_t_in_articles():
     """Cf #2078"""
     url = "https://github.com/py-pdf/pypdf/files/12311735/bad.pdf"
     name = "iss2078.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
 
@@ -2074,7 +2074,7 @@ def test_no_i_in_articles():
     """Cf #2089"""
     url = "https://github.com/py-pdf/pypdf/files/12352793/kim2002.pdf"
     name = "iss2089.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
 
@@ -2087,7 +2087,7 @@ def test_damaged_pdf_length_returning_none():
     """
     url = "https://github.com/py-pdf/pypdf/files/12168578/bad_pdf_example.pdf"
     name = "iss140_bad_pdf.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
 
@@ -2097,7 +2097,7 @@ def test_viewerpreferences():
     """Add Tests for ViewerPreferences"""
     url = "https://github.com/py-pdf/pypdf/files/9175966/2015._pb_decode_pg0.pdf"
     name = "2015._pb_decode_pg0.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     v = reader.viewer_preferences
     assert v.center_window == True  # noqa: E712
     writer = PdfWriter(clone_from=reader)
@@ -2179,7 +2179,7 @@ def test_extra_spaces_in_da_text(caplog):
 def test_object_contains_indirect_reference_to_self():
     url = "https://github.com/py-pdf/pypdf/files/12389243/testbook.pdf"
     name = "iss2102.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     width, height = 595, 841
     outpage = writer.add_blank_page(width, height)
@@ -2282,7 +2282,7 @@ PROBLEMS 74
 REFERENCES 76"""
     url = "https://github.com/py-pdf/pypdf/files/12797067/test-12.pdf"
     name = "iss2233.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter(clone_from=reader)
 
     bookmarks, history_indent = [], []
@@ -2370,7 +2370,7 @@ def test_reattach_fields():
     """
     url = "https://github.com/py-pdf/pypdf/files/14241368/ExampleForm.pdf"
     name = "iss2453.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     for p in reader.pages:
         writer.add_page(p)
@@ -2467,7 +2467,7 @@ def test_i_in_choice_fields():
     """Cf #2611"""
     url = "https://github.com/py-pdf/pypdf/files/15176321/FRA.F.6180.150.pdf"
     name = "iss2611.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     assert "/I" in writer.get_fields()["State"].indirect_reference.get_object()
     writer.update_page_form_field_values(
         writer.pages[0], {"State": "NY"}, auto_regenerate=False
@@ -2503,7 +2503,7 @@ def test_no_resource_for_14_std_fonts():
     """Cf #2670"""
     url = "https://github.com/py-pdf/pypdf/files/15405390/f1040.pdf"
     name = "iss2670.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     p = writer.pages[0]
     for a in p["/Annots"]:
         a = a.get_object()
@@ -2519,7 +2519,7 @@ def test_field_box_upside_down():
     """Cf #2724"""
     url = "https://github.com/user-attachments/files/15996356/FRA.F.6180.55.pdf"
     name = "iss2724.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.update_page_form_field_values(None, {"FreightTrainMiles": "0"})
     assert writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data() == (
         b"q\n/Tx BMC \nq\n2 1 102.29520000000001 9.835000000000036 re\n"
@@ -2536,7 +2536,7 @@ def test_matrix_entry_in_field_annots():
     """Cf #2731"""
     url = "https://github.com/user-attachments/files/16036514/template.pdf"
     name = "iss2731.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)))
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.update_page_form_field_values(
         writer.pages[0],
         {"Stellenbezeichnung_1": "some filled in text"},
@@ -2550,7 +2550,7 @@ def test_compress_identical_objects():
     """Cf #2728 and #2794"""
     url = "https://github.com/user-attachments/files/16575458/tt2.pdf"
     name = "iss2794.pdf"
-    in_bytes = BytesIO(get_data_from_url(url, name=name))
+    in_bytes = BytesIO(get_data_from_url(url=url, name=name))
     writer = PdfWriter(in_bytes)
     writer.compress_identical_objects(remove_unreferenced=False)
     out1 = BytesIO()
@@ -2589,7 +2589,7 @@ def test_compress_identical_objects__remove_unreferenced():
 def test_compress_identical_objects__deprecation():
     url = "https://github.com/user-attachments/files/16575458/tt2.pdf"
     name = "iss2794.pdf"
-    in_bytes = BytesIO(get_data_from_url(url, name=name))
+    in_bytes = BytesIO(get_data_from_url(url=url, name=name))
     writer = PdfWriter(in_bytes)
     with pytest.warns(
         DeprecationWarning,
@@ -2717,7 +2717,7 @@ def test_increment_writer(caplog):
     # insert pages in a tree
     url = "https://github.com/py-pdf/pypdf/files/13946477/panda.pdf"
     name = "iss2343b.pdf"
-    writer = PdfWriter(BytesIO(get_data_from_url(url, name=name)), incremental=True)
+    writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)), incremental=True)
     reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
     pg = writer.insert_page(reader.pages[0], 4)
     assert (
@@ -2747,7 +2747,7 @@ def test_append_pdf_with_dest_without_page(caplog):
     """Tests for #2842"""
     url = "https://github.com/user-attachments/files/16990834/test.pdf"
     name = "iss2842.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
     assert "/__WKANCHOR_8" not in writer.named_destinations
@@ -2759,7 +2759,7 @@ def test_destination_is_nullobject():
     """Tests for #2958"""
     url = "https://github.com/user-attachments/files/17822279/C0.00.-.COVER.SHEET.pdf"
     name = "iss2958.pdf"
-    source_data = BytesIO(get_data_from_url(url, name=name))
+    source_data = BytesIO(get_data_from_url(url=url, name=name))
     writer = PdfWriter()
     writer.append(source_data)
 
@@ -2769,7 +2769,7 @@ def test_destination_page_is_none():
     """Tests for #2963"""
     url = "https://github.com/user-attachments/files/17879461/3.pdf"
     name = "iss2963.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     writer = PdfWriter()
     writer.append(reader)
 
@@ -2824,12 +2824,12 @@ def test_inline_image_q_operator_handling(tmp_path):
     """Test for #2927"""
     pdf_url = "https://github.com/user-attachments/files/17614880/test_clean.pdf"
     pdf_name = "iss2927.pdf"
-    pdf_data = BytesIO(get_data_from_url(pdf_url, name=pdf_name))
+    pdf_data = BytesIO(get_data_from_url(url=pdf_url, name=pdf_name))
 
     png_url = "https://github.com/user-attachments/assets/abe16f48-9afa-4179-b1e8-62be27b95c26"
     png_name = "iss2927.png"
     expected_png_path = tmp_path / "expected.png"
-    expected_png_path.write_bytes(get_data_from_url(png_url, name=png_name))
+    expected_png_path.write_bytes(get_data_from_url(url=png_url, name=png_name))
 
     writer = PdfWriter()
     writer.append(pdf_data)
@@ -2961,7 +2961,7 @@ def test_insert_filtered_annotations__annotations_are_no_list(caplog):
     """Tests for #3320"""
     url = "https://github.com/user-attachments/files/20818089/bugpdf.pdf"
     name = "issue3320.pdf"
-    source_data = BytesIO(get_data_from_url(url, name=name))
+    source_data = BytesIO(get_data_from_url(url=url, name=name))
     reader = PdfReader(source_data)
     writer = PdfWriter()
     writer.append(reader)

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -152,7 +152,7 @@ def test_identity_function(x):
 )
 def test_xmpmm_instance_id(url, name, xmpmm_instance_id):
     """XMPMM instance id is correctly extracted."""
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     xmp_metadata = reader.xmp_metadata
     assert xmp_metadata.xmpmm_instance_id == xmpmm_instance_id
     # cache hit:
@@ -164,7 +164,7 @@ def test_xmp_dc_description_extraction():
     """XMP dc_description is correctly extracted."""
     url = "https://github.com/user-attachments/files/18381721/tika-953770.pdf"
     name = "tika-953770.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     xmp_metadata = reader.xmp_metadata
     assert xmp_metadata.dc_description == {
         "x-default": "U.S. Title 50 Certification Form"
@@ -180,7 +180,7 @@ def test_dc_creator_extraction():
     """XMP dc_creator is correctly extracted."""
     url = "https://github.com/user-attachments/files/18381721/tika-953770.pdf"
     name = "tika-953770.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     xmp_metadata = reader.xmp_metadata
     assert xmp_metadata.dc_creator == ["U.S. Fish and Wildlife Service"]
     # cache hit:
@@ -192,7 +192,7 @@ def test_custom_properties_extraction():
     """XMP custom_properties is correctly extracted."""
     url = "https://github.com/user-attachments/files/18381764/tika-986065.pdf"
     name = "tika-986065.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     xmp_metadata = reader.xmp_metadata
     assert xmp_metadata.custom_properties == {"Style": "Searchable Image (Exact)"}
     # cache hit:
@@ -204,7 +204,7 @@ def test_dc_subject_extraction():
     """XMP dc_subject is correctly extracted."""
     url = "https://github.com/user-attachments/files/18381730/tika-959519.pdf"
     name = "tika-959519.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     xmp_metadata = reader.xmp_metadata
     assert xmp_metadata.dc_subject == [
         "P&P",
@@ -240,7 +240,7 @@ def test_invalid_xmp_information_handling():
     """
     url = "https://github.com/py-pdf/pypdf/files/5536984/test.pdf"
     name = "pypdf-5536984.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
     with pytest.raises(PdfReadError) as exc:
         reader.xmp_metadata
     assert exc.value.args[0].startswith("XML in XmpInformation was invalid")
@@ -271,7 +271,7 @@ def test_pdfa_xmp_metadata_without_values():
 def test_xmp_metadata__content_stream_is_dictionary_object():
     url = "https://github.com/user-attachments/files/18943249/testing.pdf"
     name = "issue3107.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     with pytest.raises(
             PdfReadError,
@@ -284,7 +284,7 @@ def test_xmp_metadata__content_stream_is_dictionary_object():
 def test_dc_creator__bag_instead_of_seq():
     url = "https://github.com/user-attachments/files/18381698/tika-924562.pdf"
     name = "tika-924562.pdf"
-    reader = PdfReader(BytesIO(get_data_from_url(url, name=name)))
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
 
     assert reader.xmp_metadata is not None
     assert reader.xmp_metadata.dc_creator == ["William J. Hussar"]


### PR DESCRIPTION
closes TODO in tests/__init__.py line 44

changes:
- made get_data_from_url keyword-only by adding * to signature
- dropped name being optional (name: str instead of Optional[str])
- updated all call sites across test files to use explicit url= keyword argument..

tested by running pytest tests/ , no syntaxError or typeError from the refactored calls. 
remaining failures are pre-existing and seem to be unrelated to this change.

just to be absolutely sure i ran test before my commit and it showed same result

ran : pytest tests/ --timeout=60  -q 2>&1  before and after i made changes 

before the commit i got 
89 failed, 1095 passed, 8 skipped, 3 xfailed in 135.96s (0:02:15)

after my commit i got 
89 failed, 1095 passed, 8 skipped, 3 xfailed in 135.02s (0:02:15)