### PR TITLE
BUG: Decode cross-reference stream entries as unsigned integers

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -92,7 +92,7 @@ def convert_to_int(d: bytes, size: int) -> Union[int, tuple[Any, ...]]:
         raise PdfReadError("Invalid size in convert_to_int")
     d = b"\x00\x00\x00\x00\x00\x00\x00\x00" + d
     d = d[-8:]
-    return cast(int, struct.unpack(">q", d)[0])
+    return cast(int, struct.unpack(">Q", d)[0])
 
 
 class DocumentInformation(DictionaryObject):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -870,11 +870,17 @@ def test_pages_attribute():
     assert exc.value.args[0] == "Sequence index out of range"
 
 
-def test_convert_to_int():
-    assert convert_to_int(b"\x01", 8) == 1
-    # Cross-reference stream entries are unsigned (ISO 32000-2, Table 18), so a
-    # wide field with the high bit set must not decode to a negative value.
-    assert convert_to_int(b"\x80\x00\x00\x00\x00\x00\x00\x01", 8) == 0x8000000000000001
+@pytest.mark.parametrize(
+    ("d", "size", "expected"),
+    [
+        (b"\x01", 8, 1),
+        # Cross-reference stream entry fields are >= 0 (ISO 32000-2, Table 18),
+        # so a wide field with the high bit set must not decode to a negative value.
+        (b"\x80\x00\x00\x00\x00\x00\x00\x01", 8, 0x8000000000000001),
+    ],
+)
+def test_convert_to_int(d, size, expected):
+    assert convert_to_int(d, size) == expected
 
 
 def test_convert_to_int_error():

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -872,6 +872,9 @@ def test_pages_attribute():
 
 def test_convert_to_int():
     assert convert_to_int(b"\x01", 8) == 1
+    # Cross-reference stream entries are unsigned (ISO 32000-2, Table 18), so a
+    # wide field with the high bit set must not decode to a negative value.
+    assert convert_to_int(b"\x80\x00\x00\x00\x00\x00\x00\x01", 8) == 0x8000000000000001
 
 
 def test_convert_to_int_error():


### PR DESCRIPTION
`convert_to_int` in `_doc_common.py` unpacks cross-reference stream entries with the signed `>q`, but these `/W` fields hold unsigned integers (ISO 32000-2, Table 18). A wide field with the high bit set then decodes to a negative offset/object number; switch to `>Q`.