### PR TITLE
ROB: Bound /W width look-ahead in _collect_cid_character_widths

### DIFF
--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -152,7 +152,9 @@ class Font:
         #   (2) A character start index, a character stop index, and a width, e.g.
         #       `45 65 500` applies width 500 to characters 45-65.
         skip_count = 0
-        _w = d_font.get("/W", [])
+        # /W may be stored as an indirect reference; resolve it so the
+        # bounds checks below can call len() on the actual array.
+        _w = d_font.get("/W", ArrayObject()).get_object()
         for idx, w_entry in enumerate(_w):
             w_entry = w_entry.get_object()
             if skip_count:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -168,7 +168,7 @@ class Font:
                 )
                 continue
             # check for format (1): `int [int int int int ...]`
-            w_next_entry = _w[idx + 1].get_object()
+            w_next_entry = _w[idx + 1].get_object() if idx + 1 < len(_w) else None
             if isinstance(w_next_entry, Sequence):
                 start_idx, width_list = w_entry, w_next_entry
                 current_widths.update(
@@ -186,8 +186,10 @@ class Font:
                 )
                 skip_count = 1
             # check for format (2): `int int int`
-            elif isinstance(w_next_entry, (int, float)) and isinstance(
-                _w[idx + 2].get_object(), (int, float)
+            elif (
+                isinstance(w_next_entry, (int, float))
+                and idx + 2 < len(_w)
+                and isinstance(_w[idx + 2].get_object(), (int, float))
             ):
                 start_idx, stop_idx, const_width = (
                     w_entry,

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -152,9 +152,8 @@ class Font:
         #   (2) A character start index, a character stop index, and a width, e.g.
         #       `45 65 500` applies width 500 to characters 45-65.
         skip_count = 0
-        # /W may be stored as an indirect reference; resolve it so the
-        # bounds checks below can call len() on the actual array.
         _w = d_font.get("/W", ArrayObject()).get_object()
+        _w_length = len(_w)
         for idx, w_entry in enumerate(_w):
             w_entry = w_entry.get_object()
             if skip_count:
@@ -170,7 +169,7 @@ class Font:
                 )
                 continue
             # check for format (1): `int [int int int int ...]`
-            w_next_entry = _w[idx + 1].get_object() if idx + 1 < len(_w) else None
+            w_next_entry = _w[idx + 1].get_object() if idx + 1 < _w_length else None
             if isinstance(w_next_entry, Sequence):
                 start_idx, width_list = w_entry, w_next_entry
                 current_widths.update(
@@ -190,7 +189,7 @@ class Font:
             # check for format (2): `int int int`
             elif (
                 isinstance(w_next_entry, (int, float))
-                and idx + 2 < len(_w)
+                and idx + 2 < _w_length
                 and isinstance(_w[idx + 2].get_object(), (int, float))
             ):
                 start_idx, stop_idx, const_width = (

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -10,7 +10,13 @@ from fontTools.ttLib import TTFont
 from pypdf import PdfReader
 from pypdf._font import Font
 from pypdf.errors import PdfReadError
-from pypdf.generic import DictionaryObject, EncodedStreamObject, NameObject
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    EncodedStreamObject,
+    NameObject,
+    NumberObject,
+)
 
 from . import RESOURCE_ROOT
 
@@ -54,6 +60,21 @@ def test_font_descriptor():
         "/CapHeight": 562,
         "/XHeight": 439
     }
+
+
+@pytest.mark.parametrize("w_array", [[45], [45, 65]])
+def test_collect_cid_character_widths_truncated_w(w_array):
+    # A /W array that ends mid-entry must not read past its bounds.
+    d_font = DictionaryObject({
+        NameObject("/Subtype"): NameObject("/CIDFontType2"),
+        NameObject("/W"): ArrayObject(NumberObject(v) for v in w_array),
+    })
+    font_res = DictionaryObject({
+        NameObject("/Subtype"): NameObject("/Type0"),
+        NameObject("/BaseFont"): NameObject("/Foo"),
+        NameObject("/DescendantFonts"): ArrayObject([d_font]),
+    })
+    Font.from_font_resource(font_res)
 
 
 def test_font_file():


### PR DESCRIPTION
**Out-of-bounds /W look-ahead in CID font parsing**

A CID font's /W array interleaves `start [w w w]` and `start stop width` entries, so for every numeric entry the parser reads ahead at `_w[idx + 1]` (and `_w[idx + 2]`) without bounding those indices. A /W array that ends mid-entry — a trailing lone number, or a trailing `start stop` pair with the width missing — therefore raises IndexError; the trailing `else` was meant to cover truncation but only fires when the next element is present with the wrong type, never when the index itself runs off the end. This sits on untrusted font bytes during `extract_text` (via `Font.from_font_resource`, which only catches `AttributeError`/`TypeError`), so a crafted document aborts extraction. Returning `None` for an out-of-range look-ahead lets a truncated entry fall through to the existing "Invalid font width definition" warning, which seems the tidier fit with the surrounding skip-and-warn handling.