### PR TITLE
ROB: Stop reading past truncated /Nums in get_label_from_nums

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -133,13 +133,19 @@ def get_label_from_nums(dictionary_object: DictionaryObject, index: int) -> str:
     # analogously to the arrangement of keys in a name tree
     # as described in 7.9.6, "Name Trees."
     nums = cast(ArrayObject, dictionary_object["/Nums"])
+    nums_length = len(nums)
     i = 0
     value = None
     start_index = 0
-    while i + 1 < len(nums):
+    while i < nums_length:
+        if i + 1 >= nums_length:
+            logger_warning(
+                "Ignoring last /Nums key without a value.", source=__name__
+            )
+            break
         start_index = nums[i]
         value = nums[i + 1].get_object()
-        if i + 2 == len(nums):
+        if i + 2 == nums_length:
             break
         if nums[i + 2] > index:
             break

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -136,7 +136,7 @@ def get_label_from_nums(dictionary_object: DictionaryObject, index: int) -> str:
     i = 0
     value = None
     start_index = 0
-    while i < len(nums):
+    while i + 1 < len(nums):
         start_index = nums[i]
         value = nums[i + 1].get_object()
         if i + 2 == len(nums):

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -176,7 +176,7 @@ def test_get_label_from_nums__empty_nums_list():
     assert get_label_from_nums(dictionary_object, 13) == "14"
 
 
-def test_get_label_from_nums__truncated_pair():
+def test_get_label_from_nums__truncated_pair(caplog):
     # Odd-length /Nums: the trailing key has no value object.
     value = DictionaryObject()
     value[NameObject("/S")] = NameObject("/D")
@@ -185,6 +185,7 @@ def test_get_label_from_nums__truncated_pair():
         [NumberObject(0), value, NumberObject(5)]
     )
     assert get_label_from_nums(dictionary_object, 7) == "8"
+    assert "Ignoring last /Nums key without a value." in caplog.text
 
 
 def test_index2label__empty_kids_list():

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -176,6 +176,17 @@ def test_get_label_from_nums__empty_nums_list():
     assert get_label_from_nums(dictionary_object, 13) == "14"
 
 
+def test_get_label_from_nums__truncated_pair():
+    # Odd-length /Nums: the trailing key has no value object.
+    value = DictionaryObject()
+    value[NameObject("/S")] = NameObject("/D")
+    dictionary_object = DictionaryObject()
+    dictionary_object[NameObject("/Nums")] = ArrayObject(
+        [NumberObject(0), value, NumberObject(5)]
+    )
+    assert get_label_from_nums(dictionary_object, 7) == "8"
+
+
 def test_index2label__empty_kids_list():
     reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
     number_tree = DictionaryObject()


### PR DESCRIPTION
Noticed get_label_from_nums loops while `i < len(nums)` but reads `nums[i + 1]`, so a PageLabels number tree with an odd-length /Nums array (a key with no following value) raises IndexError when `reader.page_labels` is read on an untrusted file. The function already falls back to `str(index + 1)` for malformed /Nums, but the out-of-bounds read trips first. Looping while `i + 1 < len(nums)` ignores the dangling key and reaches that fallback.