### PR TITLE
ENH: Font: Collect all character widths, not only those that can be unicode mapped

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -145,6 +145,8 @@ def _parse_to_unicode(
             int_entry,
         )
 
+    map_dict.pop(-1, None)  # Don't pass the -1 key, we only used it to temporarily store encoding length
+
     return map_dict, int_entry
 
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -212,18 +212,35 @@ class Font:
                 )
 
     @staticmethod
-    def _add_default_width(current_widths: dict[str, int], flags: int) -> None:
+    def _get_space_char(
+        encoding: str | dict[int, str],
+        character_map: dict[Any, Any],
+    ) -> str:
+        space_char = " "
+        if isinstance(encoding, dict):
+            for char_code, char_str in encoding.items():
+                if char_str == space_char:
+                    return chr(char_code)
+
+        for glyph_id, char_str in character_map.items():
+            if char_str == space_char:
+                return str(glyph_id)
+
+        return space_char
+
+    @staticmethod
+    def _add_default_width(current_widths: dict[str, int], flags: int, space_char: str) -> None:
         if not current_widths:
             current_widths["default"] = 500
             return
 
-        if " " in current_widths and current_widths[" "] != 0:
+        if space_char in current_widths and current_widths[space_char] != 0:
             # Setting default to once or twice the space width, depending on fixed pitch
             if (flags & FontFlags.FIXED_PITCH) == FontFlags.FIXED_PITCH:
-                current_widths["default"] = current_widths[" "]
+                current_widths["default"] = current_widths[space_char]
                 return
 
-            current_widths["default"] = int(2 * current_widths[" "])
+            current_widths["default"] = int(2 * current_widths[space_char])
             return
 
         # Use the average width of existing glyph widths
@@ -231,8 +248,12 @@ class Font:
         current_widths["default"] = sum(valid_widths) // len(valid_widths) if valid_widths else 500
 
     @staticmethod
-    def _add_space_width(character_widths: dict[str, int], flags: int) -> int:
-        space_width = character_widths.get(" ", 0)
+    def _add_space_width(
+        character_widths: dict[str, int],
+        flags: int,
+        space_char: str
+    ) -> int:
+        space_width = character_widths.get(space_char, 0)
         if space_width != 0:
             return space_width
 
@@ -350,10 +371,10 @@ class Font:
         if not font_descriptor:
             font_descriptor = FontDescriptor(name=name)
 
+        space_char = cls._get_space_char(encoding, character_map)
         if character_widths.get("default", 0) == 0:
-            cls._add_default_width(character_widths, font_descriptor.flags)
-
-        space_width = cls._add_space_width(character_widths, font_descriptor.flags)
+            cls._add_default_width(character_widths, font_descriptor.flags, space_char)
+        space_width = cls._add_space_width(character_widths, font_descriptor.flags, space_char)
 
         return cls(
             name=name,
@@ -497,8 +518,11 @@ class Font:
             else:
                 raise PdfReadError("Font file does not have a cmap table")
 
-            cls._add_default_width(character_widths, font_descriptor_kwargs["flags"])
-            space_width = cls._add_space_width(character_widths, font_descriptor_kwargs["flags"])
+            space_char = cls._get_space_char(encoding, character_map)
+            cls._add_default_width(character_widths, font_descriptor_kwargs["flags"], space_char)
+            space_width = cls._add_space_width(
+                character_widths, font_descriptor_kwargs["flags"], space_char
+            )
 
         return cls(
             name=font_descriptor.name,

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -693,7 +693,7 @@ class Font:
         target_resource_dict[font_resource_name] = font_resource_ref
         return font_resource_ref
 
-    def text_width(self, text: str = "") -> float:
+    def get_text_width(self, text: str = "") -> float:
         """Sum of character widths specified in PDF font for the supplied text."""
         return sum(
             [self.character_widths.get(char, self.character_widths["default"]) for char in text], 0.0

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -125,6 +125,7 @@ class Font:
     font_descriptor: FontDescriptor = field(default_factory=FontDescriptor)
     character_widths: dict[str, int] = field(default_factory=lambda: {"default": 500})
     space_width: float | int = 250
+    space_char: str = " "
     interpretable: bool = True
 
     @staticmethod
@@ -384,6 +385,7 @@ class Font:
             character_map=character_map,
             character_widths=character_widths,
             space_width=space_width,
+            space_char=space_char,
             interpretable=interpretable
         )
 
@@ -532,6 +534,7 @@ class Font:
             character_map=character_map,
             character_widths=character_widths,
             space_width=space_width,
+            space_char=space_char,
             interpretable=True
         )
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -547,6 +547,34 @@ class Font:
             interpretable=True
         )
 
