### PR TITLE
BUG: Fix IndexError on empty string in ArrayObject._to_lst

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -172,7 +172,7 @@ class ArrayObject(list[Any], PdfObject):
         elif isinstance(lst, PdfObject):
             result = [lst]
         elif isinstance(lst, str):
-            if lst[0] == "/":
+            if lst.startswith("/"):
                 result = [NameObject(lst)]
             else:
                 result = [TextStringObject(lst)]


### PR DESCRIPTION
## Problem

`ArrayObject._to_lst()` tested `lst[0] == "/"` to decide whether to create a `NameObject` or `TextStringObject`. When `lst` is the empty string `""`, this raises `IndexError: string index out of range`.

This crashes `arr + ""`, `arr += ""`, and `arr -= ""`.

## Fix

Replace `lst[0] == "/"` with `lst.startswith("/")`. `"".startswith("/")` returns `False`, falling through to `TextStringObject("")` as expected. Behavior is identical for all non-empty strings.