### PR TITLE
MAINT: Use bare `raise` instead of `raise exc` (TRY201)

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -158,7 +158,7 @@ def _extended_image_from_bytes(
                 "Data is 0 bytes, cannot process an image from empty data."
             ) from exc
         if data_length % nb_pix != 0:
-            raise exc
+            raise
         k = nb_pix * len(mode) / data_length
         data = b"".join(bytes((x,) * int(k)) for x in data)
         img = Image.frombytes(mode, size, data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,6 @@ ignore = [
     "TRY002",  # Create your own exception
     "TRY003",  # Avoid specifying long messages outside the exception class
     "TRY004",  # Prefer `TypeError` exception for invalid type
-    "TRY201",  # Use `raise` without specifying exception name
     "TRY300",  # Consider moving this statement to an `else` block
     "TRY301",  # Abstract `raise` to an inner function
     "UP006",   # Non-PEP 585 annotation. As long as we are not on Python 3.11+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -33,11 +33,11 @@ def _get_data_from_url(url: str) -> bytes:
                     url
             ) as response:
                 return response.read()
-        except HTTPError as e:
+        except HTTPError:
             if attempts < 3:
                 attempts += 1
             else:
-                raise e
+                raise
     raise ValueError(f"Unknown error handling {url}")
 
 


### PR DESCRIPTION
## Description

Replace `raise exc` with bare `raise` to preserve the original traceback, following ruff's TRY201 rule. Using bare `raise` preserves the full exception chain, making debugging easier.

### Changes

- `pypdf/generic/_image_xobject.py`: Changed `raise exc` to `raise` in the ValueError handler of `_handle_flate__image_mode_1`
- `tests/__init__.py`: Changed `raise e` to `raise` in the HTTPError handler of `download_test_pdfs()`, and removed the unused `as e` binding
- `pyproject.toml`: Removed `TRY201` from the ruff ignore list since all violations are now fixed

Contributes to #3327.