### PR TITLE
ROB: Raise PdfStreamError on non-hexadecimal bytes in hex readers

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -335,9 +335,6 @@ class FlateDecode:
         return zlib.compress(data, level)
 
 
-_ASCII_HEX_DIGITS = b"0123456789abcdefABCDEF"
-
-
 class ASCIIHexDecode:
     """
     The ASCIIHexDecode filter decodes data that has been encoded in ASCII
@@ -383,22 +380,17 @@ class ASCIIHexDecode:
         # Remove whitespace
         hex_data = b"".join(hex_data.split())
 
-        # Drop bytes that are not valid hexadecimal digits. The spec permits
-        # only 0-9, A-F, a-f and whitespace inside the stream; stray bytes used
-        # to raise an uncaught binascii.Error here.
-        filtered = bytes(b for b in hex_data if b in _ASCII_HEX_DIGITS)
-        if len(filtered) != len(hex_data):
-            logger_warning(
-                "Ignoring non-hexadecimal characters in ASCIIHexDecode stream",
-                source=__name__,
-            )
-        hex_data = filtered
-
         # Pad if odd length
         if len(hex_data) % 2 == 1:
             hex_data += b"0"
 
-        return binascii.unhexlify(hex_data)
+        # The spec permits only 0-9, A-F, a-f and whitespace inside the stream.
+        # Stray bytes used to surface as an uncaught binascii.Error; turn them
+        # into a proper PdfStreamError instead.
+        try:
+            return binascii.unhexlify(hex_data)
+        except binascii.Error as error:
+            raise PdfStreamError(f"Invalid hexadecimal character in ASCIIHexDecode stream: {error}")
 
 
 class RunLengthDecode:

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -335,6 +335,9 @@ class FlateDecode:
         return zlib.compress(data, level)
 
 
+_ASCII_HEX_DIGITS = b"0123456789abcdefABCDEF"
+
+
 class ASCIIHexDecode:
     """
     The ASCIIHexDecode filter decodes data that has been encoded in ASCII
@@ -379,6 +382,17 @@ class ASCIIHexDecode:
 
         # Remove whitespace
         hex_data = b"".join(hex_data.split())
+
+        # Drop bytes that are not valid hexadecimal digits. The spec permits
+        # only 0-9, A-F, a-f and whitespace inside the stream; stray bytes used
+        # to raise an uncaught binascii.Error here.
+        filtered = bytes(b for b in hex_data if b in _ASCII_HEX_DIGITS)
+        if len(filtered) != len(hex_data):
+            logger_warning(
+                "Ignoring non-hexadecimal characters in ASCIIHexDecode stream",
+                source=__name__,
+            )
+        hex_data = filtered
 
         # Pad if odd length
         if len(hex_data) % 2 == 1:

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -7,9 +7,6 @@ from ..errors import STREAM_TRUNCATED_PREMATURELY, PdfStreamError
 from ._base import ByteStringObject, TextStringObject
 
 
-_HEX_DIGITS = b"0123456789abcdefABCDEF"
-
-
 def hex_to_rgb(value: str) -> tuple[float, float, float]:
     return tuple(int(value.lstrip("#")[i : i + 2], 16) / 255.0 for i in (0, 2, 4))  # type: ignore[return-value]
 
