### PR TITLE
MAINT: Type the always-raising deprecation helpers as `NoReturn`

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -34,6 +34,7 @@ from collections.abc import Generator, Iterable, Iterator, Mapping
 from datetime import datetime
 from typing import (
     Any,
+    NoReturn,
     Optional,
     Union,
     cast,
@@ -1273,30 +1274,13 @@ class PdfDocCommon:
 
     def decode_permissions(
         self, permissions_code: int
-    ) -> dict[str, bool]:  # pragma: no cover
+    ) -> NoReturn:  # pragma: no cover
         """Take the permissions as an integer, return the allowed access."""
         deprecation_with_replacement(
             old_name="decode_permissions",
             new_name="user_access_permissions",
             removed_in="5.0.0",
         )
-
-        permissions_mapping = {
-            "print": UserAccessPermissions.PRINT,
-            "modify": UserAccessPermissions.MODIFY,
-            "copy": UserAccessPermissions.EXTRACT,
-            "annotations": UserAccessPermissions.ADD_OR_MODIFY,
-            "forms": UserAccessPermissions.FILL_FORM_FIELDS,
-            # Do not fix typo, as part of official, but deprecated API.
-            "accessability": UserAccessPermissions.EXTRACT_TEXT_AND_GRAPHICS,
-            "assemble": UserAccessPermissions.ASSEMBLE_DOC,
-            "print_high_quality": UserAccessPermissions.PRINT_TO_REPRESENTATION,
-        }
-
-        return {
-            key: permissions_code & flag != 0
-            for key, flag in permissions_mapping.items()
-        }
 
     @property
     def user_access_permissions(self) -> Optional[UserAccessPermissions]:

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -42,6 +42,7 @@ from re import Pattern
 from typing import (
     IO,
     Any,
+    NoReturn,
     Optional,
     Union,
 )
@@ -390,7 +391,7 @@ def deprecate(msg: str, stacklevel: int = 3) -> None:
     warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
 
 
-def deprecation(msg: str) -> None:
+def deprecation(msg: str) -> NoReturn:
     raise DeprecationError(msg)
 
 
@@ -402,7 +403,7 @@ def deprecate_with_replacement(old_name: str, new_name: str, removed_in: str) ->
     )
 
 
-def deprecation_with_replacement(old_name: str, new_name: str, removed_in: str) -> None:
+def deprecation_with_replacement(old_name: str, new_name: str, removed_in: str) -> NoReturn:
     """Raise an exception that a feature was already removed, but has a replacement."""
     deprecation(
         f"{old_name} is deprecated and was removed in pypdf {removed_in}. Use {new_name} instead."
@@ -414,7 +415,7 @@ def deprecate_no_replacement(name: str, removed_in: str) -> None:
     deprecate(f"{name} is deprecated and will be removed in pypdf {removed_in}.", 4)
 
 
-def deprecation_no_replacement(name: str, removed_in: str) -> None:
+def deprecation_no_replacement(name: str, removed_in: str) -> NoReturn:
     """Raise an exception that a feature was already removed without replacement."""
     deprecation(f"{name} is deprecated and was removed in pypdf {removed_in}.")
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -405,12 +405,10 @@ class PdfWriter(PdfDocCommon):
     @property
     def with_as_usage(self) -> bool:
         deprecation_no_replacement("with_as_usage", "5.0")
-        return self._with_as_usage
 
     @with_as_usage.setter
     def with_as_usage(self, value: bool) -> None:
         deprecation_no_replacement("with_as_usage", "5.0")
-        self._with_as_usage = value
 
     def __enter__(self) -> Self:
         """Store how writer is initialized by 'with'."""

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -46,7 +46,7 @@ from base64 import a85decode
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional, Union, cast
+from typing import Any, NoReturn, Optional, Union, cast
 
 from ._codecs._codecs import LzwCodec as _LzwCodec
 from ._utils import (
@@ -604,9 +604,8 @@ def __create_old_class_instance(
     K: int = 0,
     columns: int = 0,
     rows: int = 0
-) -> CCITTParameters:
+) -> NoReturn:
     deprecation_with_replacement("CCITParameters", "CCITTParameters", "6.0.0")
-    return CCITTParameters(K, columns, rows)
 
 
 # Create an alias for the old class name


### PR DESCRIPTION
Closes #3748.

\`pypdf._utils.deprecation\` and the two convenience wrappers (\`deprecation_with_replacement\`, \`deprecation_no_replacement\`) all unconditionally raise \`DeprecationError\`. They were typed as returning \`None\`, which is wrong — \`typing.NoReturn\` is the standard type for this case (per the [Python typing docs](https://docs.python.org/3/library/typing.html#typing.NoReturn)).

The warning-only siblings (\`deprecate\`, \`deprecate_with_replacement\`, \`deprecate_no_replacement\`) return normally after \`warnings.warn\`, so they keep \`-> None\`.

## Unreachable code dropped at three call sites

The issue body predicted \"this probably leads to some unreachable code which can be deleted, possibly being detected as uncovered during tests\". Three sites match that pattern:

| File | What was dead |
|---|---|
| \`pypdf/_writer.py\` | \`with_as_usage\` property getter + setter — \`return self._with_as_usage\` / \`self._with_as_usage = value\` after \`deprecation_no_replacement(...)\` |
| \`pypdf/_doc_common.py\` | \`decode_permissions\` — the whole \`permissions_mapping = {...}; return {...}\` body (already tagged \`# pragma: no cover\`). Signature now \`-> NoReturn\` |
| \`pypdf/filters.py\` | \`__create_old_class_instance\` — \`return CCITTParameters(...)\` after the deprecation raise. Signature now \`-> NoReturn\` |

The \`if encryption_key is not None: deprecation_no_replacement(...)\` guards in \`generic/_base.py\` and \`xmp.py\` are **not** unreachable — the deprecation only fires when the deprecated parameter is passed, and the post-guard code is the normal path. Those are intentionally left alone.

## Verification

\`\`\`
$ pytest -k \"deprecat or with_as_usage or decode_perm or CCITParameters\"
============================== 5 passed, 230 deselected
\$ mypy pypdf/_utils.py pypdf/_writer.py pypdf/filters.py pypdf/_doc_common.py
# Two pre-existing errors on \`main\` (lines 330/1075), zero new errors.
\`\`\`

Net diff: 4 files changed, 8 insertions(+), 26 deletions(-).