### PR TITLE
ROB: Pad truncated data in bits2byte instead of reading out of bounds

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -133,9 +133,9 @@ def bits2byte(data: bytes, size: tuple[int, int], bits: int) -> bytes:
     mask = (1 << bits) - 1
 
     required = size[1] * ((size[0] * bits + 7) // 8)
-    if len(data) < required:
+    if (length := len(data)) < required:
         logger_warning("Image data is not rectangular. Adding padding.", source=__name__)
-        data += b"\x00" * (required - len(data))
+        data += b"\x00" * (required - length)
 
     data_index = 0
     bit = 8 - bits

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -131,6 +131,12 @@ def bits2byte(data: bytes, size: tuple[int, int], bits: int) -> bytes:
 
     byte_buffer = bytearray(buffer_size)
     mask = (1 << bits) - 1
+
+    required = size[1] * ((size[0] * bits + 7) // 8)
+    if len(data) < required:
+        logger_warning("Image data is not rectangular. Adding padding.", source=__name__)
+        data += b"\x00" * (required - len(data))
+
     data_index = 0
     bit = 8 - bits
     for y in range(size[1]):

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -278,8 +278,36 @@ def test_bits2byte__limit() -> None:
         bits2byte(data=b"TEST", size=(9000, 8500), bits=8)
 
 
-def test_bits2byte__truncated_data(caplog) -> None:
+def test_bits2byte__truncated_data(caplog: pytest.LogCaptureFixture) -> None:
     # 4x4 image at 2 bits per sample needs 4 bytes; provide only 1.
     result = bits2byte(data=b"\x00", size=(4, 4), bits=2)
     assert result == bytes(16)
+    assert "Image data is not rectangular. Adding padding." in caplog.text
+
+
+def test_handle_flate__truncated_2bit_image(caplog: pytest.LogCaptureFixture) -> None:
+    # A 3x3 indexed image at 2 bits per sample needs 3 bytes; provide only 1.
+    # Padding the missing bytes lets the image still be loaded instead of
+    # raising IndexError out of bits2byte.
+    lookup = DecodedStreamObject()
+    lookup.set_data(bytes([0, 0, 0, 10, 10, 10, 20, 20, 20, 30, 30, 30]))
+    result = _handle_flate(
+        size=(3, 3),
+        data=b"\xe4",
+        mode="2bits",
+        color_space=ArrayObject(
+            [NameObject("/Indexed"), NameObject("/DeviceRGB"), NumberObject(3), lookup]
+        ),
+        colors=1,
+        obj_as_text="dummy",
+    )
+    image = result[0]
+    image.load()
+    assert image.mode == "RGB"
+    assert image.size == (3, 3)
+    assert get_image_data(image) == (
+        (30, 30, 30), (20, 20, 20), (10, 10, 10),
+        (0, 0, 0), (0, 0, 0), (0, 0, 0),
+        (0, 0, 0), (0, 0, 0), (0, 0, 0),
+    )
     assert "Image data is not rectangular. Adding padding." in caplog.text

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -276,3 +276,10 @@ def test_bits2byte__limit() -> None:
             match=r"^Requested buffer size 76500000 exceeds limit of 75000000\.$"
     ):
         bits2byte(data=b"TEST", size=(9000, 8500), bits=8)
+
+
+def test_bits2byte__truncated_data(caplog) -> None:
+    # 4x4 image at 2 bits per sample needs 4 bytes; provide only 1.
+    result = bits2byte(data=b"\x00", size=(4, 4), bits=2)
+    assert result == bytes(16)
+    assert "Image data is not rectangular. Adding padding." in caplog.text


### PR DESCRIPTION
bits2byte unpacks 2/4-bit image samples by indexing data[data_index] in a loop sized from the image Width/Height, with no check the stream actually holds that many bytes, so a PDF whose flate-decoded image data is shorter than the dimensions imply raises IndexError during extraction. Pad the input up front like _decode_png_prediction already does for short rows.