### PR TITLE
Quality: Broad exception handling in fill_from_encoding

### DIFF
--- a/pypdf/_codecs/__init__.py
+++ b/pypdf/_codecs/__init__.py
@@ -10,7 +10,7 @@ def fill_from_encoding(enc: str) -> list[str]:
     for x in range(256):
         try:
             lst += (bytes((x,)).decode(enc),)
-        except Exception:
+        except UnicodeDecodeError:
             lst += (chr(x),)
     return lst
 


### PR DESCRIPTION
## Summary

Quality: Broad exception handling in fill_from_encoding

## Problem

**Severity**: `Low` | **File**: `pypdf/_codecs/__init__.py:L10`

The function fill_from_encoding catches a generic Exception when decoding bytes to string. This can mask various errors (e.g., MemoryError, KeyboardInterrupt) and makes debugging difficult. It should catch specific exceptions like UnicodeDecodeError.

## Solution

Replace `except Exception:` with `except UnicodeDecodeError:` to handle only expected decoding failures.

## Changes

- `pypdf/_codecs/__init__.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"