### PR TITLE
ROB: guard zero unitsPerEm in from_truetype_font_file

### DIFF
--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -470,6 +470,8 @@ class Font:
 
             # Get the scaling factor to convert font file's units per em to PDF's 1000 units per em
             units_per_em = header.unitsPerEm
+            if not units_per_em:
+                raise PdfReadError("Font file has an invalid unitsPerEm of 0")
             scale_factor = 1000.0 / units_per_em
 
             # Get the font descriptor

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -112,6 +112,19 @@ def test_font_from_font_file():
                     Font.from_truetype_font_file(crippled_font_data)
 
 
+def test_font_from_font_file_zero_units_per_em():
+    reader = PdfReader(RESOURCE_ROOT / "fontsampler.pdf")
+    font_resource = reader.pages[0]["/Resources"]["/Font"]["/F1"]
+    font_data = font_resource["/DescendantFonts"][0]["/FontDescriptor"]["/FontFile2"].get_data()
+    crippled_font_data = BytesIO()
+    with TTFont(BytesIO(font_data)) as tt_font_object:
+        tt_font_object["head"].unitsPerEm = 0
+        tt_font_object.save(crippled_font_data)
+    crippled_font_data.seek(0)
+    with pytest.raises(PdfReadError, match=r"invalid unitsPerEm"):
+        Font.from_truetype_font_file(crippled_font_data)
+
+
 def test_font_from_font_file_no_fonttools(tmp_path):
     env = os.environ.copy()
     env["COVERAGE_PROCESS_START"] = "pyproject.toml"


### PR DESCRIPTION
**Division by zero on a malformed unitsPerEm**

`from_truetype_font_file` reads `unitsPerEm` from the embedded TrueType `head` table and divides 1000 by it, so a font whose table carries a `unitsPerEm` of 0 raises an unhandled `ZeroDivisionError`. The bytes are attacker-controlled: the appearance-stream generator parses the embedded font here when a form value cannot be encoded, and that caller only catches `ImportError`/`PdfReadError`. Raising `PdfReadError` for a zero value keeps the malformed-font handling in one place, matching the existing missing-cmap guard so the caller falls back cleanly. Added a regression test alongside the other crippled-font cases.
