### PR TITLE
SEC: Detect multi-hop cyclic /Pages trees in _flatten to prevent SIGSEGV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Version 6.14.0, 2026-XX-XX
+
+### Security (SEC)
+- Detect multi-hop cyclic /Pages trees in `_flatten` to prevent SIGSEGV (#XXXX)
+
 ## Version 6.13.1, 2026-06-08
 
 ### Security (SEC)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # CHANGELOG
 
-## Version 6.14.0, 2026-XX-XX
-
-### Security (SEC)
-- Detect multi-hop cyclic /Pages trees in `_flatten` to prevent SIGSEGV (#XXXX)
-
 ## Version 6.13.1, 2026-06-08
 
 ### Security (SEC)

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1157,6 +1157,7 @@ class PdfDocCommon(ABC):
         pages: Union[None, DictionaryObject, PageObject] = None,
         inherit: Optional[dict[str, Any]] = None,
         indirect_reference: Optional[IndirectObject] = None,
+        _seen_refs: Optional[set] = None,
     ) -> None:
         """
         Process the document pages to ease searching.
@@ -1175,6 +1176,9 @@ class PdfDocCommon(ABC):
             pages:
             inherit:
             indirect_reference: Used recursively to flatten the /Pages object.
+            _seen_refs: Set of indirect-reference idnum/generation pairs already
+                visited while traversing /Pages nodes. Detects multi-hop cycles
+                such as A→B→C→A that the single-parent check misses.
 
         """
         inheritable_page_attributes = (
@@ -1185,6 +1189,8 @@ class PdfDocCommon(ABC):
         )
         if inherit is None:
             inherit = {}
+        if _seen_refs is None:
+            _seen_refs = set()
         if is_null_or_none(pages):
             # Fix issue 327: set flattened_pages attribute only for
             # decrypted file
@@ -1225,12 +1231,13 @@ class PdfDocCommon(ABC):
                 obj = page.get_object()
                 if obj:
                     # damaged file may have invalid child in /Pages
-                    try:
-                        self._flatten(list_only, obj, inherit, **addt)
-                    except RecursionError:
-                        raise PdfReadError(
-                            "Maximum recursion depth reached during page flattening."
-                        )
+                    ref = getattr(obj, "indirect_reference", None)
+                    ref_key = (ref.idnum, ref.generation) if ref is not None else None
+                    if ref_key is not None:
+                        if ref_key in _seen_refs:
+                            raise PdfReadError("Detected cyclic page references.")
+                        _seen_refs.add(ref_key)
+                    self._flatten(list_only, obj, inherit, _seen_refs=_seen_refs, **addt)
         elif t == "/Page":
             for attr_in, value in inherit.items():
                 # if the page has its own value, it does not inherit the

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1157,7 +1157,7 @@ class PdfDocCommon(ABC):
         pages: Union[None, DictionaryObject, PageObject] = None,
         inherit: Optional[dict[str, Any]] = None,
         indirect_reference: Optional[IndirectObject] = None,
-        _seen_refs: Optional[set] = None,
+        _seen_refs: Optional[set[tuple[int, int]]] = None,
     ) -> None:
         """
         Process the document pages to ease searching.

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1157,7 +1157,7 @@ class PdfDocCommon(ABC):
         pages: Union[None, DictionaryObject, PageObject] = None,
         inherit: Optional[dict[str, Any]] = None,
         indirect_reference: Optional[IndirectObject] = None,
-        _seen_refs: Optional[set[tuple[int, int]]] = None,
+        visited: Optional[set[int]] = None,
     ) -> None:
         """
         Process the document pages to ease searching.
@@ -1176,9 +1176,9 @@ class PdfDocCommon(ABC):
             pages:
             inherit:
             indirect_reference: Used recursively to flatten the /Pages object.
