### PR TITLE
ROB: Tolerate unknown inline image keys in _get_inline_images

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -764,7 +764,15 @@ class PageObject(DictionaryObject):
                     )
                 else:
                     v = self._translate_value_inline_image(k, v)
-                k = NameObject(_INLINE_IMAGE_KEY_MAPPING.get(k, k))
+                if k in _INLINE_IMAGE_KEY_MAPPING:
+                    k = NameObject(_INLINE_IMAGE_KEY_MAPPING[k])
+                else:
+                    logger_warning(
+                        "Unknown inline image key %(key)s, keeping it as-is.",
+                        source=__name__,
+                        key=k,
+                    )
+                    k = NameObject(k)
                 if k not in init:
                     init[k] = v
             ii["object"] = EncodedStreamObject.initialize_from_dictionary(init)

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -764,7 +764,7 @@ class PageObject(DictionaryObject):
                     )
                 else:
                     v = self._translate_value_inline_image(k, v)
-                k = NameObject(_INLINE_IMAGE_KEY_MAPPING[k])
+                k = NameObject(_INLINE_IMAGE_KEY_MAPPING.get(k, k))
                 if k not in init:
                     init[k] = v
             ii["object"] = EncodedStreamObject.initialize_from_dictionary(init)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -17,7 +17,7 @@ from PIL import Image, ImageChops, ImageDraw
 from pypdf import PageObject, PdfReader, PdfWriter
 from pypdf.errors import LimitReachedError
 from pypdf.filters import JBIG2Decode
-from pypdf.generic import ContentStream, NameObject, NullObject
+from pypdf.generic import ContentStream, DecodedStreamObject, NameObject, NullObject
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
 from .utils import get_image_data
@@ -243,6 +243,34 @@ def test_get_inline_image_without_xobject_resources_raises_when_missing():
         pytest.raises(KeyError, match="No inline image can be found"),
     ):
         page._get_image("~0~")
+
+
+def test_inline_image_with_unknown_key():
+    """
+    An inline image carrying a key outside the abbreviation map must not
+    crash image extraction (cf. _get_inline_images).
+    """
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=200, height=200)
+    # 2x2 RGB image with a non-standard `/Foo` key that is absent from
+    # _INLINE_IMAGE_KEY_MAPPING. A numeric value keeps value translation from
+    # bailing out first so the key lookup is reached.
+    content = (
+        b"q 20 0 0 20 0 0 cm "
+        b"BI /W 2 /H 2 /CS /RGB /BPC 8 /Foo 1 ID " + b"\x00" * 12 + b" EI Q"
+    )
+    stream = DecodedStreamObject()
+    stream.set_data(content)
+    page[NameObject("/Contents")] = writer._add_object(stream)
+
+    buffer = BytesIO()
+    writer.write(buffer)
+    buffer.seek(0)
+
+    reader = PdfReader(buffer)
+    images = reader.pages[0].images
+    assert len(images) == 1
+    assert images[0].image is not None
 
 
 def test_get_xobject_image_without_xobject_resources_raises():

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -17,7 +17,7 @@ from PIL import Image, ImageChops, ImageDraw
 from pypdf import PageObject, PdfReader, PdfWriter
 from pypdf.errors import LimitReachedError
 from pypdf.filters import JBIG2Decode
-from pypdf.generic import ContentStream, DecodedStreamObject, NameObject, NullObject
+from pypdf.generic import ContentStream, NameObject, NullObject
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
 from .utils import get_image_data
@@ -245,7 +245,7 @@ def test_get_inline_image_without_xobject_resources_raises_when_missing():
         page._get_image("~0~")
 
 
-def test_inline_image_with_unknown_key():
+def test_inline_image_with_unknown_key(caplog):
     """
     An inline image carrying a key outside the abbreviation map must not
     crash image extraction (cf. _get_inline_images).
@@ -259,9 +259,9 @@ def test_inline_image_with_unknown_key():
         b"q 20 0 0 20 0 0 cm "
         b"BI /W 2 /H 2 /CS /RGB /BPC 8 /Foo 1 ID " + b"\x00" * 12 + b" EI Q"
     )
-    stream = DecodedStreamObject()
+    stream = ContentStream(stream=None, pdf=writer)
     stream.set_data(content)
-    page[NameObject("/Contents")] = writer._add_object(stream)
+    page.replace_contents(stream)
 
     buffer = BytesIO()
     writer.write(buffer)
@@ -271,6 +271,7 @@ def test_inline_image_with_unknown_key():
     images = reader.pages[0].images
     assert len(images) == 1
     assert images[0].image is not None
+    assert "Unknown inline image key /Foo" in caplog.text
 
 
 def test_get_xobject_image_without_xobject_resources_raises():

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -248,7 +248,7 @@ def test_get_inline_image_without_xobject_resources_raises_when_missing():
 def test_inline_image_with_unknown_key(caplog):
     """
     An inline image carrying a key outside the abbreviation map must not
-    crash image extraction (cf. _get_inline_images).
+    crash image extraction.
     """
     writer = PdfWriter()
     page = writer.add_blank_page(width=200, height=200)


### PR DESCRIPTION
**KeyError on unrecognised inline image keys**

`_get_inline_images` maps every inline image key through `_INLINE_IMAGE_KEY_MAPPING` with a direct lookup, so a `BI ... ID ... EI` block carrying any key outside that abbreviation table aborts `page.images` with an uncaught `KeyError` on untrusted content. The value side already tolerates unmapped entries, so I have kept the original key when it is absent from the table, which leaves the known abbreviations behaving exactly as before.