### PR TITLE
TST: Add 4-bit image test 

### DIFF
--- a/tests/example_files.yaml
+++ b/tests/example_files.yaml
@@ -104,6 +104,8 @@
   url: https://github.com/py-pdf/pypdf/assets/4083478/56c93021-33cd-4387-ae13-5cbe7e673f42
 - local_filename: paid.pdf
   url: https://github.com/py-pdf/pypdf/files/12050253/tt.pdf
+- local_filename: 4bits_image.pdf
+  url: https://github.com/user-attachments/files/27491104/test_4bit.pdf
 - local_filename: Pesquisa-de-Precos-Combustiveis-novembro-2023.pdf
   url: https://www.joinville.sc.gov.br/wp-content/uploads/2023/11/Pesquisa-de-Precos-Combustiveis-novembro-2023.pdf
 - local_filename: iss2138.pdf

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -485,10 +485,21 @@ def test_index_lookup():
 
 @pytest.mark.enable_socket
 def test_2bits_image():
-    """From #1954, test with 2bits image. TODO: 4bits also"""
+    """From #1954, test with 2bits image."""
     reader = PdfReader(BytesIO(get_data_from_url(name="paid.pdf")))
     url_png = "https://user-images.githubusercontent.com/4083478/253568117-ca95cc85-9dea-4145-a5e0-032f1c1aa322.png"
     name_png = "Paid.png"
+    refimg = BytesIO(get_data_from_url(url=url_png, name=name_png))
+    data = reader.pages[0].images[0]
+    assert image_similarity(data.image, refimg) > 0.99
+
+
+@pytest.mark.enable_socket
+def test_4bits_image():
+    """From #1954, test with 4bits image."""
+    reader = PdfReader(BytesIO(get_data_from_url(name="4bits_image.pdf")))
+    url_png = "https://github.com/user-attachments/files/27492549/4bits_image.png.txt"
+    name_png = "4bits_image.png"
     refimg = BytesIO(get_data_from_url(url=url_png, name=name_png))
     data = reader.pages[0].images[0]
     assert image_similarity(data.image, refimg) > 0.99


### PR DESCRIPTION
closes TODO in tests/test_filters.py , line 488 

changes made:

- Added test_4bits_image()  in tests/test_filters.py to cover the 4-bit
  (/BitsPerComponent 4) grayscale image decoding path
- Registered the test PDF in tests/example_files.yaml as 4bits_image.pdf

the test PDF is a minimal 16×16 grayscale image with /BitsPerComponent 4
and /Filter /FlateDecode. The reference PNG was extracted by running pypdf on the test PDF and saving the output.

the test PDF and reference PNG are attached to my comment on #1954
(the issue is closed, but the attachment URLs remain accessible)

tested locally:
Before my commit : 32 failed, 1153 passed, 8 skipped, 2 xfailed, 1 xpassed
After my commit :  32 failed, 1153 passed, 8 skipped, 2 xfailed, 1 xpassed

used AI assistance (Claude) for generating the 4 bit pdf,
understanding the `bits2byte` code path, and drafting the test structure.
all changes were reviewed and understood before committing