-            _seen_refs: Set of indirect-reference idnum/generation pairs already
-                visited while traversing /Pages nodes. Detects multi-hop cycles
-                such as A→B→C→A that the single-parent check misses.
+            visited: Set of id() values of /Pages nodes already visited during
+                traversal. Detects multi-hop cycles such as A→B→C→A that the
+                single-parent check misses.
 
         """
         inheritable_page_attributes = (
@@ -1189,8 +1189,8 @@ class PdfDocCommon(ABC):
         )
         if inherit is None:
             inherit = {}
-        if _seen_refs is None:
-            _seen_refs = set()
+        if visited is None:
+            visited = set()
         if is_null_or_none(pages):
             # Fix issue 327: set flattened_pages attribute only for
             # decrypted file
@@ -1231,13 +1231,11 @@ class PdfDocCommon(ABC):
                 obj = page.get_object()
                 if obj:
                     # damaged file may have invalid child in /Pages
-                    ref = getattr(obj, "indirect_reference", None)
-                    ref_key = (ref.idnum, ref.generation) if ref is not None else None
-                    if ref_key is not None:
-                        if ref_key in _seen_refs:
-                            raise PdfReadError("Detected cyclic page references.")
-                        _seen_refs.add(ref_key)
-                    self._flatten(list_only, obj, inherit, _seen_refs=_seen_refs, **addt)
+                    obj_id = id(obj)
+                    if obj_id in visited:
+                        raise PdfReadError("Detected cyclic page references.")
+                    visited.add(obj_id)
+                    self._flatten(list_only, obj, inherit, visited=visited, **addt)
         elif t == "/Page":
             for attr_in, value in inherit.items():
                 # if the page has its own value, it does not inherit the

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -684,6 +684,88 @@ def test_circular_xref_prev_reference(caplog):
     assert "Circular xref chain detected" in caplog.text
 
 
+def test_cyclic_pages_tree():
+    """Circular /Pages reference (multi-hop cycle) must raise PdfReadError, not recurse infinitely (#XXXX)."""
+    # Page tree: root /Pages (obj 2) -> /Pages obj 3 -> /Pages obj 4 -> /Pages obj 5 -> obj 3 (cycle)
+    # obj 6 is the only real /Page (reachable directly from root).
+    pdf_data = b"""%PDF-1.7
+
+1 0 obj
+  << /Type /Catalog
+     /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Pages
+     /Kids [6 0 R 3 0 R]
+     /Count 2
+     /MediaBox [0 0 595 842]
+  >>
+endobj
+
+3 0 obj
+  << /Type /Pages
+     /Kids [4 0 R]
+     /Count 1
+     /MediaBox [0 0 595 842]
+  >>
+endobj
+
+4 0 obj
+  << /Type /Pages
+     /Kids [5 0 R]
+     /Count 1
+     /MediaBox [0 0 595 842]
+  >>
+endobj
+
+5 0 obj
+  << /Type /Pages
+     /Kids [3 0 R]
+     /Count 1
+     /MediaBox [0 0 595 842]
+  >>
+endobj
+
+6 0 obj
+  << /Type /Page
+     /Parent 2 0 R
+     /Resources << /Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Courier >> >> >>
+     /Contents [7 0 R]
+  >>
+endobj
+
+7 0 obj
+  << /Length 44 >>
+stream
+  BT /F1 22 Tf 30 800 Td (Test) Tj ET
+endstream
+endobj
+
+xref
+0 8
+0000000000 65535 f\x20
+0000000010 00000 n\x20
+0000000069 00000 n\x20
+0000000176 00000 n\x20
+0000000277 00000 n\x20
+0000000378 00000 n\x20
+0000000479 00000 n\x20
+0000000744 00000 n\x20
+trailer
+  << /Root 1 0 R
+     /Size 8
+  >>
+startxref
+841
+%%EOF
+"""
+    with pytest.raises(PdfReadError, match="cyclic"):
+        reader = PdfReader(io.BytesIO(pdf_data), strict=False)
+        len(reader.pages)
+
+
 def test_read_missing_startxref():
     pdf_data = (
         b"%%PDF-1.7\n"
@@ -2410,7 +2492,7 @@ def test_get_object_from_stream__size_limit(caplog):
         _ = reader.pages[0]
     assert caplog.messages == []
 
-    with pytest.raises(PdfReadError, match=r"^Maximum recursion depth reached during page flattening\.$"):
+    with pytest.raises(PdfReadError, match=r"cyclic page references|Maximum recursion depth"):
         reader = PdfReader(BytesIO(pdf), strict=False)
         _ = reader.pages[0]
     assert caplog.messages == [

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -685,7 +685,7 @@ def test_circular_xref_prev_reference(caplog):
 
 
 def test_cyclic_pages_tree():
-    """Circular /Pages reference (multi-hop cycle) must raise PdfReadError, not recurse infinitely (#XXXX)."""
+    """Circular /Pages reference (multi-hop cycle) must raise PdfReadError, not recurse infinitely (#3847)."""
     # Page tree: root /Pages (obj 2) -> /Pages obj 3 -> /Pages obj 4 -> /Pages obj 5 -> obj 3 (cycle)
     # obj 6 is the only real /Page (reachable directly from root).
     pdf_data = b"""%PDF-1.7
@@ -761,7 +761,7 @@ startxref
 841
 %%EOF
 """
-    with pytest.raises(PdfReadError, match="cyclic"):
+    with pytest.raises(PdfReadError, match=r"^Detected cyclic page references\.$"):
         reader = PdfReader(io.BytesIO(pdf_data), strict=False)
         len(reader.pages)
 


### PR DESCRIPTION
## Summary

`_flatten()` only checked if a `/Pages` kid directly referenced its own parent node (the single-parent check on line 1219). This missed multi-hop cycles such as A → B → C → A, where no node is its own immediate child.

A malformed PDF with such a cycle causes `_flatten()` to recurse until Python's `RecursionError` is raised. In production environments with partially-consumed C stacks (e.g. gunicorn workers), the native stack overflows before Python can intercept the recursion, resulting in **SIGSEGV** and a dead worker process — not a catchable Python exception.

## Root cause

```
/Pages obj 2  →  /Kids [6 0 R, 3 0 R]
/Pages obj 3  →  /Kids [4 0 R]
/Pages obj 4  →  /Kids [5 0 R]
/Pages obj 5  →  /Kids [3 0 R]   ← cycle back to obj 3
```

`len(reader.pages)` on this PDF triggers the infinite recursion. The existing `except RecursionError` block is an unreliable backstop: it works in an isolated Python process but fails under a heavily-framed call stack.

## Fix

Add a `_seen_refs: set` parameter to `_flatten()` that accumulates the `(idnum, generation)` of every `/Pages` indirect reference visited during traversal. Any reference seen a second time raises `PdfReadError("Detected cyclic page references.")` immediately, without relying on Python's recursion limit.

## Test

`test_cyclic_pages_tree` constructs a minimal in-memory PDF reproducing the exact cycle above and asserts `PdfReadError` is raised when accessing `reader.pages`. The existing `test_get_object_from_stream__size_limit` test's match pattern was relaxed because that broken PDF also produces a cycle that is now detected earlier.

## Reproduction

```python
from pypdf import PdfReader

# PDF with /Pages loop: obj 3 → obj 4 → obj 5 → obj 3
pdf_bytes = open("page_loop.pdf", "rb").read()
reader = PdfReader(io.BytesIO(pdf_bytes), strict=False)
len(reader.pages)  # RecursionError / SIGSEGV before this fix
```