### PR TITLE
ROB: Guard truncated Type1 font program in _type1_alternative

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -344,12 +344,15 @@ def _type1_alternative(
     assert ft_desc is not None, "mypy"
     txt = ft_desc.get_object().get_data()
     txt = txt.split(b"eexec\n")[0]  # only clear part
-    txt = txt.split(b"/Encoding")[1]  # to get the encoding part
+    encoding_part = txt.split(b"/Encoding")
+    if len(encoding_part) < 2:
+        return map_dict, int_entry
+    txt = encoding_part[1]  # to get the encoding part
     lines = txt.replace(b"\r", b"\n").split(b"\n")
     for li in lines:
         if li.startswith(b"dup"):
             words = [_w for _w in li.split(b" ") if _w != b""]
-            if len(words) > 3 and words[3] != b"put":
+            if len(words) < 3 or (len(words) > 3 and words[3] != b"put"):
                 continue
             try:
                 i = int(words[1])

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -344,6 +344,32 @@ def test_get_encoding__encoding_value_is_none():
     )
 
 
+def _type1_font(font_file_data: bytes) -> DictionaryObject:
+    font_file = DecodedStreamObject()
+    font_file.set_data(font_file_data)
+    font_descriptor = DictionaryObject()
+    font_descriptor[NameObject("/FontFile")] = font_file
+    ft = DictionaryObject()
+    ft[NameObject("/Subtype")] = NameObject("/Type1")
+    ft[NameObject("/FontDescriptor")] = font_descriptor
+    return ft
+
+
+def test_get_encoding__type1_font_file_without_encoding():
+    # Clear part of the embedded Type1 program has no /Encoding section.
+    ft = _type1_font(b"%!PS-AdobeFont\n/FontName /Foo def\neexec\nbinary")
+    assert get_encoding(ft) == ("charmap", {})
+
+
+def test_get_encoding__type1_font_file_truncated_dup_line():
+    # A "dup" entry missing the glyph name must be skipped, not crash.
+    ft = _type1_font(
+        b"/Encoding 256 array\ndup\ndup 65\ndup 97 /a put\nreadonly def\neexec\n"
+    )
+    _encoding, character_map = get_encoding(ft)
+    assert character_map == {"a": "a"}
+
+
 def test_parse_bfchar(caplog):
     map_dict = {}
     int_entry = []


### PR DESCRIPTION
_type1_alternative recovers a type1 font's /encoding from the clear part of its embedded program, but it split on /encoding and indexed [1] unconditionally, so a /fontfile whose decoded bytes carry no /encoding section raised an uncaught indexerror. it also read words[1] and words[2] of each dup line without checking the token count, so a bare 'dup' or 'dup 65' did the same (only the int() valueerror was handled). this is reachable from page.extract_text on a /type1 font without /tounicode, and from_font_resource only catches attributeerror/typeerror, so the crash propagates out of extraction. fix returns early when there is no /encoding section and skips dup lines with fewer than three tokens, in line with the skip-and-continue the function already does for unparseable entries.