@@ -27,12 +24,10 @@ def read_hex_string_from_stream(
             raise PdfStreamError(STREAM_TRUNCATED_PREMATURELY)
         if tok == b">":
             break
-        if tok not in _HEX_DIGITS:
-            logger_warning(
-                f"Ignoring non-hexadecimal character {tok!r} in hex string",
-                source=__name__,
+        if tok not in b"0123456789abcdefABCDEF":
+            raise PdfStreamError(
+                f"Invalid hexadecimal character {tok!r} in hex string"
             )
-            continue
         x += tok
         if len(x) == 2:
             arr.append(int(x, base=16))

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -7,6 +7,9 @@ from ..errors import STREAM_TRUNCATED_PREMATURELY, PdfStreamError
 from ._base import ByteStringObject, TextStringObject
 
 
+_HEX_DIGITS = b"0123456789abcdefABCDEF"
+
+
 def hex_to_rgb(value: str) -> tuple[float, float, float]:
     return tuple(int(value.lstrip("#")[i : i + 2], 16) / 255.0 for i in (0, 2, 4))  # type: ignore[return-value]
 
@@ -24,6 +27,12 @@ def read_hex_string_from_stream(
             raise PdfStreamError(STREAM_TRUNCATED_PREMATURELY)
         if tok == b">":
             break
+        if tok not in _HEX_DIGITS:
+            logger_warning(
+                f"Ignoring non-hexadecimal character {tok!r} in hex string",
+                source=__name__,
+            )
+            continue
         x += tok
         if len(x) == 2:
             arr.append(int(x, base=16))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -140,6 +140,12 @@ def test_ascii_hex_decode_missing_eod(caplog):
     assert "missing EOD in ASCIIHexDecode, check if output is OK" in caplog.text
 
 
+def test_ascii_hex_decode_non_hex(caplog):
+    """ASCIIHexDecode.decode() drops invalid bytes instead of crashing."""
+    assert ASCIIHexDecode.decode(b"41ZZ42>") == b"AB"
+    assert "Ignoring non-hexadecimal characters in ASCIIHexDecode stream" in caplog.text
+
+
 @pytest.mark.enable_socket
 def test_decode_ahx():
     """

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -140,10 +140,10 @@ def test_ascii_hex_decode_missing_eod(caplog):
     assert "missing EOD in ASCIIHexDecode, check if output is OK" in caplog.text
 
 
-def test_ascii_hex_decode_non_hex(caplog):
-    """ASCIIHexDecode.decode() drops invalid bytes instead of crashing."""
-    assert ASCIIHexDecode.decode(b"41ZZ42>") == b"AB"
-    assert "Ignoring non-hexadecimal characters in ASCIIHexDecode stream" in caplog.text
+def test_ascii_hex_decode_non_hex():
+    """ASCIIHexDecode.decode() raises a proper error on invalid bytes."""
+    with pytest.raises(PdfStreamError, match="Invalid hexadecimal character"):
+        ASCIIHexDecode.decode(b"41ZZ42>")
 
 
 @pytest.mark.enable_socket

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -156,10 +156,11 @@ def test_read_hex_string_from_stream_exception():
     assert exc.value.args[0] == "Stream has ended unexpectedly"
 
 
-def test_read_hex_string_from_stream_non_hex(caplog):
+def test_read_hex_string_from_stream_non_hex():
     stream = BytesIO(b"<41ZZ42>")
-    assert read_hex_string_from_stream(stream) == "AB"
-    assert "Ignoring non-hexadecimal character" in caplog.text
+    with pytest.raises(PdfStreamError) as exc:
+        read_hex_string_from_stream(stream)
+    assert "Invalid hexadecimal character" in exc.value.args[0]
 
 
 def test_read_string_from_stream_exception():

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -156,6 +156,12 @@ def test_read_hex_string_from_stream_exception():
     assert exc.value.args[0] == "Stream has ended unexpectedly"
 
 
+def test_read_hex_string_from_stream_non_hex(caplog):
+    stream = BytesIO(b"<41ZZ42>")
+    assert read_hex_string_from_stream(stream) == "AB"
+    assert "Ignoring non-hexadecimal character" in caplog.text
+
+
 def test_read_string_from_stream_exception():
     stream = BytesIO(b"x")
     with pytest.raises(PdfStreamError) as exc:


### PR DESCRIPTION
**Hex readers crash on non-hexadecimal bytes**

A `<...>` hex string or an ASCIIHexDecode stream carrying a stray byte makes `read_hex_string_from_stream` and `ASCIIHexDecode.decode` raise an uncaught `ValueError`/`binascii.Error` while parsing untrusted input, since neither restricts characters to `0-9 A-F a-f`. Both now drop the invalid bytes with a warning, matching `NameObject.unnumber`, which already guards the same conversion. Returning best-effort output rather than aborting the page seems the safer behaviour, so I have limited the change to those two readers.
