### PR TITLE
ENH: Implement SASLprep (RFC 4013) for AES-256 password normalization

### DIFF
--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -26,7 +26,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import hashlib
 import secrets
+import stringprep
 import struct
+import unicodedata
 from enum import Enum, IntEnum
 from typing import Any, Optional, Union, cast
 
@@ -116,6 +118,22 @@ _PADDING = (
 
 def _padding(data: bytes) -> bytes:
     return (data + _PADDING)[:32]
+
+
+# Module-level constant for SASLprep prohibited character checks (RFC 4013 §2.3)
+_SASLPREP_PROHIBITED_CHECKS = (
+    (stringprep.in_table_c12, "non-ASCII space character"),
+    (stringprep.in_table_c21, "ASCII control character"),
+    (stringprep.in_table_c22, "non-ASCII control character"),
+    (stringprep.in_table_c3, "private use character"),
+    (stringprep.in_table_c4, "non-character code point"),
+    (stringprep.in_table_c5, "surrogate code point"),
+    (stringprep.in_table_c6, "inappropriate for plain text"),
+    (stringprep.in_table_c7, "inappropriate for canonical representation"),
+    (stringprep.in_table_c8, "change display properties/deprecated"),
+    (stringprep.in_table_c9, "tagging character"),
+    (stringprep.in_table_a1, "unassigned code point"),
+)
 
 
 class AlgV4:
@@ -767,6 +785,73 @@ class PasswordType(IntEnum):
     OWNER_PASSWORD = 2
 
 
+def _saslprep(password: str) -> str:
+    """
+    Apply the SASLprep profile (RFC 4013) of stringprep (RFC 3454).
+
+    This normalizes Unicode passwords for PDF 2.0 (AES-256, revision 5/6)
+    encryption as required by the PDF specification.
+
+    Args:
+        password: The Unicode password string to normalize.
+
+    Returns:
+        The SASLprep-normalized string.
+
+    Raises:
+        ValueError: If the password contains prohibited characters
+            or fails the bidirectional character check.
+
+    """
+    # Mapping (RFC 4013 §2.1)
+    #    - Map characters in table B.1 to nothing
+    #    - Map characters in table C.1.2 (non-ASCII spaces) to U+0020 (SPACE)
+    mapped: list[str] = []
+    for character in password:
+        if stringprep.in_table_b1(character):
+            continue  # map to nothing
+        if stringprep.in_table_c12(character):
+            mapped.append(" ")  # map to SPACE
+        else:
+            mapped.append(character)
+    password = "".join(mapped)
+
+    # Normalization (RFC 4013 §2.2) — Unicode NFKC
+    password = unicodedata.normalize("NFKC", password)
+
+    for character in password:
+        for check, description in _SASLPREP_PROHIBITED_CHECKS:
+            if check(character):
+                raise ValueError(
+                    f"SASLprep: {description} U+{ord(character):04X}"
+                )
+
+    # Bidirectional check (RFC 4013 §2.4, RFC 3454 §6)
+    has_r_and_al = False
+    has_l = False
+    for character in password:
+        if stringprep.in_table_d1(character):
+            has_r_and_al = True
+        if stringprep.in_table_d2(character):
+            has_l = True
+
+    if has_r_and_al:
+        if has_l:
+            raise ValueError(
+                "SASLprep: string with RandALCat characters must not "
+                "contain LCat characters"
+            )
+        if not stringprep.in_table_d1(password[0]) or not stringprep.in_table_d1(
+            password[-1]
+        ):
+            raise ValueError(
+                "SASLprep: string with RandALCat characters must start "
+                "and end with RandALCat characters"
+            )
+
+    return password
+
+
 class EncryptAlgorithm(tuple, Enum):  # type: ignore # noqa: SLOT001
     # V, R, Length
     RC4_40 = (1, 2, 40)
@@ -958,19 +1043,39 @@ class Encryption:
 
         return CryptRC4(rc4_key)
 
-    @staticmethod
-    def _encode_password(password: Union[bytes, str]) -> bytes:
+    def _encode_password(
+        self, password: Union[bytes, str], *, strict: bool = False
+    ) -> bytes:
         if isinstance(password, str):
-            try:
-                pwd = password.encode("latin-1")
-            except Exception:
+            if self.V >= 5:
+                # PDF 2.0 §7.6.4.3.3: AES-256 (R5/R6) requires SASLprep
+                # normalization followed by UTF-8 encoding.
+                try:
+                    password = _saslprep(password)
+                except (ValueError, IndexError) as e:
+                    if strict:
+                        raise ValueError(
+                            f"Password SASLprep normalization failed: {e}"
+                        ) from e
+                    logger_warning(
+                        "SASLprep normalization failed, using plain UTF-8: %(err)s",
+                        source=__name__,
+                        err=str(e),
+                    )
                 pwd = password.encode("utf-8")
+            else:
+                try:
+                    pwd = password.encode("latin-1")
+                except Exception:
+                    pwd = password.encode("utf-8")
         else:
             pwd = password
         return pwd
 
-    def verify(self, password: Union[bytes, str]) -> PasswordType:
-        pwd = self._encode_password(password)
+    def verify(
+        self, password: Union[bytes, str], *, strict: bool = False
+    ) -> PasswordType:
+        pwd = self._encode_password(password, strict=strict)
         key, rc = self.verify_v4(pwd) if self.V <= 4 else self.verify_v5(pwd)
         if rc != PasswordType.NOT_DECRYPTED:
             self._password_type = rc
@@ -1006,7 +1111,6 @@ class Encryption:
         return b"", PasswordType.NOT_DECRYPTED
 
     def verify_v5(self, password: bytes) -> tuple[bytes, PasswordType]:
-        # TODO: use SASLprep process
         # verify owner password first
         key = AlgV5.verify_owner_password(
             self.R, password, self.values.O, self.values.OE, self.values.U
@@ -1027,10 +1131,18 @@ class Encryption:
         return key, rc
 
     def write_entry(
-        self, user_password: str, owner_password: Optional[str]
+        self,
+        user_password: str,
+        owner_password: Optional[str],
+        *,
+        strict: bool = False,
     ) -> DictionaryObject:
-        user_pwd = self._encode_password(user_password)
-        owner_pwd = self._encode_password(owner_password) if owner_password else None
+        user_pwd = self._encode_password(user_password, strict=strict)
+        owner_pwd = (
+            self._encode_password(owner_password, strict=strict)
+            if owner_password
+            else None
+        )
         if owner_pwd is None:
             owner_pwd = user_pwd
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -188,7 +188,7 @@ class PdfReader(PdfDocCommon):
         # try empty password if no password provided
         pwd = password if password is not None else b""
         if (
-            self._encryption.verify(pwd) == PasswordType.NOT_DECRYPTED
+            self._encryption.verify(pwd, strict=self.strict) == PasswordType.NOT_DECRYPTED
             and password is not None
         ):
             # raise if password provided
@@ -1395,7 +1395,7 @@ class PdfReader(PdfDocCommon):
         if not self._encryption:
             raise PdfReadError("Not encrypted file")
         # TODO: raise Exception for wrong password
-        return self._encryption.verify(password)
+        return self._encryption.verify(password, strict=self.strict)
 
     @property
     def is_encrypted(self) -> bool:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1348,7 +1348,7 @@ class PdfWriter(PdfDocCommon):
         assert self._ID
         self._encryption = Encryption.make(alg, permissions_flag, self._ID[0])
         # in case call `encrypt` again
-        entry = self._encryption.write_entry(user_password, owner_password)
+        entry = self._encryption.write_entry(user_password, owner_password, strict=self.strict)
         if self._encrypt_entry:
             # replace old encrypt_entry
             assert self._encrypt_entry.indirect_reference is not None

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -11,7 +11,7 @@ import pypdf
 from pypdf import PasswordType, PdfReader, PdfWriter
 from pypdf._crypt_providers import crypt_provider
 from pypdf._crypt_providers._fallback import _DEPENDENCY_ERROR_STR
-from pypdf._encryption import AlgV5, CryptAES, CryptRC4
+from pypdf._encryption import AlgV5, CryptAES, CryptRC4, EncryptAlgorithm, Encryption, _saslprep
 from pypdf.errors import DependencyError, PdfReadError, PdfStreamError
 from tests import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
 
@@ -526,3 +526,62 @@ def test_reader__decryption_error_handling(caplog) -> None:
     with pytest.raises(PdfStreamError, match=r"^(Invalid padding bytes|(PKCS#7 p|P)adding is incorrect)\.$"):
         reader = PdfReader(BytesIO(data), strict=True)
         _ = list(reader.pages)
+
+
+@pytest.mark.parametrize(("password", "expected"), [
+    ("password", "password"),          # plain ASCII unchanged
+    ("USER", "USER"),                  # case preserved (RFC 4013 example 3)
+    ("I\u00adX", "IX"),                # B.1 soft hyphen mapped to nothing (RFC 4013 example 1)
+    ("a\u00a0b", "a b"),               # C.1.2 non-ASCII space mapped to U+0020
+    ("\u00aa", "a"),                   # NFKC normalization (RFC 4013 example 4)
+    ("\u2168", "IX"),                  # NFKC normalization (RFC 4013 example 5)
+    ("pässwört", "pässwört"),          # normal unicode passthrough after NFKC
+    ("", ""),                          # empty string passes through
+    ("\u0627\u0628", "\u0627\u0628"),  # pure RandALCat at both edges passes
+])
+def test_saslprep_valid(password: str, expected: str) -> None:
+    assert _saslprep(password) == expected
+
+
+@pytest.mark.parametrize(("password", "match"), [
+    ("\u0007", "ASCII control character"),                            # RFC 4013 example 6
+    ("\u06dd", "non-ASCII control character"),                        # U+06DD ARABIC END OF AYAH
+    ("\ue000", "private use character"),
+    ("\ufdd0", "non-character code point"),
+    ("\ufffd", "inappropriate for plain text"),                       # U+FFFD REPLACEMENT CHARACTER
+    ("\u2ff0", "inappropriate for canonical representation"),
+    ("\u200e", "change display properties"),
+    ("\U000e0001", "tagging character"),
+    ("\u0627a\u0628", r"RandALCat.*must not.*LCat"),                  # RFC 4013 example 7
+    ("\u0627\u0628\u0030", "must start and end"),                     # RandALCat not at edges
+])
+def test_saslprep_invalid(password: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _saslprep(password)
+
+
+@pytest.mark.parametrize(("alg", "password", "expected"), [
+    (EncryptAlgorithm.AES_256, b"raw bytes", b"raw bytes"),           # bytes passthrough, V5
+    (EncryptAlgorithm.AES_128, b"raw bytes", b"raw bytes"),           # bytes passthrough, V4
+    (EncryptAlgorithm.AES_256, "pässwört", "pässwört".encode()),      # normal unicode SASLprepped + UTF-8, V5
+    (EncryptAlgorithm.AES_128, "pässwört", "pässwört".encode("latin-1")),  # V4 uses latin-1
+    (EncryptAlgorithm.AES_128, "\u4e2d", "\u4e2d".encode()),          # V4 non-latin-1 falls back to UTF-8
+])
+def test_encode_password_valid(alg: EncryptAlgorithm, password, expected: bytes) -> None:
+    enc = Encryption.make(alg, -1, b"\x00" * 16)
+    assert enc._encode_password(password, strict=True) == expected
+
+
+def test_encode_password_strict_raises_on_prohibited() -> None:
+    """strict=True raises ValueError on SASLprep-prohibited characters."""
+    enc = Encryption.make(EncryptAlgorithm.AES_256, -1, b"\x00" * 16)
+    with pytest.raises(ValueError, match="SASLprep normalization failed"):
+        enc._encode_password("pass\x07word", strict=True)
+
+
+def test_encode_password_nonstrict_warns_and_falls_back(caplog) -> None:
+    """strict=False logs a warning and returns plain UTF-8."""
+    enc = Encryption.make(EncryptAlgorithm.AES_256, -1, b"\x00" * 16)
+    result = enc._encode_password("pass\x07word", strict=False)
+    assert result == b"pass\x07word"
+    assert any("SASLprep normalization failed" in m for m in caplog.messages)


### PR DESCRIPTION
Fixes #3777

Changes:
- Added _saslprep() function in pypdf/_encryption.py using only stdlib (stringprep + unicodedata) implementing RFC 4013
- Modified _encode_password to apply SASLprep for V>=5 (AES-256) str inputs only, with strict parameter following the existing pattern
- strict=True raises on invalid passwords, strict=False issues a warning and falls back to UTF-8
- Removed TODO comment from verify_v5

Tested with the reproduction script from the issue:
- Before: reader.decrypt("pässwört") returned 0 (NOT_DECRYPTED)
- After: reader.decrypt("pässwört") returned 1 (USER_PASSWORD)