### PR TITLE
ROB: AppearanceStream: Also honor user-set font name when not flattening annotations

### DIFF
--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from enum import IntEnum
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
@@ -480,21 +480,33 @@ class TextStreamAppearance(BaseStreamAppearance):
         writer: PdfWriter,
         font_name: str,
         font: Font,
-        target_resource_dict: DictionaryObject
-    ) -> DictionaryObject | IndirectObject:
+        target_resource_dict: DictionaryObject,
+        page: PageObject | None = None
+    ) -> IndirectObject:
         """
-        Unified helper to sync fonts from an AP stream to a target
-        resource dictionary (e.g., AcroForm /DR or Page /Resources).
+        Unified helper to sync fonts from an AP stream to a target resource dictionary (e.g., AcroForm /DR).
+        Will sync to page resources as well when page is added to the arguments.
         """
         target_fonts = target_resource_dict.setdefault(NameObject("/Font"), DictionaryObject()).get_object()
         if font_name not in target_fonts:
-            return font._add_to_writer(
+            font_resource_reference = font._add_to_writer(
                 writer,
                 target_fonts,
                 NameObject(font_name)
             )
+        else:
+            font_resource_reference = target_fonts[font_name]
 
-        return cast(Union[DictionaryObject, IndirectObject], target_fonts[font_name])
+        if page:
+            page_fonts_resource = cast(DictionaryObject, page[PageAttributes.RESOURCES]).setdefault(
+                NameObject("/Font"), DictionaryObject()
+            ).get_object()
+            if font_name not in page_fonts_resource:
+                page_fonts_resource[NameObject(font_name)] = getattr(
+                    font_resource_reference, "indirect_reference", font_resource_reference
+                )
+
+        return font_resource_reference
 
     @classmethod
     def from_text_annotation(
@@ -594,12 +606,13 @@ class TextStreamAppearance(BaseStreamAppearance):
             annotation[NameObject("/DA")] = TextStringObject(default_appearance.replace(da_font_name, font_name))
 
         # Synchronise font resources
-        if flatten:
-            sync_target = cast(DictionaryObject, page[PageAttributes.RESOURCES])
-        else:
-            sync_target = acro_form.setdefault(NameObject("/DR"), DictionaryObject())
-
-        font_resource_reference = cls._sync_appearance_stream_font_resources(writer, font_name, font, sync_target)
+        font_resource_reference = cls._sync_appearance_stream_font_resources(
+            writer,
+            font_name,
+            font,
+            acro_form.setdefault(NameObject("/DR"), DictionaryObject()),
+            page if flatten else None,
+        )
 
         # Retrieve formatting information
         is_comb = False

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -574,18 +574,24 @@ class TextStreamAppearance(BaseStreamAppearance):
         # font) operator along with its two operands, font and size" (Section 12.7.4.3
         # "Variable text" of the PDF 2.0 specification).
         font_properties = [prop for prop in re.split(r"\s", default_appearance) if prop]
-        font_name = font_properties.pop(font_properties.index("Tf") - 2)
+        da_font_name = font_properties.pop(font_properties.index("Tf") - 2)
         font_size = float(font_properties.pop(font_properties.index("Tf") - 1))
         font_properties.remove("Tf")
         font_color = " ".join(font_properties)
         # Determine the font name to use, prioritizing the user's input
         if user_font_name:
             font_name = user_font_name
+        else:
+            font_name = da_font_name
         # Determine the font size to use, prioritizing the user's input
         if user_font_size > 0:
             font_size = user_font_size
 
         font_name, font = cls._find_annotation_font_resource(font_name, annotation, acro_form, text)
+
+        # Change the /DA information if we changed the font name
+        if font_name != da_font_name:
+            annotation[NameObject("/DA")] = TextStringObject(default_appearance.replace(da_font_name, font_name))
 
         # Synchronise font resources
         if flatten:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1836,7 +1836,7 @@ def test_update_form_fields3(caplog, tmp_path):
         "adresa_judet": "Конференция",
     }
     writer.update_page_form_field_values(writer.pages[0], data, flatten=True)
-    # Test that we have changed the font rsource from /Ubuntu to /PYPDF1
+    # Test that we have changed the font resource from /Ubuntu to /PYPDF1
     new_font_resource = "/PYPDF1"
     assert new_font_resource in writer.pages[0]["/Annots"][0]["/DA"]
     assert new_font_resource in writer.pages[0]["/Resources"]["/Font"]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1836,6 +1836,11 @@ def test_update_form_fields3(caplog, tmp_path):
         "adresa_judet": "Конференция",
     }
     writer.update_page_form_field_values(writer.pages[0], data, flatten=True)
+    # Test that we have changed the font rsource from /Ubuntu to /PYPDF1
+    new_font_resource = "/PYPDF1"
+    assert new_font_resource in writer.pages[0]["/Annots"][0]["/DA"]
+    assert new_font_resource in writer.pages[0]["/Resources"]["/Font"]
+    assert new_font_resource in writer._root_object["/AcroForm"]["/DR"]["/Font"]
     writer.write(output)
     output.seek(0)
     reader = PdfReader(output)


### PR DESCRIPTION
We give the opportunity to set a font name when filling text form fields. The font name, in fact, is the name of a font resource that can be inherited by an annotation, or that is part of one of the 14 Core Fonts. For flattened annotations, this works well. The font resource is either located or created and embedded, and then used in the appearance stream. However, when the annotation is _not_ flattened, we additionally need to set annotation["/DA"] to have the new font resource name, or (at least some) pdf readers may revert to the font resource mentioned there. This PR makes sure that we change annotation["/DA"] to reflect a user-set font name.

If this bug: https://github.com/py-pdf/pypdf/issues/2253 wasn't already closed, then we should be able to close it now.

((Additionally, we could allow a user to either set a font name or an existing true type font file, and in case of the latter, embed the font file, create an associated font resource, and put it somewhere an annotation can find it. This is not difficult. That would go even further lengths to closing the above issue. This PR, however, is really more a bug fix.))