### PR TITLE
MAINT: Remove unreachable return in read_until_regex

### DIFF
--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -280,7 +280,6 @@ def read_until_regex(stream: StreamType, regex: Pattern[bytes]) -> bytes:
         tail = tok[-16:]
         if chunk_size < 8192:
             chunk_size <<= 1
-    return b"".join(parts)
 
 
 def read_block_backwards(stream: BinaryStreamType, to_read: int) -> bytes:


### PR DESCRIPTION
## Summary

Closes #3828.

The final `return b"".join(parts)` after the `while True` loop in `read_until_regex()` is unreachable. The loop has no `break`; it can only be exited through the two `return` statements inside it:

- EOF: `if not tok: return b"".join(parts)`
- regex match: `if m is not None: ... return b"".join(parts)[:actual_start]`

Every other path falls through to the next iteration, so control never reaches the trailing statement. This removes the dead line.

As @stefan6419846 noted in the issue, it can be removed.

## Test plan

- No behaviour change (only an unreachable statement is removed).
- `pytest tests/test_utils.py` — 111 passed (incl. the `read_until_regex` boundary/EOF/match tests).
- `ruff check pypdf/_utils.py` — clean.
- `mypy pypdf/_utils.py` — clean (the function still type-checks; `while True` with returns is exhaustive).
