### PR TITLE
MAINT: Add ABC as a base class

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -29,7 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import struct
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable, Iterator, Mapping
 from datetime import datetime
 from typing import (
@@ -255,7 +255,7 @@ class DocumentInformation(DictionaryObject):
         return self.get(DI.KEYWORDS)
 
 
-class PdfDocCommon:
+class PdfDocCommon(ABC):
     """
     Common functions from PdfWriter and PdfReader objects.
 

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -311,6 +311,7 @@ class PdfDocCommon(ABC):
         return retval
 
     @property
+    @abstractmethod
     def xmp_metadata(self) -> Optional[XmpInformation]:
         ...  # pragma: no cover
 


### PR DESCRIPTION
@abc.abstractmethod requires that the class's
metaclass is ABCMeta or is derived from it.
https://docs.python.org/3/library/abc.html