### PR TITLE
ROB: Fix UnboundLocalError in _read_standard_xref_table

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -970,6 +970,7 @@ class PdfReader(PdfDocCommon):
                         )
                         generation = int(f.group(1))
                         offset = f.start()
+                        entry_type_b = b"n"
 
                 if generation not in self.xref:
                     self.xref[generation] = {}

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2022,6 +2022,32 @@ def test_read_standard_xref_table__two_whitespace_characters_between_offset_and_
     assert reader.pages[0].extract_text() == "Hello World!"
 
 
+def test_read_standard_xref_table__entry_invalid_but_object_found(caplog):
+    """Tests for #3841"""
+    body = (
+        b"%PDF-1.7\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+    )
+    xref_offset = len(body)
+    corrupt_entry = b"xxxxxxxxxxxxxxxx 0\r\n"
+    assert len(corrupt_entry) == 20
+    data = body + (
+        b"xref\n1 3\n"
+        + corrupt_entry
+        + b"%010d 00000 n\r\n" % body.index(b"2 0 obj")
+        + b"%010d 00000 n\r\n" % body.index(b"3 0 obj")
+        + b"trailer\n<< /Size 4 /Root 1 0 R >>\nstartxref\n"
+        + b"%d" % xref_offset
+        + b"\n%%EOF"
+    )
+
+    reader = PdfReader(BytesIO(data))
+    assert len(reader.pages) == 1
+    assert "entry 1 in Xref table invalid but object found" in caplog.text
+
+
 @pytest.mark.enable_socket
 def test_root_object_recovery_limit(caplog):
     url = "https://github.com/user-attachments/files/24525509/root_object_recovery_limit.pdf"


### PR DESCRIPTION
Fixes #3840.
  
  ### Problem
  A malformed standard cross-reference entry whose object is still present in the body takes the "object found" recovery branch in `_read_standard_xref_table`. That branch set `generation` and `offset` but
  never assigned `entry_type_b`, so the following `if entry_type_b == b"n":` raised `UnboundLocalError` instead of recovering (whenever the branch runs before `entry_type_b` is assigned, e.g. the first entry).
  
  ### Fix
  The recovered object exists in the body, so it is an in-use entry: assign `entry_type_b = b"n"`, mirroring the sibling "object not found" branch which sets `b"f"`.
  
  ### Test
  Added `test_read_standard_xref_table__entry_invalid_but_object_found` — a self-contained (no network) PDF with one corrupted xref entry whose object is recoverable from the body. It reproduces the
  `UnboundLocalError` before the fix and loads the page (and logs the existing recovery warning) after. Existing reader tests pass. 