### PR TITLE
ROB: Recover a corrupt trailing startxref pointer (closes #3238)

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -819,8 +819,52 @@ class PdfReader(PdfDocCommon):
         else:
             line = read_previous_line(stream)
             if not line.startswith(b"startxref"):
-                raise PdfReadError("startxref not found")
+                # The 'startxref' keyword expected just above the offset is
+                # missing or corrupt (for example a truncated 'tartxref').
+                # Some producers append a broken trailing cross-reference
+                # pointer while an earlier, intact 'startxref' from a previous
+                # revision is still present. Rather than giving up, scan
+                # further back for that pointer (#3238).
+                startxref = self._find_previous_startxref_pos(stream)
         return startxref
+
+    def _find_previous_startxref_pos(self, stream: StreamType) -> int:
+        """
+        Recover the most recent intact ``startxref`` pointer by scanning
+        backwards from the current position.
+
+        This is used as a fallback when the ``startxref`` keyword belonging to
+        the final ``%%EOF`` is corrupt (#3238). The offset always appears on
+        the line directly below the keyword, so the value read immediately
+        before encountering ``startxref`` (while moving backwards) is returned.
+
+        Args:
+            stream:
+
+        Returns:
+            The bytes offset
+
+        """
+        offset: Optional[int] = None
+        while stream.tell() > 0:
+            line = read_previous_line(stream)
+            if line.startswith(b"startxref"):
+                if len(line) > 9:
+                    # 'startxref' on the same line as the offset
+                    return int(line[9:].strip())
+                if offset is not None:
+                    logger_warning(
+                        "found startxref pointing to a previous revision after "
+                        "a corrupt one",
+                        source=__name__,
+                    )
+                    return offset
+                break
+            try:
+                offset = int(line)
+            except ValueError:
+                offset = None
+        raise PdfReadError("startxref not found")
 
     def _read_standard_xref_table(self, stream: StreamType) -> None:
         # standard cross-reference table

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -823,12 +823,21 @@ class PdfReader(PdfDocCommon):
                 # missing or corrupt (for example a truncated 'tartxref').
                 # Some producers append a broken trailing cross-reference
                 # pointer while an earlier, intact 'startxref' from a previous
-                # revision is still present. Rather than giving up, scan
-                # further back for that pointer (#3238).
+                # revision is still present. Recovering from this violates the
+                # standard, so only attempt it in non-strict mode (#3238).
+                if self.strict:
+                    raise PdfReadError("startxref not found")
                 startxref = self._find_previous_startxref_pos(stream)
         return startxref
 
-    def _find_previous_startxref_pos(self, stream: StreamType) -> int:
+    # Upper bound on the number of lines _find_previous_startxref_pos scans
+    # backwards while recovering a corrupt trailing startxref pointer. Kept
+    # fixed and non-configurable so a crafted file cannot trigger an unbounded
+    # backwards scan.
+    _MAX_STARTXREF_RECOVERY_LINES = 1000
+
+    @classmethod
+    def _find_previous_startxref_pos(cls, stream: StreamType) -> int:
         """
         Recover the most recent intact ``startxref`` pointer by scanning
         backwards from the current position.
@@ -837,33 +846,38 @@ class PdfReader(PdfDocCommon):
         the final ``%%EOF`` is corrupt (#3238). The offset always appears on
         the line directly below the keyword, so the value read immediately
         before encountering ``startxref`` (while moving backwards) is returned.
+        At most ``_MAX_STARTXREF_RECOVERY_LINES`` lines are inspected.
 
         Args:
-            stream:
+            stream: The PDF byte stream, positioned just above the corrupt
+                trailing pointer.
 
         Returns:
-            The bytes offset
+            The bytes offset of the recovered ``startxref``.
 
         """
         offset: Optional[int] = None
-        while stream.tell() > 0:
-            line = read_previous_line(stream)
-            if line.startswith(b"startxref"):
-                if len(line) > 9:
-                    # 'startxref' on the same line as the offset
-                    return int(line[9:].strip())
-                if offset is not None:
-                    logger_warning(
-                        "found startxref pointing to a previous revision after "
-                        "a corrupt one",
-                        source=__name__,
-                    )
-                    return offset
+        for _ in range(cls._MAX_STARTXREF_RECOVERY_LINES):
+            if stream.tell() <= 0:
                 break
-            try:
-                offset = int(line)
-            except ValueError:
-                offset = None
+            line = read_previous_line(stream)
+            if not line.startswith(b"startxref"):
+                try:
+                    offset = int(line)
+                except ValueError:
+                    offset = None
+                continue
+            if len(line) > 9:
+                # 'startxref' on the same line as the offset
+                return int(line[9:].strip())
+            if offset is not None:
+                logger_warning(
+                    "found startxref pointing to a previous revision after "
+                    "a corrupt one",
+                    source=__name__,
+                )
+                return offset
+            break
         raise PdfReadError("startxref not found")
 
     def _read_standard_xref_table(self, stream: StreamType) -> None:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -422,6 +422,11 @@ def test_startxref_corrupt_trailing_pointer(caplog):
         "found startxref pointing to a previous revision after a corrupt one",
     ]
 
