### PR TITLE
DOC: Block encrypting writer in incremental mode

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1318,6 +1318,9 @@ class PdfWriter(PdfDocCommon):
                 `use_128bit` will be ignored.
 
         """
+        if self.incremental:
+            raise NotImplementedError("Encrypting incremental PDF files is currently not supported.")
+
         if owner_password is None:
             owner_password = user_password
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3210,3 +3210,11 @@ def test_clone_reader_document_root__incremental__unknown_object():
     reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
     with mock.patch.object(writer, "_collect_incremental_clone_object_ids", return_value=[*list(range(1, 23)), 42]):
         writer.clone_reader_document_root(reader)
+
+
+def test_encrypt__incremental():
+    writer = PdfWriter(RESOURCE_ROOT / "crazyones.pdf", incremental=True)
+    writer.add_blank_page(width=10, height=10)
+
+    with pytest.raises(NotImplementedError):
+        writer.encrypt(user_password="dummy")


### PR DESCRIPTION
This feature is currently not supported and nothing will be encrypted. To avoid confusion about this, raise a proper exception.