### PR TITLE
MAINT: Move try block statements to else blocks (TRY300)

### DIFF
--- a/pypdf/_codecs/_codecs.py
+++ b/pypdf/_codecs/_codecs.py
@@ -172,10 +172,10 @@ class LzwCodec(Codec):
             # Reduce data to get rid of the overhead,
             # which increases performance on large streams significantly.
             self._next_data = self._next_data & 0xFFFFF
-
-            return code
         except IndexError:
             return self.EOD_MARKER
+        else:
+            return code
 
     # The following method has been converted to Python from PDFsharp:
     # https://github.com/empira/PDFsharp/blob/5fbf6ed14740bc4e16786816882d32e43af3ff5d/src/foundation/src/PDFsharp/src/PdfSharp/Pdf.Filters/LzwDecode.cs

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1044,9 +1044,10 @@ class PdfReader(PdfDocCommon):
             logger_warning("Invalid parent xref., rebuild xref", __name__)
             try:
                 self._rebuild_xref_table(stream)
-                return None
             except Exception:
                 raise PdfReadError("Cannot rebuild xref")
+            else:
+                return None
         raise PdfReadError("Could not find xref table at specified location")
 
     def _sanitize_pdf15_xref_stream_index_pairs(

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -185,9 +185,10 @@ def create_string_object(
             retval = TextStringObject(decode_pdfdocencoding(string))
             retval._original_bytes = string
             retval.autodetect_pdfdocencoding = True
-            return retval
         except UnicodeDecodeError:
             return ByteStringObject(string)
+        else:
+            return retval
     else:
         raise TypeError("create_string_object should have str or unicode arg")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,6 @@ ignore = [
     "TRY003",  # Avoid specifying long messages outside the exception class
     "TRY004",  # Prefer `TypeError` exception for invalid type
     "TRY201",  # Use `raise` without specifying exception name
-    "TRY300",  # Consider moving this statement to an `else` block
     "TRY301",  # Abstract `raise` to an inner function
     "UP006",   # Non-PEP 585 annotation. As long as we are not on Python 3.11+
     "UP007",   # Non-PEP 604 annotation. As long as we are not on Python 3.11+


### PR DESCRIPTION
## Description

Move return/yield statements from the end of `try` blocks to the corresponding `else` blocks, following ruff's TRY300 rule. This makes the control flow clearer by explicitly separating the code that may raise an exception from the code that only runs on success.

### Changes

- `pypdf/_codecs/_codecs.py`: Moved `return code` from try block to else block
- `pypdf/_reader.py`: Moved `return None` from try block to else block after xref rebuild
- `pypdf/generic/_utils.py`: Moved `return retval` from try block to else block
- `pyproject.toml`: Removed TRY300 from the ruff ignore list since all violations are now fixed

Contributes to #3327.