### PR TITLE
ROB: Skip truncated bfrange and bfchar lines in process_cm_line

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -1,4 +1,3 @@
-import binascii
 from binascii import Error as BinasciiError
 from binascii import unhexlify
 from math import ceil
@@ -218,10 +217,13 @@ def process_cm_line(
     elif process_rg:
         try:
             multiline_rg = parse_bfrange(line, map_dict, int_entry, multiline_rg)
-        except binascii.Error as error:
+        except (ValueError, IndexError) as error:
             logger_warning("Skipping broken line %(line)r: %(error)s", source=__name__, line=line, error=error)
     elif process_char:
-        parse_bfchar(line, map_dict, int_entry)
+        try:
+            parse_bfchar(line, map_dict, int_entry)
+        except (ValueError, IndexError) as error:
+            logger_warning("Skipping broken line %(line)r: %(error)s", source=__name__, line=line, error=error)
     return process_rg, process_char, multiline_rg
 
 

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -431,6 +431,40 @@ def test_parse_bfrange__iteration_limit():
     assert map_dict == {-1: 1, "\x01": "�", "\x02": "�", "\x03": "�", "\x04": "\uffff", "\x05": "ﾫ"}
 
 
+def test_parse_to_unicode_skips_truncated_lines(caplog):
+    """A truncated bfrange or malformed bfchar line must not crash extraction."""
+    writer = PdfWriter()
+
+    to_unicode = StreamObject()
+    to_unicode.set_data(
+        b"beginbfrange\n"
+        b"<0001> <0005>\n"  # missing destination token
+        b"endbfrange\n"
+        b"beginbfchar\n"
+        b"<0001> <0041>\n"  # valid
+        b"zz <0042>\n"  # non-hex source
+        b"endbfchar\n"
+    )
+    font = writer._add_object(DictionaryObject({
+        NameObject("/Type"): NameObject("/Font"),
+        NameObject("/Subtype"): NameObject("/Type1"),
+        NameObject("/BaseFont"): NameObject("/Helvetica"),
+        NameObject("/ToUnicode"): to_unicode,
+    }))
+
+    page = writer.add_blank_page(width=100, height=100)
+    page[NameObject("/Resources")] = DictionaryObject({
+        NameObject("/Font"): DictionaryObject({
+            NameObject("/F1"): font.indirect_reference,
+        })
+    })
+
+    # No exception, broken lines reported.
+    page.extract_text()
+    assert "Skipping broken line b'0001   0005': list index out of range" in caplog.text
+    assert "Skipping broken line b'zz  0042': Non-hexadecimal digit found" in caplog.text
+
+
 def test_parse_bfchar__iteration_limit():
     int_entry = [0] * 99_995
     map_dict = {}


### PR DESCRIPTION
**Truncated /ToUnicode lines crash text extraction**
A beginbfrange line with fewer than three tokens makes parse_bfrange read past the split list, and a beginbfchar line with a non-hex source token raises out of parse_bfchar. The bfrange call only caught binascii.Error and the bfchar call caught nothing, so a crafted /ToUnicode CMap takes down extract_text on the page. Widened both to skip the broken line and warn, same as the existing handling. LimitReachedError is a PyPdfError not a ValueError so the mapping size cap still propagates.