### PR TITLE
ROB: Prevent cyclic parent hierarchies for inherited dictionaries

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -743,22 +743,12 @@ class PdfDocCommon:
                     (example: radio buttons, field repeated on multiple pages).
 
         """
-
-        def _get_inherited(obj: DictionaryObject, key: str) -> Any:
-            if key in obj:
-                return obj[key]
-            if "/Parent" in obj:
-                return _get_inherited(
-                    cast(DictionaryObject, obj["/Parent"].get_object()), key
-                )
-            return None
-
         try:
             # to cope with all types
             field = cast(DictionaryObject, field.indirect_reference.get_object())  # type: ignore
         except Exception as exc:
             raise ValueError("Field type is invalid") from exc
-        if is_null_or_none(_get_inherited(field, "/FT")):
+        if is_null_or_none(field.get_inherited(key="/FT", default=None)):
             raise ValueError("Field is not valid")
         ret = []
         if field.get("/Subtype", "") == "/Widget":

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -452,15 +452,26 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             Current key or inherited one, otherwise default value.
 
         """
-        if key in self:
-            return self[key]
-        try:
-            if "/Parent" not in self:
+        current = self
+        visited: set[int] = set()
+
+        while True:
+            # Detect cyclic parent references
+            obj_id = id(current)
+            if obj_id in visited:
+                raise LimitReachedError(f"Detected cycle in /Parent hierarchy when retrieving value for key {key!r}.")
+            visited.add(obj_id)
+
+            if key in current:
+                return current[key]
+
+            if "/Parent" not in current:
                 return default
-            raise KeyError("Not present")
-        except KeyError:
-            return cast("DictionaryObject", self["/Parent"].get_object()).get_inherited(
-                key, default
+
+            # Walk upward
+            current = cast(
+                "DictionaryObject",
+                current["/Parent"].get_object(),
             )
 
     def __setitem__(self, key: Any, value: Any) -> Any:

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -358,3 +358,23 @@ startxref
     reader = PdfReader(buffer, strict=False)
     with pytest.raises(expected_exception=PdfReadError, match=r"^Cannot find Root object in pdf$"):
         assert len(reader.pages) == 0
+
+
+@pytest.mark.timeout(5)
+def test_dictionary_object__get_inherited__cyclic() -> None:
+    writer = PdfWriter()
+
+    dictionary1 = DictionaryObject()
+    reference1 = writer._add_object(dictionary1)
+    dictionary2 = DictionaryObject()
+    reference2 = writer._add_object(dictionary2)
+    dictionary3 = DictionaryObject({NameObject("/Parent"): reference2})
+    reference3 = writer._add_object(dictionary3)
+    dictionary1[NameObject("/Parent")] = reference3
+    dictionary2[NameObject("/Parent")] = reference1
+
+    with pytest.raises(
+            expected_exception=LimitReachedError,
+            match=r"^Detected cycle in /Parent hierarchy when retrieving value for key '/FT'\.$"
+    ):
+        writer.get_pages_showing_field(reference1)

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -581,3 +581,23 @@ def test_xfa__decompression_limit():
             expected_exception=LimitReachedError, match=r"^Limit reached while decompressing. 902 bytes remaining.$"
     ):
         _ = reader.xfa
+
+
+@pytest.mark.timeout(5)
+def test_get_pages_showing_field__cyclic() -> None:
+    writer = PdfWriter()
+
+    dictionary1 = DictionaryObject()
+    reference1 = writer._add_object(dictionary1)
+    dictionary2 = DictionaryObject()
+    reference2 = writer._add_object(dictionary2)
+    dictionary3 = DictionaryObject({NameObject("/Parent"): reference2})
+    reference3 = writer._add_object(dictionary3)
+    dictionary1[NameObject("/Parent")] = reference3
+    dictionary2[NameObject("/Parent")] = reference1
+
+    with pytest.raises(
+            expected_exception=LimitReachedError,
+            match=r"^Detected cycle in /Parent hierarchy when retrieving value for key 'key'\.$"
+    ):
+        dictionary1.get_inherited("key")


### PR DESCRIPTION
Additionally avoid two similar implementations and re-use the generic one.