### PR TITLE
BUG: Fix TreeObject.insert_child KeyError on fresh children

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv/
 # Code coverage artifacts
 .coverage*
 coverage.xml
+# coverage.py annotated source files
 *.py,cover
 
 # Editors / IDEs

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ venv/
 # Code coverage artifacts
 .coverage*
 coverage.xml
+*.py,cover
 
 # Editors / IDEs
 .vscode/

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -807,8 +807,7 @@ class TreeObject(DictionaryObject):
             prev["/Prev"][NameObject("/Next")] = child_reference
             child_obj[NameObject("/Prev")] = prev["/Prev"]
         except Exception:  # it means we are inserting in first position
-            if "/Next" in child_obj:
-                del child_obj["/Next"]
+            child_obj.pop("/Next", None)
         child_obj[NameObject("/Next")] = prev
         prev[NameObject("/Prev")] = child_reference
         child_obj[NameObject("/Parent")] = self.indirect_reference

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -807,7 +807,8 @@ class TreeObject(DictionaryObject):
             prev["/Prev"][NameObject("/Next")] = child_reference
             child_obj[NameObject("/Prev")] = prev["/Prev"]
         except Exception:  # it means we are inserting in first position
-            del child_obj["/Next"]
+            if "/Next" in child_obj:
+                del child_obj["/Next"]
         child_obj[NameObject("/Next")] = prev
         prev[NameObject("/Prev")] = child_reference
         child_obj[NameObject("/Parent")] = self.indirect_reference

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -106,22 +106,21 @@ def test_tree_object__insert_child_in_first_position_with_next() -> None:
     tree = TreeObject()
     writer._add_object(tree)
 
-    # Create two children already linked: A -> B
+    # Create a single child A as the /First (and /Last)
     child_a = DictionaryObject()
     child_a_ref = writer._add_object(child_a)
     tree.add_child(child_a_ref, writer)
 
-    child_b = DictionaryObject()
-    child_b_ref = writer._add_object(child_b)
-    tree.insert_child(child_b_ref, child_a_ref, writer)
+    # prev = tree["/Last"] = A, prev == before, so no while loop.
+    # try: prev["/Prev"] — A has no /Prev → KeyError → except block fires.
 
-    # Now create a new child C that already has a /Next pointer
+    # Create child C with a /Next pointer pointing to something
     child_c = DictionaryObject()
     child_c[NameObject("/Next")] = child_a_ref  # C -> A
     child_c_ref = writer._add_object(child_c)
     assert "/Next" in child_c
 
-    # Insert C before A (first position) — C has /Next, so the del fires
+    # Insert C before A (first position)
     tree.insert_child(child_c_ref, child_a_ref, writer)
 
     # C is now first, linked to A

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -94,6 +94,42 @@ def test_tree_object__insert_child_without_next_key() -> None:
     assert first_child["/Prev"] == fresh_child
 
 
+def test_tree_object__insert_child_in_first_position_with_next() -> None:
+    r"""
+    Regression test: When a child with a ``/Next`` entry is inserted in the
+    first position, the ``except`` handler must delete ``/Next`` from the
+    child (since it's now the first node and should not have a forward
+    pointer). This tests the guarded deletion ``if "/Next" in child_obj:
+    del child_obj["/Next"]`` inside the except block.
+    """
+    writer = PdfWriter()
+    tree = TreeObject()
+    writer._add_object(tree)
+
+    # Create two children already linked: A -> B
+    child_a = DictionaryObject()
+    child_a_ref = writer._add_object(child_a)
+    tree.add_child(child_a_ref, writer)
+
+    child_b = DictionaryObject()
+    child_b_ref = writer._add_object(child_b)
+    tree.insert_child(child_b_ref, child_a_ref, writer)
+
+    # Now create a new child C that already has a /Next pointer
+    child_c = DictionaryObject()
+    child_c[NameObject("/Next")] = child_a_ref  # C -> A
+    child_c_ref = writer._add_object(child_c)
+    assert "/Next" in child_c
+
+    # Insert C before A (first position) — C has /Next, so the del fires
+    tree.insert_child(child_c_ref, child_a_ref, writer)
+
+    # C is now first, linked to A
+    c_obj = child_c_ref.get_object()
+    assert isinstance(c_obj, DictionaryObject)
+    assert c_obj["/Next"] == child_a
+
+
 @pytest.mark.enable_socket
 def test_array_object__clone_same_object_multiple_times(caplog: pytest.LogCaptureFixture) -> None:
     url = "https://github.com/user-attachments/files/25412858/Draft_OSMF_financial_statement_2013.pdf"

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -66,6 +66,33 @@ def test_tree_object__cyclic_reference(caplog: pytest.LogCaptureFixture) -> None
     assert "Detected cycle in outline structure for " in caplog.text
 
 
