### PR TITLE
ROB: Accept inline image EI marker at the end of a content stream

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1433,15 +1433,17 @@ class ContentStream(DecodedStreamObject):
         # unconditionally would step back into the marker (#3468).
         if len(ei) == 3:
             stream.seek(-1, 1)
-        if ei[:2] != b"EI" or (ei[2:3] != b"" and ei[2:3] not in WHITESPACES):
+        ei_trailing = ei[2:3]
+        if ei[:2] != b"EI" or (ei_trailing != b"" and ei_trailing not in WHITESPACES):
             # Deal with wrong/missing `EI` tags. Example: Wrong dimensions specified above.
             stream.seek(savpos, 0)
             data = extract_inline_default(stream)
             ei = stream.read(3)
             if len(ei) == 3:
                 stream.seek(-1, 1)
+            ei_trailing = ei[2:3]
             if ei[:2] != b"EI" or (
-                ei[2:3] != b"" and ei[2:3] not in WHITESPACES
+                ei_trailing != b"" and ei_trailing not in WHITESPACES
             ):  # pragma: no cover
                 # Check the same condition again. This should never fail as
                 # edge cases are covered by `extract_inline_default` above,

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1429,14 +1429,20 @@ class ContentStream(DecodedStreamObject):
             data = extract_inline_default(stream)
 
         ei = stream.read(3)
-        stream.seek(-1, 1)
-        if ei[:2] != b"EI" or ei[2:3] not in WHITESPACES:
+        # An `EI` at the very end of the stream yields only two bytes; rewinding
+        # unconditionally would step back into the marker (#3468).
+        if len(ei) == 3:
+            stream.seek(-1, 1)
+        if ei[:2] != b"EI" or (ei[2:3] != b"" and ei[2:3] not in WHITESPACES):
             # Deal with wrong/missing `EI` tags. Example: Wrong dimensions specified above.
             stream.seek(savpos, 0)
             data = extract_inline_default(stream)
             ei = stream.read(3)
-            stream.seek(-1, 1)
-            if ei[:2] != b"EI" or ei[2:3] not in WHITESPACES:  # pragma: no cover
+            if len(ei) == 3:
+                stream.seek(-1, 1)
+            if ei[:2] != b"EI" or (
+                ei[2:3] != b"" and ei[2:3] not in WHITESPACES
+            ):  # pragma: no cover
                 # Check the same condition again. This should never fail as
                 # edge cases are covered by `extract_inline_default` above,
                 # but check this ot make sure that we are behind the `EI` afterwards.

--- a/pypdf/generic/_image_inline.py
+++ b/pypdf/generic/_image_inline.py
@@ -233,6 +233,13 @@ def extract_inline_default(stream: StreamType) -> bytes:
                 stream.seek(saved_pos, 0)
                 continue
             tok3 = stream.read(1)  # possible space after "EI"
+            if tok3 == b"":
+                # The `EI` marker is at the very end of the stream. There can be
+                # no trailing binary data, so this is unambiguously the end of the
+                # inline image (#3468).
+                stream.seek(saved_pos - 1, 0)
+                stream_out.truncate(sav_pos_ei)
+                break
             if tok3 not in WHITESPACES:
                 stream.seek(saved_pos, 0)
                 continue

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1280,6 +1280,21 @@ Q\nQ\nBT 1 0 0 1 200 100 Tm (Test) Tj T* ET\n \n"""
     assert co.operations[7][0]["data"] == b"abcdefghijklmnop"
 
 
+def test_inline_image_at_end_of_stream():
+    # An inline image whose `EI` marker is the very end of the content stream
+    # (no trailing whitespace or operator) must not raise (#3468).
+    image = b"abcdefghijklmnop"  # 4 * 4 * 1 byte
+    for tail in (b"", b"\n", b"\nQ\n"):
+        b = b"q 100 0 0 100 100 100 cm\nBI\n/W 4 /H 4 /CS /G\nID\n" + image + b"\nEI" + tail
+        ec = DecodedStreamObject()
+        ec.set_data(b)
+        co = ContentStream(ec, None)
+        operations = co.operations
+        inline = [op for op in operations if op[1] == b"INLINE IMAGE"]
+        assert len(inline) == 1
+        assert inline[0][0]["data"] == image
+
+
 def test_missing_hashbin():
     assert NullObject().hash_bin() == hash((NullObject,))
     assert hash(NullObject()) == NullObject().hash_bin()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1280,19 +1280,32 @@ Q\nQ\nBT 1 0 0 1 200 100 Tm (Test) Tj T* ET\n \n"""
     assert co.operations[7][0]["data"] == b"abcdefghijklmnop"
 
 
-def test_inline_image_at_end_of_stream():
+@pytest.mark.parametrize("tail", [b"", b"\n", b"\nQ\n"])
+def test_inline_image_at_end_of_stream(tail):
     # An inline image whose `EI` marker is the very end of the content stream
     # (no trailing whitespace or operator) must not raise (#3468).
     image = b"abcdefghijklmnop"  # 4 * 4 * 1 byte
