### PR TITLE
ROB: Handle truncated replicate run in RunLengthDecode

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -457,7 +457,7 @@ class RunLengthDecode:
             else:  # >128
                 if index >= data_length:
                     logger_warning(
-                        "missing EOD in RunLengthDecode, check if output is OK", source=__name__
+                        "Missing EOD in RunLengthDecode, check if output is OK", source=__name__
                     )
                     break  # Reached end of string without the replicated byte
                 length = 257 - length

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -455,6 +455,11 @@ class RunLengthDecode:
                 lst.append(data[index : (index + length)])
                 index += length
             else:  # >128
+                if index >= data_length:
+                    logger_warning(
+                        "missing EOD in RunLengthDecode, check if output is OK", source=__name__
+                    )
+                    break  # Reached end of string without the replicated byte
                 length = 257 - length
                 lst.append(bytes((data[index],)) * length)
                 index += 1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -893,6 +893,14 @@ def test_rle_decode_exception_with_corrupted_stream(caplog):
     assert caplog.messages == ["Early EOD in RunLengthDecode, check if output is OK"]
 
 
+def test_rle_decode_truncated_after_run_length(caplog):
+    # A replicate run (length byte > 128) that is not followed by the byte to
+    # repeat must be handled like any other truncated input instead of reading
+    # past the end of the data.
+    assert RunLengthDecode.decode(b"\x00A\xff") == b"A"
+    assert caplog.messages == ["missing EOD in RunLengthDecode, check if output is OK"]
+
+
 def test_decompress():
     data = string.printable.encode("utf-8") + string.printable[::-1].encode("utf-8")
     compressed = FlateDecode.encode(data)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -898,7 +898,7 @@ def test_rle_decode_truncated_after_run_length(caplog):
     # repeat must be handled like any other truncated input instead of reading
     # past the end of the data.
     assert RunLengthDecode.decode(b"\x00A\xff") == b"A"
-    assert caplog.messages == ["missing EOD in RunLengthDecode, check if output is OK"]
+    assert caplog.messages == ["Missing EOD in RunLengthDecode, check if output is OK"]
 
 
 def test_decompress():


### PR DESCRIPTION
RunLengthDecode.decode reads the byte to replicate for a run length above 128 without checking it is still present, so a stream whose final byte is such a length marker reads past the end of the data and raises IndexError. Every other branch in the loop already falls back to the existing missing-EOD warning, so apply the same guard before reading the replicated byte and let truncated input degrade gracefully.