+    # Recovering from the corrupt pointer violates the standard, so it must
+    # only happen in non-strict mode; strict mode raises instead.
+    with pytest.raises(PdfReadError, match="startxref not found"):
+        PdfReader(io.BytesIO(pdf_data), strict=True)
+
 
 @pytest.mark.parametrize(
     ("pdffile", "password", "should_fail"),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -374,6 +374,55 @@ def test_issue297(caplog):
     reader.pages[0]
 
 
+def test_startxref_corrupt_trailing_pointer(caplog):
+    """
+    A corrupt trailing startxref keyword (e.g. ``tartxref``) must not prevent
+    reading when an earlier, intact startxref from a previous revision is still
+    present further up the file. See #3238.
+    """
+    pdf_data = (
+        b"%%PDF-1.7\n"
+        b"1 0 obj << /Count 1 /Kids [4 0 R] /Type /Pages >> endobj\n"
+        b"2 0 obj << >> endobj\n"
+        b"3 0 obj << >> endobj\n"
+        b"4 0 obj << /Contents 3 0 R /CropBox [0.0 0.0 2550.0 3508.0]"
+        b" /MediaBox [0.0 0.0 2550.0 3508.0] /Parent 1 0 R"
+        b" /Resources << /Font << >> >>"
+        b" /Rotate 0 /Type /Page >> endobj\n"
+        b"5 0 obj << /Pages 1 0 R /Type /Catalog >> endobj\n"
+        b"xref 1 5\n"
+        b"%010d 00000 n\n"
+        b"%010d 00000 n\n"
+        b"%010d 00000 n\n"
+        b"%010d 00000 n\n"
+        b"%010d 00000 n\n"
+        b"trailer << /Root 5 0 R /Size 6 >>\n"
+        b"startxref\n"
+        b"%d\n"
+        b"%%%%EOF\n"
+        # A corrupt, trailing cross-reference pointer left behind by a broken
+        # incremental update: the keyword has lost its leading 's'.
+        b"tartxref\n"
+        b"99999\n"
+        b"%%%%EOF"
+    )
+    pdf_data = pdf_data % (
+        # - 1 below in the find because of the double % at the beginning
+        pdf_data.find(b"1 0 obj") - 1,
+        pdf_data.find(b"2 0 obj") - 1,
+        pdf_data.find(b"3 0 obj") - 1,
+        pdf_data.find(b"4 0 obj") - 1,
+        pdf_data.find(b"5 0 obj") - 1,
+        pdf_data.find(b"xref") - 1,
+    )
+    reader = PdfReader(io.BytesIO(pdf_data))
+    assert len(reader.pages) == 1
+    assert reader.pages[0].mediabox.width == 2550
+    assert normalize_warnings(caplog.text) == [
+        "found startxref pointing to a previous revision after a corrupt one",
+    ]
+
+
 @pytest.mark.parametrize(
     ("pdffile", "password", "should_fail"),
     [

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -450,6 +450,11 @@ def test_find_previous_startxref_pos_recovery_variants():
     with pytest.raises(PdfReadError, match="startxref not found"):
         scan(b"only some bytes\nand more\n")
 
+    # The backward scan is bounded: a long stream without a recoverable
+    # pointer hits the line cap and gives up instead of scanning forever
+    with pytest.raises(PdfReadError, match="startxref not found"):
+        scan(b"x\n" * (PdfReader._MAX_STARTXREF_RECOVERY_LINES + 100))
+
 
 @pytest.mark.parametrize(
     ("pdffile", "password", "should_fail"),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -428,6 +428,29 @@ def test_startxref_corrupt_trailing_pointer(caplog):
         PdfReader(io.BytesIO(pdf_data), strict=True)
 
 
+def test_find_previous_startxref_pos_recovery_variants():
+    """Cover the backward-scan branches of _find_previous_startxref_pos (#3238)."""
+
+    def scan(data: bytes) -> int:
+        stream = io.BytesIO(data)
+        stream.seek(0, 2)
+        return PdfReader._find_previous_startxref_pos(stream)
+
+    # Offset on the line below the keyword (the usual layout)
+    assert scan(b"startxref\n12345\ngarbage\n") == 12345
+
+    # Keyword and offset share a line
+    assert scan(b"startxref 6789\ngarbage\n") == 6789
+
+    # A startxref keyword with no numeric offset above it cannot be recovered
+    with pytest.raises(PdfReadError, match="startxref not found"):
+        scan(b"startxref\nnot-a-number\n")
+
+    # No startxref keyword at all: the scan exhausts the stream and gives up
+    with pytest.raises(PdfReadError, match="startxref not found"):
+        scan(b"only some bytes\nand more\n")
+
+
 @pytest.mark.parametrize(
     ("pdffile", "password", "should_fail"),
     [


### PR DESCRIPTION
## Summary

Some PDFs end with a broken trailing cross-reference pointer left behind by a faulty incremental update — the `startxref` keyword for the final `%%EOF` has been corrupted (e.g. it reads `tartxref`), while an earlier, intact `startxref` from a previous revision is still present further up the file:

```
trailer
<<...>>
startxref
160113
%%EOF
tartxref      <- corrupt keyword (missing leading 's')
160135
%%EOF
```

Today `PdfReader` aborts on such a file with `PdfReadError: startxref not found`, even though the document is otherwise fully readable from the earlier pointer.

This was noted in #3238, where the suggestion was to "circumvent this by further looking for another startxref". This PR does exactly that: when the `startxref` keyword expected just above the offset is missing or corrupt, it scans further back for the most recent intact pointer rather than giving up.

## Details

- `_find_startxref_pos` now delegates to a new `_find_previous_startxref_pos` fallback when the keyword line is not where it should be.
- The fallback walks backwards, and because the offset always sits on the line directly below the keyword, it returns the value read immediately before the recovered `startxref`.
- The change is purely additive: it only runs when the normal path would have raised, so well-formed files are unaffected. If no earlier pointer exists, the original `startxref not found` error is still raised.

On the file from #3238 the reader now opens all 11 pages and extracts text correctly, using the valid `startxref` at 160113.

## Test

`test_startxref_corrupt_trailing_pointer` builds a minimal PDF with a valid `startxref`/`%%EOF` followed by a corrupt `tartxref` trailer and asserts the page is recovered. It runs fully offline (no sample files).

## AI use disclosure

Per the project's AI policy: I used AI coding assistance while preparing this PR. Tool: Claude Code. Model: Claude Opus 4.8 (`claude-opus-4-8`). I've reviewed, run, and verified the change myself and take responsibility for it; the PR text and my replies in this thread are written in my own words.