### PR TITLE
Fix TreeObject.insert_child except branch KeyError on fresh children

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -804,7 +804,8 @@ class TreeObject(DictionaryObject):
             prev["/Prev"][NameObject("/Next")] = child_reference
             child_obj[NameObject("/Prev")] = prev["/Prev"]
         except Exception:  # it means we are inserting in first position
-            del child_obj["/Next"]
+            if "/Next" in child_obj:
+                del child_obj["/Next"]
         child_obj[NameObject("/Next")] = prev
         prev[NameObject("/Prev")] = child_reference
         child_obj[NameObject("/Parent")] = self.indirect_reference


### PR DESCRIPTION
## Summary

TreeObject.insert_child in pypdf/generic/_data_structures.py has an except branch (lines 806-807) that unconditionally calls `del child_obj["/Next"]`. When inserting a freshly-created TreeObject (which has no "/Next" key), this raises a new KeyError, masking the original intent of the except branch.

## Proposed fix

Guard the deletion:

```python
except Exception:  # it means we are inserting in first position
    if "/Next" in child_obj:
        del child_obj["/Next"]
```

This matches the pattern used in lines 783-786 for the first-child branch.

Closes #3727

---
*Automated contribution via [MCP Contributor](https://github.com/nguyenthanhthe/mcp-contributor)*

Closes #3727