-    for tail in (b"", b"\n", b"\nQ\n"):
-        b = b"q 100 0 0 100 100 100 cm\nBI\n/W 4 /H 4 /CS /G\nID\n" + image + b"\nEI" + tail
-        ec = DecodedStreamObject()
-        ec.set_data(b)
-        co = ContentStream(ec, None)
-        operations = co.operations
-        inline = [op for op in operations if op[1] == b"INLINE IMAGE"]
-        assert len(inline) == 1
-        assert inline[0][0]["data"] == image
+    content = b"q 100 0 0 100 100 100 cm\nBI\n/W 4 /H 4 /CS /G\nID\n" + image + b"\nEI" + tail
+    stream_object = DecodedStreamObject()
+    stream_object.set_data(content)
+    content_stream = ContentStream(stream_object, None)
+    inline_images = [op for op in content_stream.operations if op[1] == b"INLINE IMAGE"]
+    assert len(inline_images) == 1
+    assert inline_images[0][0]["data"] == image
+
+
+def test_inline_image_at_end_of_stream_default_extractor():
+    # An unrecognized colorspace forces extraction through
+    # `extract_inline_default`, which must also accept an `EI` marker at the
+    # very end of the stream without raising (#3468).
+    image = b"abcdefghijklmnop"  # 4 * 4 * 1 byte
+    content = b"q 100 0 0 100 100 100 cm\nBI\n/W 4 /H 4 /CS /Unknown\nID\n" + image + b"\nEI"
+    stream_object = DecodedStreamObject()
+    stream_object.set_data(content)
+    content_stream = ContentStream(stream_object, None)
+    inline_images = [op for op in content_stream.operations if op[1] == b"INLINE IMAGE"]
+    assert len(inline_images) == 1
+    assert image in inline_images[0][0]["data"]
 
 
 def test_missing_hashbin():

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1308,6 +1308,22 @@ def test_inline_image_at_end_of_stream_default_extractor():
     assert image in inline_images[0][0]["data"]
 
 
+def test_inline_image_at_end_of_stream_fallback_extractor():
+    # A recognized colorspace with oversized `/W`/`/H` makes the primary
+    # dimension-based read overshoot the `EI` marker, so extraction falls back
+    # to `extract_inline_default`. With the marker at the very end of the
+    # stream the fallback `read(3)` returns only two bytes (`b"EI"`), which
+    # exercises the `len(ei) != 3` path of the fallback branch (#3468).
+    image = b"abcdefghijklmnop"  # 16 bytes; `/W 8` * `/H 4` would expect 32
+    content = b"q 100 0 0 100 100 100 cm\nBI\n/W 8 /H 4 /CS /G\nID\n" + image + b"\nEI"
+    stream_object = DecodedStreamObject()
+    stream_object.set_data(content)
+    content_stream = ContentStream(stream_object, None)
+    inline_images = [op for op in content_stream.operations if op[1] == b"INLINE IMAGE"]
+    assert len(inline_images) == 1
+    assert image in inline_images[0][0]["data"]
+
+
 def test_missing_hashbin():
     assert NullObject().hash_bin() == hash((NullObject,))
     assert hash(NullObject()) == NullObject().hash_bin()


### PR DESCRIPTION
Part of #3468.

## Problem

If an inline image (`BI` ... `ID` ... `EI`) is the last thing in a content stream and its `EI` marker sits at the very end with no trailing whitespace or operator, parsing raises a `PdfReadError`:

```python
from pypdf.generic import ContentStream, DecodedStreamObject

data = b"q 100 0 0 100 100 100 cm\nBI\n/W 4 /H 4 /CS /G\nID\nabcdefghijklmnop\nEI"
ec = DecodedStreamObject()
ec.set_data(data)
ContentStream(ec, None).operations   # PdfReadError: Unexpected end of stream
```

Adding a trailing newline or a following operator (e.g. `Q`) makes the same image parse fine, so the marker itself is being detected correctly — the failure is purely in how the end of stream is handled right after `EI`.

Two spots assume at least one more byte always follows `EI`:

- In `_read_inline_image`, `stream.read(3)` returns only two bytes at end of stream, so the unconditional `stream.seek(-1, 1)` steps back *into* the marker, and the check `ei[2:3] not in WHITESPACES` treats the empty trailing byte as a malformed marker and drops into the fallback path.
- `extract_inline_default` reads the byte after `EI` and, when it is empty (end of stream), treats it as "not whitespace", rejects the match and keeps reading until it runs out of data.

This was reported in #3468 (second case in the thread); the maintainer noted it is a separate, more tractable issue and invited a PR.

## Fix

Treat `EI` at end of stream as a valid image end in both places. This is unambiguous: nothing can follow it, so it cannot be an `EI` byte sequence embedded in binary image data. `_check_end_image_marker` already accepts the end-of-stream case the same way, so this just makes the other two code paths consistent. The one-byte rewind in `_read_inline_image` is now only done when a third byte was actually read.

## Tests

Added `test_inline_image_at_end_of_stream`, which parses an inline image whose `EI` is the last token (and, for good measure, the same image followed by a newline and by `Q`) and checks the image data is recovered. It fails on the current code (`PdfReadError`) and passes with the fix. The existing `tests/test_generic.py` suite stays green.

## AI use disclosure

Per the project's AI policy: I used AI coding assistance while preparing this PR. Tool: Claude Code. Model: Claude Opus 4.8 (`claude-opus-4-8`). I've reviewed, run, and verified the change myself and take responsibility for it; the PR text and my replies in this thread are written in my own words.