### PR TITLE
ROB: Handle object numbers above 2**31 in _make_crypt_filter

### DIFF
--- a/pypdf/_encryption.py
+++ b/pypdf/_encryption.py
@@ -1000,8 +1000,8 @@ class Encryption:
            that is stored as the first 16 bytes of the encrypted stream or string.
            The output is the encrypted data to be stored in the PDF file.
         """
-        pack1 = struct.pack("<i", idnum)[:3]
-        pack2 = struct.pack("<i", generation)[:2]
+        pack1 = (idnum & 0xFFFFFF).to_bytes(3, "little")
+        pack2 = (generation & 0xFFFF).to_bytes(2, "little")
 
         assert self._key
         key = self._key

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -216,15 +216,16 @@ def test_encrypt_decrypt_with_cipher_class(cryptcls):
     assert crypt.decrypt(crypt.encrypt(message)) == message
 
 
-@pytest.mark.parametrize("idnum", [5, 2**31, 2**32 + 1])
-def test_make_crypt_filter_large_object_number(idnum):
-    """Object numbers above the signed 32-bit range use only their low-order bytes."""
+@pytest.mark.parametrize(("idnum", "low_three_bytes"), [(2**31, 0), (2**32 + 1, 1), (0x01020304, 0x020304)])
+def test_make_crypt_filter_large_object_number(idnum, low_three_bytes):
+    """Object numbers above the signed 32-bit range use only their low-order three bytes."""
     reader = PdfReader(RESOURCE_ROOT / "encryption" / "r3-user-password.pdf", password="asdfzxcv")
     encryption = reader._encryption
     # Object numbers are unsigned and may exceed 2**31 in a crafted file. Only
     # the low-order three bytes feed the per-object key, so a large number must
-    # not raise and must encrypt identically to its masked equivalent.
-    reference = encryption._make_crypt_filter(idnum & 0xFFFFFF, 0)
+    # not raise and must encrypt the same as the small object number formed by
+    # those three bytes (given here as an independent literal).
+    reference = encryption._make_crypt_filter(low_three_bytes, 0)
     crypt_filter = encryption._make_crypt_filter(idnum, 0)
     assert crypt_filter.stm_crypt.encrypt(b"hello world") == reference.stm_crypt.encrypt(b"hello world")
 

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -216,6 +216,17 @@ def test_encrypt_decrypt_with_cipher_class(cryptcls):
     assert crypt.decrypt(crypt.encrypt(message)) == message
 
 
+def test_make_crypt_filter_large_object_number():
+    """Object/generation numbers above the signed 32-bit range do not raise."""
+    reader = PdfReader(RESOURCE_ROOT / "crazyones-encrypted-256.pdf", password="password")
+    encryption = reader._encryption
+    # Object and generation numbers are unsigned and may exceed 2**31 in a
+    # crafted file; only their low-order bytes are used.
+    for idnum in (5, 2**31, 2**32 + 1):
+        encryption._make_crypt_filter(idnum, 0)
+    encryption._make_crypt_filter(5, 2**31)
+
+
 def test_attempt_decrypt_unencrypted_pdf():
     """Attempting to decrypt an unencrypted PDF raises a PdfReadError."""
     path = RESOURCE_ROOT / "crazyones.pdf"

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -216,15 +216,14 @@ def test_encrypt_decrypt_with_cipher_class(cryptcls):
     assert crypt.decrypt(crypt.encrypt(message)) == message
 
 
-def test_make_crypt_filter_large_object_number():
-    """Object/generation numbers above the signed 32-bit range do not raise."""
+@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
+@pytest.mark.parametrize("idnum", [5, 2**31, 2**32 + 1])
+def test_make_crypt_filter_large_object_number(idnum):
+    """Object numbers above the signed 32-bit range do not raise."""
     reader = PdfReader(RESOURCE_ROOT / "crazyones-encrypted-256.pdf", password="password")
-    encryption = reader._encryption
-    # Object and generation numbers are unsigned and may exceed 2**31 in a
-    # crafted file; only their low-order bytes are used.
-    for idnum in (5, 2**31, 2**32 + 1):
-        encryption._make_crypt_filter(idnum, 0)
-    encryption._make_crypt_filter(5, 2**31)
+    # Object numbers are unsigned and may exceed 2**31 in a crafted file;
+    # only their low-order bytes are used.
+    reader._encryption._make_crypt_filter(idnum, 0)
 
 
 def test_attempt_decrypt_unencrypted_pdf():

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -216,14 +216,17 @@ def test_encrypt_decrypt_with_cipher_class(cryptcls):
     assert crypt.decrypt(crypt.encrypt(message)) == message
 
 
-@pytest.mark.skipif(not HAS_AES, reason="No AES implementation")
 @pytest.mark.parametrize("idnum", [5, 2**31, 2**32 + 1])
 def test_make_crypt_filter_large_object_number(idnum):
-    """Object numbers above the signed 32-bit range do not raise."""
-    reader = PdfReader(RESOURCE_ROOT / "crazyones-encrypted-256.pdf", password="password")
-    # Object numbers are unsigned and may exceed 2**31 in a crafted file;
-    # only their low-order bytes are used.
-    reader._encryption._make_crypt_filter(idnum, 0)
+    """Object numbers above the signed 32-bit range use only their low-order bytes."""
+    reader = PdfReader(RESOURCE_ROOT / "encryption" / "r3-user-password.pdf", password="asdfzxcv")
+    encryption = reader._encryption
+    # Object numbers are unsigned and may exceed 2**31 in a crafted file. Only
+    # the low-order three bytes feed the per-object key, so a large number must
+    # not raise and must encrypt identically to its masked equivalent.
+    reference = encryption._make_crypt_filter(idnum & 0xFFFFFF, 0)
+    crypt_filter = encryption._make_crypt_filter(idnum, 0)
+    assert crypt_filter.stm_crypt.encrypt(b"hello world") == reference.stm_crypt.encrypt(b"hello world")
 
 
 def test_attempt_decrypt_unencrypted_pdf():


### PR DESCRIPTION
_make_crypt_filter packs the object and generation numbers into the per-object key with the signed format "<i", but both are unsigned in the file. A referenced object numbered at or above 2**31 in a crafted encrypted PDF therefore raises an uncaught struct.error in decrypt_object, and it fires regardless of the encryption version since these two lines run before the V check. The algorithm only consumes the low-order three bytes of the object number and the low two of the generation, so masking and converting with to_bytes keeps the output byte-identical for every value that already worked while accepting the full unsigned range.