+    def _get_typographic_maps(self) -> tuple[dict[str, str], dict[str, bytes]]:
+        """
+        Generates maps to translate input unicode text to bytes in two steps:
+        Unicode code point -> raw_character (reverse cmap) -> PDF bytes (encoding cmap).
+        """
+        reverse_cmap = {}
+        encoding_cmap = {}
+
+        if isinstance(self.encoding, str):
+            for glyph_id, unicode_char in self.character_map.items():
+                glyph_id_str = str(glyph_id)
+                reverse_cmap[unicode_char] = glyph_id_str
+                encoding_cmap[glyph_id_str] = glyph_id_str.encode(self.encoding)
+        else:
+            for character_code, unicode_char in self.encoding.items():
+                character_str = chr(character_code)
+                reverse_cmap[unicode_char] = character_str
+                encoding_cmap[character_str] = bytes((character_code,))
+
+            unicode_to_bytes = {
+                unicode_char: bytes((character_code,)) for character_code, unicode_char in self.encoding.items()
+            }
+            for glyph_id, unicode_char in self.character_map.items():  # This code is not covered nor tested
+                reverse_cmap[unicode_char] = glyph_id
+                encoding_cmap[glyph_id] = unicode_to_bytes.get(unicode_char, bytes((glyph_id,)))
+
+        return reverse_cmap, encoding_cmap
+
     def _create_widths_list_and_unicode_stream(self) -> tuple[list[PdfObject], StreamObject]:
         widths_list = []
         unicode_map = []

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -339,7 +339,16 @@ class Font:
 
                 elif name in CORE_FONT_METRICS:
                     font_descriptor = CORE_FONT_METRICS[name].font_descriptor
-                    character_widths = CORE_FONT_METRICS[name].character_widths
+                    if isinstance(encoding, dict):
+                        for code, character in encoding.items():
+                            # Look up the width using the glyph name from the encoding
+                            if character in CORE_FONT_METRICS[name].character_widths:
+                                character_widths[chr(code)] = CORE_FONT_METRICS[name].character_widths[character]
+                    else:
+                        for code in range(256):
+                            character = chr(code)
+                            if character in CORE_FONT_METRICS[name].character_widths:
+                                character_widths[character] = CORE_FONT_METRICS[name].character_widths[character]
                 if "/FontDescriptor" in pdf_font_dict:
                     font_descriptor_obj = pdf_font_dict.get("/FontDescriptor", DictionaryObject()).get_object()
                     if "/MissingWidth" in font_descriptor_obj:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -137,38 +137,14 @@ class Font:
         """Parses a TrueType or Type1 font's /Widths array from a font dictionary and updates character widths"""
         widths_array = cast(ArrayObject, pdf_font_dict["/Widths"])
         first_char = pdf_font_dict.get("/FirstChar", 0)
-        if not isinstance(encoding, str):
-            # This means that encoding is a dict
-            current_widths.update({
-                encoding.get(idx + first_char, chr(idx + first_char)): width
-                for idx, width in enumerate(widths_array)
-            })
-            return
-
-        # We map the character code directly to the character
-        # using the string encoding
         for idx, width in enumerate(widths_array):
-            # Often "idx == 0" will denote the .notdef character, but we add it anyway
-            char_code = idx + first_char  # This is a raw code
-            # Get the "raw" character or byte representation
-            raw_char = bytes([char_code]).decode(encoding, "surrogatepass")
-            # Translate raw_char to the REAL Unicode character using the char_map
-            unicode_char = char_map.get(raw_char)
-            if unicode_char:
-                current_widths[unicode_char] = int(width)
-            else:
-                current_widths[raw_char] = int(width)
+            current_widths[chr(idx + first_char)] = int(width)
 
     @staticmethod
     def _collect_cid_character_widths(
         d_font: DictionaryObject, char_map: dict[Any, Any], current_widths: dict[str, int]
     ) -> None:
         """Parses the /W array from a DescendantFont dictionary and updates character widths."""
-        ord_map = {
-            ord(_target): _surrogate
-            for _target, _surrogate in char_map.items()
-            if isinstance(_target, str)
-        }
         # /W width definitions have two valid formats which can be mixed and matched:
         #   (1) A character start index followed by a list of widths, e.g.
         #       `45 [500 600 700]` applies widths 500, 600, 700 to characters 45-47.
@@ -196,7 +172,7 @@ class Font:
                 start_idx, width_list = w_entry, w_next_entry
                 current_widths.update(
                     {
-                        ord_map[_cidx]: _width
+                        chr(_cidx): _width
                         for _cidx, _width in zip(
                             range(
                                 cast(int, start_idx),
@@ -205,7 +181,6 @@ class Font:
                             ),
                             width_list,
                         )
-                        if _cidx in ord_map
                     }
                 )
                 skip_count = 1
@@ -220,11 +195,10 @@ class Font:
                 )
                 current_widths.update(
                     {
-                        ord_map[_cidx]: const_width
+                        chr(_cidx): const_width
                         for _cidx in range(
                             cast(int, start_idx), cast(int, stop_idx + 1), 1
                         )
-                        if _cidx in ord_map
                     }
                 )
                 skip_count = 2
