### PR TITLE
STY: Convert once to Path.pathlib

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -264,7 +264,7 @@ class PdfWriter(PdfDocCommon):
             clone_from: Union[None, PdfReader, str, Path, IO[Any], BytesIO],
         ) -> Union[None, PdfReader, str, Path, IO[Any], BytesIO]:
             if isinstance(fileobj, (str, Path, IO, BytesIO)) and (
-                fileobj is None or clone_from is not None
+                fileobj == "" or clone_from is not None
             ):
                 return clone_from
             cloning = True

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -264,16 +264,15 @@ class PdfWriter(PdfDocCommon):
             clone_from: Union[None, PdfReader, str, Path, IO[Any], BytesIO],
         ) -> Union[None, PdfReader, str, Path, IO[Any], BytesIO]:
             if isinstance(fileobj, (str, Path, IO, BytesIO)) and (
-                fileobj == "" or clone_from is not None
+                fileobj is None or clone_from is not None
             ):
                 return clone_from
             cloning = True
-            if isinstance(fileobj, (str, Path)) and (
-                not Path(str(fileobj)).exists()
-                or Path(str(fileobj)).stat().st_size == 0
-            ):
-                cloning = False
-            if isinstance(fileobj, (IOBase, BytesIO)):
+            if isinstance(fileobj, (str, Path)):
+                fileobj_path = Path(fileobj)
+                if not fileobj_path.exists() or fileobj_path.stat().st_size == 0:
+                    cloning = False
+            elif isinstance(fileobj, (IOBase, BytesIO)):
                 t = fileobj.tell()
                 if fileobj.seek(0, 2) == 0:
                     cloning = False


### PR DESCRIPTION
Replaces unnecessary conversion to a str and then a Path.pathlib.