### PR TITLE
ROB: Tolerate malformed /Limits in index2label

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -193,11 +193,13 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
             kids = cast(list[DictionaryObject], number_tree["/Kids"])
             for kid in kids:
                 # kid = {'/Limits': [0, 63], '/Nums': [0, {'/P': 'C1'}, ...]}
-                limits = kid.get("/Limits")
-                if limits is not None:
-                    limits = limits.get_object()
+                limits = kid.get("/Limits", NullObject()).get_object()
                 if not isinstance(limits, list) or len(limits) < 2:
                     # Skip kids whose /Limits range is missing or malformed.
+                    logger_warning(
+                        "Ignoring kid with missing or malformed /Limits in /PageLabels.",
+                        source=__name__,
+                    )
                     continue
                 if limits[0] <= index <= limits[1]:
                     if not is_null_or_none(kid.get("/Kids", None)):

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -193,7 +193,12 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
             kids = cast(list[DictionaryObject], number_tree["/Kids"])
             for kid in kids:
                 # kid = {'/Limits': [0, 63], '/Nums': [0, {'/P': 'C1'}, ...]}
-                limits = cast(list[int], kid["/Limits"])
+                limits = kid.get("/Limits")
+                if limits is not None:
+                    limits = limits.get_object()
+                if not isinstance(limits, list) or len(limits) < 2:
+                    # Skip kids whose /Limits range is missing or malformed.
+                    continue
                 if limits[0] <= index <= limits[1]:
                     if not is_null_or_none(kid.get("/Kids", None)):
                         # Recursive definition.

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -216,4 +216,5 @@ def test_index2label__malformed_kid_limits(limits, caplog):
     reader.root_object[NameObject("/PageLabels")] = number_tree
 
     assert index2label(reader, 5) == "6"
+    assert "Ignoring kid with missing or malformed /Limits" in caplog.text
     assert "Could not reliably determine page label" in caplog.text

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -196,3 +196,24 @@ def test_index2label__empty_kids_list():
     root[NameObject("/PageLabels")] = number_tree
 
     assert index2label(reader, 42) == "43"
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        None,  # /Limits key entirely absent
+        ArrayObject([NumberObject(0)]),  # truncated to a single bound
+    ],
+)
+def test_index2label__malformed_kid_limits(limits, caplog):
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+    kid = DictionaryObject()
+    if limits is not None:
+        kid[NameObject("/Limits")] = limits
+    kid[NameObject("/Nums")] = ArrayObject([NumberObject(0), DictionaryObject()])
+    number_tree = DictionaryObject()
+    number_tree[NameObject("/Kids")] = ArrayObject([kid])
+    reader.root_object[NameObject("/PageLabels")] = number_tree
+
+    assert index2label(reader, 5) == "6"
+    assert "Could not reliably determine page label" in caplog.text


### PR DESCRIPTION
**Crash on a malformed /PageLabels kids tree**

While walking a `/Kids` number tree, `index2label` reads each kid's `/Limits` with a direct subscript, so a kid missing `/Limits` raises `KeyError` and a kid whose `/Limits` holds a single bound raises `IndexError` when `reader.page_labels` is read on an untrusted file. Skipping kids without a usable two-element range lets parsing fall through to the existing "could not reliably determine page label" fallback, which keeps the read path forgiving for partially broken documents.