+def test_tree_object__insert_child_without_next_key() -> None:
+    """
+    Regression test: ``TreeObject.insert_child`` previously raised a
+    ``KeyError`` when the new child had no ``/Next`` entry yet and was
+    inserted in the first position. The except branch unconditionally
+    deleted ``/Next``, which only worked for children that already had it.
+    """
+    writer = PdfWriter()
+    tree = TreeObject()
+    writer._add_object(tree)
+
+    first_child_ref = writer._add_object(DictionaryObject())
+    tree.add_child(first_child_ref, writer)
+
+    fresh_child = DictionaryObject()
+    fresh_child_ref = writer._add_object(fresh_child)
+    assert "/Next" not in fresh_child
+
+    # Must not raise KeyError("/Next") even though the new child has no /Next.
+    tree.insert_child(fresh_child_ref, first_child_ref, writer)
+
+    # The new child is linked before the existing one.
+    first_child = first_child_ref.get_object()
+    assert fresh_child["/Next"] == first_child
+    assert first_child["/Prev"] == fresh_child
+
+
 @pytest.mark.enable_socket
 def test_array_object__clone_same_object_multiple_times(caplog: pytest.LogCaptureFixture) -> None:
     url = "https://github.com/user-attachments/files/25412858/Draft_OSMF_financial_statement_2013.pdf"

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -89,6 +89,7 @@ def test_tree_object__insert_child_without_next_key() -> None:
 
     # The new child is linked before the existing one.
     first_child = first_child_ref.get_object()
+    assert isinstance(first_child, DictionaryObject)
     assert fresh_child["/Next"] == first_child
     assert first_child["/Prev"] == fresh_child
 

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -67,12 +67,7 @@ def test_tree_object__cyclic_reference(caplog: pytest.LogCaptureFixture) -> None
 
 
 def test_tree_object__insert_child_without_next_key() -> None:
-    """
-    Regression test: ``TreeObject.insert_child`` previously raised a
-    ``KeyError`` when the new child had no ``/Next`` entry yet and was
-    inserted in the first position. The except branch unconditionally
-    deleted ``/Next``, which only worked for children that already had it.
-    """
+    """Regression test for TreeObject.insert_child without /Next."""
     writer = PdfWriter()
     tree = TreeObject()
     writer._add_object(tree)
@@ -95,13 +90,7 @@ def test_tree_object__insert_child_without_next_key() -> None:
 
 
 def test_tree_object__insert_child_in_first_position_with_next() -> None:
-    r"""
-    Regression test: When a child with a ``/Next`` entry is inserted in the
-    first position, the ``except`` handler must delete ``/Next`` from the
-    child (since it's now the first node and should not have a forward
-    pointer). This tests the guarded deletion ``if "/Next" in child_obj:
-    del child_obj["/Next"]`` inside the except block.
-    """
+    """Regression test: child with /Next inserted in first position."""
     writer = PdfWriter()
     tree = TreeObject()
     writer._add_object(tree)


### PR DESCRIPTION
Fixes #3727

When inserting a child at the first position, the exception handler unconditionally deletes child_obj["/Next"]. If the child is a fresh TreeObject without a "/Next" key, this raises KeyError. Fix: guard the deletion with a key existence check.

### Testing

- ✅ New regression test `test_tree_object__insert_child_without_next_key` covers the fixed code path
- ✅ Test verifies the child is correctly linked before the existing one

### AI Assistance Declaration

AI (Claude Code / Hermes Agent) was used for coding assistance on this PR. The author reviewed and validated all changes.