### PR TITLE
MAINT: Pack CCITTFaxDecode TIFF header fields as unsigned

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -660,7 +660,9 @@ class CCITTFaxDecode:
         params = CCITTFaxDecode._get_parameters(decode_parms, height)
 
         img_size = len(data)
-        tiff_header_struct = "<2shlh" + "hhll" * 8 + "h"
+        # TIFF SHORT and LONG fields are unsigned (TIFF 6.0, §2); pack them with
+        # unsigned codes so dimensions with the high bit set do not overflow.
+        tiff_header_struct = "<2sHLH" + "HHLL" * 8 + "H"
         tiff_header = struct.pack(
             tiff_header_struct,
             b"II",  # Byte order indication: Little endian

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -251,6 +251,18 @@ def test_ccitt_fax_decode():
     )
 
 
+def test_ccitt_fax_decode__unsigned_columns():
+    # /Columns above 2**31 - 1 is a valid unsigned TIFF LONG and must not
+    # overflow the packed header.
+    data = b"\x00\x01\x02\x03"
+    parameters = DictionaryObject(
+        {"/K": NumberObject(-1), "/Columns": NumberObject(3_000_000_000)}
+    )
+    result = CCITTFaxDecode.decode(data, parameters, height=10)
+    assert result.endswith(data)
+    assert result[18:22] == (3_000_000_000).to_bytes(4, "little")
+
+
 @pytest.mark.enable_socket
 def test_decompress_zlib_error(caplog):
     reader = PdfReader(BytesIO(get_data_from_url(name="tika-952445.pdf")))


### PR DESCRIPTION
The synthetic TIFF header built in `CCITTFaxDecode.decode` describes ImageWidth/ImageLength and friends, which TIFF defines as unsigned SHORT/LONG, but packs them with the signed `struct` codes `h`/`l`. A `/Columns` or `/Rows` past 2**31-1 then overflows the signed code and raises `struct.error` mid extraction. Uppercasing the integer codes keeps the byte layout and `calcsize` identical for existing files while accepting the full unsigned range.