@@ -340,6 +314,7 @@ class Font:
                     cls._collect_tt_t1_character_widths(
                         pdf_font_dict, character_map, encoding, character_widths
                     )
+
                 elif name in CORE_FONT_METRICS:
                     font_descriptor = CORE_FONT_METRICS[name].font_descriptor
                     character_widths = CORE_FONT_METRICS[name].character_widths

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1724,7 +1724,7 @@ class PageObject(DictionaryObject):
                     font_resources[font_resource] = font_resource_object
                     fonts[font_resource] = Font.from_font_resource(font_resource_object)
                     # Override space width, if applicable
-                    if fonts[font_resource].character_widths.get(" ", 0) == 0:
+                    if fonts[font_resource].character_widths.get(fonts[font_resource].space_char, 0) == 0:
                         fonts[font_resource].space_width = space_width
                 except (AttributeError, TypeError):
                     pass

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -206,7 +206,7 @@ def get_display_str(
     # "\u0590 - \u08FF \uFB50 - \uFDFF"
     widths: float = 0.0
     for raw_character in text_operands:
-        widths += font.space_width if raw_character == font.space_char else font.text_width(raw_character)
+        widths += font.space_width if raw_character == font.space_char else font.get_text_width(raw_character)
         x = font.character_map.get(raw_character, raw_character)
         # x can be a sequence of bytes ; ex: habibi.pdf
         if len(x) == 1:

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -205,7 +205,9 @@ def get_display_str(
 ) -> tuple[str, bool, float]:
     # "\u0590 - \u08FF \uFB50 - \uFDFF"
     widths: float = 0.0
-    for x in [font.character_map.get(x, x) for x in text_operands]:
+    for raw_character in text_operands:
+        widths += font.space_width if raw_character == font.space_char else font.text_width(raw_character)
+        x = font.character_map.get(raw_character, raw_character)
         # x can be a sequence of bytes ; ex: habibi.pdf
         if len(x) == 1:
             xx = ord(x)
@@ -240,6 +242,5 @@ def get_display_str(
                     visitor_text(text, cm_matrix, tm_matrix, font_resource, font_size)
                 text = ""
             text = text + x
-        widths += font.space_width if x == " " else font.text_width(x)
         # fmt: on
     return text, rtl_dir, widths

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -150,7 +150,7 @@ def recurse_to_target_op(
                             actual=spaces, limit=WHITESPACE_LIMIT, source=__name__
                         )
                         spaces = WHITESPACE_LIMIT
-                    new_text = f'{" " * spaces}{_tj.txt}'
+                    new_text = f'{" " * spaces}{_tj.text}'
 
                     last_ty = _tj.ty
                     _text = f"{_text}{new_text}"

--- a/pypdf/_text_extraction/_layout_mode/_text_state_manager.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_manager.py
@@ -94,26 +94,8 @@ class TextStateManager:
             raise PdfReadError(
                 "font not set: is PDF missing a Tf operator?"
             )  # pragma: no cover
-        if isinstance(value, bytes):
-            try:
-                if isinstance(self.font.encoding, str):
-                    txt = value.decode(self.font.encoding, "surrogatepass")
-                else:
-                    txt = "".join(
-                        self.font.encoding[x]
-                        if x in self.font.encoding
-                        else bytes((x,)).decode()
-                        for x in value
-                    )
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                txt = value.decode("utf-8", "replace")
-            txt = "".join(
-                self.font.character_map.get(x, x) for x in txt
-            )
-        else:
-            txt = value
         return TextStateParams(
-            txt,
+            value,
             self.font,
             self.font_size,
             self.Tc,

--- a/pypdf/_text_extraction/_layout_mode/_text_state_params.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_params.py
@@ -15,7 +15,7 @@ class TextStateParams:
     TJ or Tj PDF operation.
 
     Attributes:
-        value (Union[bytes, str]): the raw text to be rendered.
+        value (bytes | str): the raw text to be rendered.
         font (Font): font object
         font_size (int | float): font size
         Tc (float): character spacing. Defaults to 0.0.
@@ -52,26 +52,28 @@ class TextStateParams:
     font_height: float = field(default=0.0, init=False)
     flip_vertical: bool = field(default=False, init=False)
     rotated: bool = field(default=False, init=False)
+    text: str = ""
+    _decoded_value: str = ""
 
     def __post_init__(self) -> None:
         if isinstance(self.value, bytes):
             try:
                 if isinstance(self.font.encoding, str):
-                    self.txt = self.value.decode(self.font.encoding, "surrogatepass")
+                    self._decoded_value = self.value.decode(self.font.encoding, "surrogatepass")
                 else:
-                    self.txt = "".join(
+                    self._decoded_value = "".join(
                         self.font.encoding[x]
                         if x in self.font.encoding
                         else bytes((x,)).decode()
                         for x in self.value
                     )
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                self.txt = self.value.decode("utf-8", "replace")
-            self.txt = "".join(
-                self.font.character_map.get(x, x) for x in self.txt
+            except UnicodeDecodeError:
+                self._decoded_value = self.value.decode("utf-8", "replace")
+            self.text = "".join(
+                self.font.character_map.get(x, x) for x in self._decoded_value
             )
         else:
-            self.txt = self.value
+            self.text = self.value
 
         if orient(self.transform) in (90, 270):
             self.transform = mult(
@@ -87,7 +89,7 @@ class TextStateParams:
         self.displaced_tx = self.displaced_transform()[4]
         self.tx = self.transform[4]
         self.ty = self.render_transform()[5]
-        self.space_tx = round(self.word_tx(" "), 3)
+        self.space_tx = round(self.word_tx(self.font.space_char), 3)
         if self.space_tx < 1e-6:
             # if the " " char is assigned 0 width (e.g. for fine tuned spacing
             # with TJ int operators a la crazyones.pdf), calculate space_tx as
@@ -120,32 +122,37 @@ class TextStateParams:
         return mult(self.font_size_matrix(), self.transform)
 
     def displacement_matrix(
-        self, word: Union[str, None] = None, td_offset: float = 0.0
+        self, word: Union[bytes, str, None] = None, td_offset: float = 0.0
     ) -> list[float]:
         """
         Text displacement matrix
 
         Args:
-            word (str, optional): Defaults to None in which case self.txt displacement is
+            word (bytes | str, optional): Defaults to None in which case self.text displacement is
                 returned.
             td_offset (float, optional): translation applied by TD operator. Defaults to 0.0.
 
         """
-        word = word if word is not None else self.txt
+        word = word if word is not None else self.value
         return [1.0, 0.0, 0.0, 1.0, self.word_tx(word, td_offset), 0.0]
 
-    def word_tx(self, word: str, td_offset: float = 0.0) -> float:
+    def word_tx(self, word: Union[bytes, str], td_offset: float = 0.0) -> float:
         """Horizontal text displacement for any word according this text state"""
         width: float = 0.0
+
+        if isinstance(word, bytes):
+            word = self._decoded_value
+
         for char in word:
-            if char == " ":
+            if char == self.font.space_char:
                 width += self.font.space_width
             else:
                 width += self.font.text_width(char)
+
         return (
             (self.font_size * ((width - td_offset) / 1000.0))
             + self.Tc
-            + word.count(" ") * self.Tw
+            + word.count(self.font.space_char) * self.Tw
         ) * (self.Tz / 100.0)
 
     @staticmethod

--- a/pypdf/_text_extraction/_layout_mode/_text_state_params.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_params.py
@@ -147,7 +147,7 @@ class TextStateParams:
             if char == self.font.space_char:
                 width += self.font.space_width
             else:
-                width += self.font.text_width(char)
+                width += self.font.get_text_width(char)
 
         return (
             (self.font_size * ((width - td_offset) / 1000.0))

--- a/pypdf/_text_extraction/_layout_mode/_text_state_params.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_params.py
@@ -15,7 +15,7 @@ class TextStateParams:
     TJ or Tj PDF operation.
 
     Attributes:
-        txt (str): the text to be rendered.
+        value (Union[bytes, str]): the raw text to be rendered.
         font (Font): font object
         font_size (int | float): font size
         Tc (float): character spacing. Defaults to 0.0.
@@ -34,7 +34,7 @@ class TextStateParams:
 
     """
 
-    txt: str
+    value: Union[bytes, str]
     font: Font
     font_size: Union[int, float]
     Tc: float = 0.0
@@ -54,6 +54,25 @@ class TextStateParams:
     rotated: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
+        if isinstance(self.value, bytes):
+            try:
+                if isinstance(self.font.encoding, str):
+                    self.txt = self.value.decode(self.font.encoding, "surrogatepass")
+                else:
+                    self.txt = "".join(
+                        self.font.encoding[x]
+                        if x in self.font.encoding
+                        else bytes((x,)).decode()
+                        for x in self.value
+                    )
+            except (UnicodeEncodeError, UnicodeDecodeError):
+                self.txt = self.value.decode("utf-8", "replace")
+            self.txt = "".join(
+                self.font.character_map.get(x, x) for x in self.txt
+            )
+        else:
+            self.txt = self.value
+
         if orient(self.transform) in (90, 270):
             self.transform = mult(
                 [1.0, -self.transform[1], -self.transform[2], 1.0, 0.0, 0.0],

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -184,7 +184,7 @@ class TextExtraction:
         )
         if is_str_operands:
             text += text_operands
-            font_widths = sum([font.space_width if x == " " else font.text_width(x) for x in text_operands])
+            font_widths = sum([font.space_width if x == font.space_char else font.text_width(x) for x in text_operands])
         else:
             text, rtl_dir, font_widths = get_display_str(
                 text,

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -184,7 +184,9 @@ class TextExtraction:
         )
         if is_str_operands:
             text += text_operands
-            font_widths = sum([font.space_width if x == font.space_char else font.text_width(x) for x in text_operands])
+            font_widths = sum(
+                [font.space_width if x == font.space_char else font.get_text_width(x) for x in text_operands]
+            )
         else:
             text, rtl_dir, font_widths = get_display_str(
                 text,

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -362,13 +362,18 @@ class TextStreamAppearance(BaseStreamAppearance):
         if not font or not font_resource:
             font_name = "/Helv"
             core_font_metrics = CORE_FONT_METRICS["Helvetica"]
+            win_ansi_encoding_list = fill_from_encoding("cp1252")
             font = Font(
                 name="Helvetica",
                 character_map={},
-                encoding=dict(zip(range(256), fill_from_encoding("cp1252"))),  # WinAnsiEncoding
+                encoding=dict(zip(range(256), win_ansi_encoding_list)),  # WinAnsiEncoding
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
-                character_widths=core_font_metrics.character_widths
+                character_widths={
+                    chr(code): core_font_metrics.character_widths[value] for code, value in enumerate(
+                        win_ansi_encoding_list
+                    ) if value in core_font_metrics.character_widths
+                },
             )
             font_resource = font.as_font_resource()
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -79,7 +79,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         leading_factor: float,
         field_width: float,
         field_height: float,
-        text: str,
+        paragraphs: list[str],
         min_font_size: float,
         font_size_step: float = 0.2
     ) -> tuple[list[tuple[float, str]], float]:
@@ -93,7 +93,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             leading_factor: The line distance.
             field_width: The width of the field in which to fit the text.
             field_height: The height of the field in which to fit the text.
-            text: The text to fit with the field.
+            paragraphs: The text paragraphs to fit with the field.
             min_font_size: The minimum font size at which to scale the text.
             font_size_step: The amount by which to decrement font size per step while scaling.
 
@@ -101,8 +101,6 @@ class TextStreamAppearance(BaseStreamAppearance):
             The text in the form of list of tuples, each tuple containing the length of a line
             and its contents, and the font_size for these lines and lengths.
         """
-        orig_text = text
-        paragraphs = text.replace("\n", "\r").split("\r")
         wrapped_lines = []
         current_line_words: list[str] = []
         current_line_width: float = 0
@@ -111,12 +109,12 @@ class TextStreamAppearance(BaseStreamAppearance):
             if not paragraph.strip():
                 wrapped_lines.append((0.0, ""))
                 continue
-            words = paragraph.split(" ")
+            words = paragraph.split(font.space_char)
             for i, word in enumerate(words):
                 word_width = font.text_width(word) * font_size / 1000
                 test_width = current_line_width + word_width + (space_width if i else 0)
                 if test_width > field_width and current_line_words:
-                    wrapped_lines.append((current_line_width, " ".join(current_line_words)))
+                    wrapped_lines.append((current_line_width, font.space_char.join(current_line_words)))
                     current_line_words = [word]
                     current_line_width = word_width
                 elif not current_line_words and word_width > field_width:
@@ -129,7 +127,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                     current_line_words.append(word)
                     current_line_width += word_width
             if current_line_words:
-                wrapped_lines.append((current_line_width, " ".join(current_line_words)))
+                wrapped_lines.append((current_line_width, font.space_char.join(current_line_words)))
                 current_line_words = []
                 current_line_width = 0
         # Estimate total height.
@@ -144,7 +142,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                     leading_factor,
                     field_width,
                     field_height,
-                    orig_text,
+                    paragraphs,
                     min_font_size,
                     font_size_step
                 )
@@ -155,7 +153,6 @@ class TextStreamAppearance(BaseStreamAppearance):
         text: str,
         selection: list[str] | None ,
         font: Font,
-        font_glyph_byte_map: dict[str, bytes] | None = None,
         font_name: str = "/Helv",
         font_size: float = 0.0,
         font_color: str = "0 g",
@@ -175,8 +172,6 @@ class TextStreamAppearance(BaseStreamAppearance):
             text: The text to be rendered in the form field.
             selection: An optional list of strings that should be highlighted as selected.
             font: The font to use.
-            font_glyph_byte_map: An optional dictionary mapping characters to their
-                byte representation for glyph encoding.
             font_name: The name of the font resource to use (e.g., "/Helv").
             font_size: The font size. If 0, it is automatically calculated
                 based on whether the field is multiline or not.
@@ -194,7 +189,6 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         """
         rectangle = self._layout.rectangle
-        font_glyph_byte_map = font_glyph_byte_map or {}
         if isinstance(rectangle, tuple):
             rectangle = RectangleObject(rectangle)
         leading_factor = (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / 1000.0
@@ -205,6 +199,16 @@ class TextStreamAppearance(BaseStreamAppearance):
         field_height = rectangle.height - 2 * margin
         field_width = rectangle.width - 4 * margin
 
+        reverse_cmap, encoding_cmap = font._get_typographic_maps()
+
+        def _unicode_to_glyph_id(text: str, reverse_cmap: dict[str, str]) -> str:
+            return "".join(reverse_cmap.get(character, character) for character in text)
+
+        def _glyph_id_to_bytes(glyphs: str, encoding_cmap: dict[str, bytes]) -> list[bytes]:
+            return [encoding_cmap.get(
+                glyph_id, bytes((ord(glyph_id),)) if ord(glyph_id) < 256 else b"?"
+            ) for glyph_id in glyphs]
+
         # If font_size is 0, apply the logic for multiline or large-as-possible font
         if font_size == 0:
             min_font_size = 4.0       # The mininum font size
@@ -212,21 +216,25 @@ class TextStreamAppearance(BaseStreamAppearance):
                 is_multiline = False  # with matching "selection" with "line" later on.
             if is_multiline:
                 font_size = DEFAULT_FONT_SIZE_IN_MULTILINE
+                glyph_paragraphs = [
+                    _unicode_to_glyph_id(paragraph, reverse_cmap) for paragraph in text.splitlines()
+                ]
                 lines, font_size = self._scale_text(
                     font,
                     font_size,
                     leading_factor,
                     field_width,
                     field_height,
-                    text,
+                    glyph_paragraphs,
                     min_font_size
                 )
             else:
                 max_vertical_size = field_height / leading_factor
-                text_width_unscaled = font.text_width(text) / 1000
+                glyphs = _unicode_to_glyph_id(text, reverse_cmap)
+                text_width_unscaled = font.text_width(glyphs) / 1000
                 max_horizontal_size = field_width / (text_width_unscaled or 1)
                 font_size = round(max(min(max_vertical_size, max_horizontal_size), min_font_size), 1)
-                lines = [(text_width_unscaled * font_size, text)]
+                lines = [(text_width_unscaled * font_size, glyphs)]
         elif is_comb:
             if max_length and len(text) > max_length:
                 logger_warning(
@@ -239,15 +247,16 @@ class TextStreamAppearance(BaseStreamAppearance):
                     max_length=max_length,
                 )
             # We act as if each character is one line, because we draw it separately later on
-            lines = [(
-                font.text_width(char) * font_size / 1000,
-                char
-            ) for index, char in enumerate(text) if index < (max_length or len(text))]
+            lines = []
+            for index, char in enumerate(text):
+                if index < (max_length or len(text)):
+                    glyphs = _unicode_to_glyph_id(char, reverse_cmap)
+                    lines.append((font.text_width(glyphs) * font_size / 1000, glyphs))
         else:
-            lines = [(
-                font.text_width(line) * font_size / 1000,
-                line
-            ) for line in text.replace("\n", "\r").split("\r")]
+            lines = []
+            for line in text.splitlines():
+                glyphs = _unicode_to_glyph_id(line, reverse_cmap)
+                lines.append((font.text_width(glyphs) * font_size / 1000, glyphs))
 
         # Set the vertical offset
         if is_multiline:
@@ -263,7 +272,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         current_x_pos: float = 0  # Initial virtual position within the text object.
 
         for line_number, (line_width, line) in enumerate(lines):
-            if selection and line in selection:
+            if selection and line in _unicode_to_glyph_id("".join(selection), reverse_cmap):
                 # Might be improved, but cannot find how to get fill working => replaced with lined box
                 ap_stream += (
                     f"1 {y_offset - (line_number * font_size * leading_factor) - 1} "
@@ -307,14 +316,13 @@ class TextStreamAppearance(BaseStreamAppearance):
             # This is the X position where the *current line* will start.
             current_x_pos = desired_abs_x_start
 
-            encoded_line: list[bytes] = [
-                font_glyph_byte_map.get(c, c.encode("utf-16-be")) for c in line
-            ]
+            encoded_line = _glyph_id_to_bytes(line, encoding_cmap)
             if any(len(c) >= 2 for c in encoded_line):
                 ap_stream += b"<" + (b"".join(encoded_line)).hex().encode() + b"> Tj\n"
             else:
                 ap_stream += b"(" + b"".join(encoded_line) + b") Tj\n"
         ap_stream += b"ET\nQ\nEMC\nQ\n"
+
         return ap_stream
 
     def __init__(
@@ -362,11 +370,11 @@ class TextStreamAppearance(BaseStreamAppearance):
         if not font or not font_resource:
             font_name = "/Helv"
             core_font_metrics = CORE_FONT_METRICS["Helvetica"]
-            win_ansi_encoding_list = fill_from_encoding("cp1252")
+            win_ansi_encoding_list = fill_from_encoding("cp1252")  # WinAnsiEncoding
             font = Font(
                 name="Helvetica",
                 character_map={},
-                encoding=dict(zip(range(256), win_ansi_encoding_list)),  # WinAnsiEncoding
+                encoding=dict(zip(range(256), win_ansi_encoding_list)),
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
                 character_widths={
@@ -375,24 +383,13 @@ class TextStreamAppearance(BaseStreamAppearance):
                     ) if value in core_font_metrics.character_widths
                 },
             )
+            font.character_widths["default"] = core_font_metrics.character_widths["default"]
             font_resource = font.as_font_resource()
-
-        font_glyph_byte_map: dict[str, bytes] = {}
-        if isinstance(font.encoding, str):
-            font.character_map.pop(-1, None)  # Remove -1 key that does not map a character
-            for k, v in font.character_map.items():
-                font_glyph_byte_map[v] = k.encode(font.encoding)
-        else:
-            font_glyph_byte_map = {v: bytes((k,)) for k, v in font.encoding.items()}
-            font_encoding_rev = {v: bytes((k,)) for k, v in font.encoding.items()}
-            for key, value in font.character_map.items():
-                font_glyph_byte_map[value] = font_encoding_rev.get(key, key)
 
         ap_stream_data = self._generate_appearance_stream_data(
             text,
             selection,
             font,
-            font_glyph_byte_map,
             font_name=font_name,
             font_size=font_size,
             font_color=font_color,

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -111,7 +111,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                 continue
             words = paragraph.split(font.space_char)
             for i, word in enumerate(words):
-                word_width = font.text_width(word) * font_size / 1000
+                word_width = font.get_text_width(word) * font_size / 1000
                 test_width = current_line_width + word_width + (space_width if i else 0)
                 if test_width > field_width and current_line_words:
                     wrapped_lines.append((current_line_width, font.space_char.join(current_line_words)))
@@ -231,7 +231,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             else:
                 max_vertical_size = field_height / leading_factor
                 glyphs = _unicode_to_glyph_id(text, reverse_cmap)
-                text_width_unscaled = font.text_width(glyphs) / 1000
+                text_width_unscaled = font.get_text_width(glyphs) / 1000
                 max_horizontal_size = field_width / (text_width_unscaled or 1)
                 font_size = round(max(min(max_vertical_size, max_horizontal_size), min_font_size), 1)
                 lines = [(text_width_unscaled * font_size, glyphs)]
@@ -251,12 +251,12 @@ class TextStreamAppearance(BaseStreamAppearance):
             for index, char in enumerate(text):
                 if index < (max_length or len(text)):
                     glyphs = _unicode_to_glyph_id(char, reverse_cmap)
-                    lines.append((font.text_width(glyphs) * font_size / 1000, glyphs))
+                    lines.append((font.get_text_width(glyphs) * font_size / 1000, glyphs))
         else:
             lines = []
             for line in text.splitlines():
                 glyphs = _unicode_to_glyph_id(line, reverse_cmap)
-                lines.append((font.text_width(glyphs) * font_size / 1000, glyphs))
+                lines.append((font.get_text_width(glyphs) * font_size / 1000, glyphs))
 
         # Set the vertical offset
         if is_multiline:

--- a/tests/generic/test_base.py
+++ b/tests/generic/test_base.py
@@ -34,12 +34,12 @@ def test_text_string_object__wrongly_detected_bom() -> None:
         writer_page.merge_page(page)
 
         assert writer_page.extract_text() == (
-            "无译形带 r的参 z慧队手行 c要枪互工先调 uC一在你 k该方导最 xT况 M味政没出 v大同团\n"
-            "想急压游这体构主 m基重张预另做内已织程术并 U种规被中应 s过小立就公测和 F更为 BS\n"
-            "把强型 w利 qfJ现能您关文）己个言 VW是 Z亲社 y。说准密令 K络通自力 i诸旦明量放及 I\n"
-            "成战康养 d都蜂多开 pE次提朋动比台有培愿 A确 l充计标去人如么 b灵 N它 g弃语看 X；j\n"
-            "轮 HG采共由地友入（器 Y果感建切理情从集德翻 a单第识任 Q模 eh目经相哪受起时着 DR\n"
-            "用好 o备划付信、度解效作协读 O讨高具击始者意群治扩到 P才兰网认 t马倒来本整 L们 n\n"
+            "无译形带r的参 z慧队手行 c要枪互工先调 uC一在你 k该方导最 xT况 M味政没出 v大同团\n"
+            "想急压游这体构主m基重张预另做内已织程术并 U种规被中应 s过小立就公测和 F更为 BS\n"
+            "把强型w利 qfJ现能您关文）己个言 VW是 Z亲社 y。说准密令K络通自力 i诸旦明量放及 I\n"
+            "成战康养d都蜂多开 pE次提朋动比台有培愿 A确 l充计标去人如么 b灵 N它 g弃语看 X；j\n"
+            "轮HG采共由地友入（器Y果感建切理情从集德翻a单第识任 Q模 eh目经相哪受起时着 DR\n"
+            "用好o备划付信、度解效作协读 O讨高具击始者意群治扩到 P才兰网认 t马倒来本整 L们 n\n"
             "系可论，步各之但\n"
             "12"
         )

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -30,7 +30,7 @@ def test_font_descriptor():
     test_string = "This is a long sentence. !@%%^€€€. çûiö¶´"
     reverse_map = {char: byte for byte, char in my_font.encoding.items()}
     encoded_string = ([chr(reverse_map[char]) for char in test_string])
-    charwidth = my_font.text_width(encoded_string)
+    charwidth = my_font.get_text_width(encoded_string)
     assert charwidth == 19251
 
     font_res[NameObject("/BaseFont")] = NameObject("/Palatino")

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -18,7 +18,8 @@ from . import RESOURCE_ROOT
 def test_font_descriptor():
     font_res = DictionaryObject({
         NameObject("/BaseFont"): NameObject("/Helvetica"),
-        NameObject("/Subtype"): NameObject("/Type1")
+        NameObject("/Subtype"): NameObject("/Type1"),
+        NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
     })
     my_font = Font.from_font_resource(font_res)
     assert my_font.font_descriptor.family == "Helvetica"
@@ -26,8 +27,10 @@ def test_font_descriptor():
     assert my_font.font_descriptor.ascent == 718
     assert my_font.font_descriptor.descent == -207
 
-    test_string = "This is a long sentence. !@%%^€€€. çûįö¶´"
-    charwidth = my_font.text_width(test_string)
+    test_string = "This is a long sentence. !@%%^€€€. çûiö¶´"
+    reverse_map = {char: byte for byte, char in my_font.encoding.items()}
+    encoded_string = ([chr(reverse_map[char]) for char in test_string])
+    charwidth = my_font.text_width(encoded_string)
     assert charwidth == 19251
 
     font_res[NameObject("/BaseFont")] = NameObject("/Palatino")

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -151,6 +151,7 @@ def test_font_class_to_dict():
             ),
         },
         "character_widths": {"default": 500},
+        "space_char": " ",
         "space_width": 8,
         "interpretable": True,
     }

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -20,6 +20,7 @@ from pypdf._text_extraction._layout_mode._fixed_width_page import (
     text_show_operations,
 )
 from pypdf._text_extraction._layout_mode._text_state_manager import TextStateManager
+from pypdf._text_extraction._layout_mode._text_state_params import TextStateParams
 from pypdf.errors import PdfReadError
 from pypdf.generic import ContentStream, DictionaryObject, NameObject
 
@@ -621,3 +622,30 @@ def test_page__extract_text__xform__self_references(caplog):
 
     assert page.extract_text() == ""
     assert caplog.messages == ["Detected cyclic form XObject reference, skipping /X1."]
+
+
+@pytest.mark.parametrize(
+    "encoding",
+    [
+        "ascii",
+        {65: "A"},
+    ],
+    ids=["string", "dictionary"],
+)
+def test_text_state_params__unicode_decode_error(encoding):
+    font_dictionary = DictionaryObject({
+        NameObject("/Type"): NameObject("/Font"),
+        NameObject("/Subtype"): NameObject("/Type1"),
+        NameObject("/BaseFont"): NameObject("/Helvetica"),
+    })
+    font = Font.from_font_resource(font_dictionary)
+    font.encoding = encoding
+
+    # For string: 0xff (255) is out of range for ASCII (0-127)
+    # For dictionary: 0xff (255) is missing from the dict, and bytes((255,)).decode()
+    # throws a UnicodeDecodeError under default UTF-8 rules.
+    parameters = TextStateParams(value=b"\xff", font=font, font_size=10)
+
+    # Assertions: 'replace' mode changes invalid UTF-8 bytes to '\xfffd'.
+    assert parameters.text == "\ufffd"
+    assert parameters._decoded_value == "\ufffd"


### PR DESCRIPTION
A PDF font can include more character widths than unicode code points, because some glyphs (e.g., ligatures, arabic shaped characters) do not map one-to-one on unicode code points. The current character_widths in Font, however _are_ unicode mapped, meaning that some widths aren't collected. This PR collects all available widths instead.

Note that previously (before we converged on one Font class in https://github.com/py-pdf/pypdf/commit/d9ce594772717fdcfcd505d0309843461579bbf7), this was already the case for the text extraction code. This PR includes additional patches to also make this work for the layout mode text extraction and for generating appearance streams.

I should note that, for core font metrics, this actually _reduces_ the width list, but that is because we now _only_ consider widths for character glyphs that _can_ be encoded. So, no loss of functionality. For all other cases, the new widths lists are longer than the originals (I can give an overview).

Some lines are not covered, but they never were originally either, as far as I can tell.

I used Google Gemini to suggest good variable names, and to help with the code that replaces font_glyph_byte_map in AppearanceStream (see the new Font._get_typographic_maps method).

This PR contributes to fixing: https://github.com/py-pdf/pypdf/issues/3514

Tests are failing, but I don't think that's because of this PR :-)

EDIT

On second though - this PR might not be _necessary_ for shaping arabic text. If we would take to harfbuzz for doing this, then it would do all the font width measurements itself, negating the need to collect all widths. For completeness sake, though, this PR improves on what we had and might also make it easier to produce complete font resources that also include character widths for glyphs that are not in character_map.