### PR TITLE
TST: Surface worker thread exceptions in download_test_pdfs

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -61,8 +61,7 @@ def get_data_from_url(*, url: Optional[str] = None, name: str) -> bytes:
         cache_dir = Path("tests", "pdf_cache").resolve()
     else:
         cache_dir = Path(__file__).parent / "pdf_cache"
-    if not cache_dir.exists():
-        cache_dir.mkdir()
+    cache_dir.mkdir(exist_ok=True)
     cache_path = cache_dir / name
 
     if url is not None:
@@ -134,7 +133,8 @@ def download_test_pdfs() -> None:
             executor.submit(get_data_from_url, url=pdf["url"], name=pdf["local_filename"])
             for pdf in pdfs
         ]
-        concurrent.futures.wait(futures)
+        for future in concurrent.futures.as_completed(futures):
+            future.result()  # re-raises any exception from the worker thread
 
 
 class PILContext:


### PR DESCRIPTION
## Summary

Previously, `download_test_pdfs()` called `concurrent.futures.wait(futures)` but never iterated the returned futures or called `.result()` on them. Any exception raised in a worker thread was silently captured, causing confusing downstream `FileNotFoundError`s when tests tried to open missing files.

Replace `wait()` with `as_completed()` + `.result()` so that download failures are surfaced immediately at the source.

## Fix

- Replace `concurrent.futures.wait(futures)` with `concurrent.futures.as_completed(futures)` and call `.result()` on each future to re-raise any worker thread exceptions.

## Testing

- The change is in test infrastructure code, so the existing test suite exercises it.
- To manually verify: temporarily break a URL in `example_files.yaml` and confirm that `download_test_pdfs()` now raises instead of silently swallowing the error.

Closes #3728