### PR TITLE
ROB: raise PdfReadError for XMP without rdf:RDF root

### DIFF
--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -225,9 +225,12 @@ class XmpInformation(XmpInformationProtocol, PdfObject):
             doc_root: Document = _XmpBuilder().parseString(data)
         except (AttributeError, ExpatError) as e:
             raise PdfReadError(f"XML in XmpInformation was invalid: {e}")
-        self.rdf_root: XmlElement = doc_root.getElementsByTagNameNS(
-            RDF_NAMESPACE, "RDF"
-        )[0]
+        rdf_roots = doc_root.getElementsByTagNameNS(RDF_NAMESPACE, "RDF")
+        if not rdf_roots:
+            raise PdfReadError(
+                "XML in XmpInformation was invalid: missing rdf:RDF root element"
+            )
+        self.rdf_root: XmlElement = rdf_roots[0]
         self.cache: dict[Any, Any] = {}
 
     @classmethod

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -228,7 +228,7 @@ class XmpInformation(XmpInformationProtocol, PdfObject):
         rdf_roots = doc_root.getElementsByTagNameNS(RDF_NAMESPACE, "RDF")
         if not rdf_roots:
             raise PdfReadError(
-                "XML in XmpInformation was invalid: missing rdf:RDF root element"
+                "XML in XmpInformation was invalid: Missing rdf:RDF root element"
             )
         self.rdf_root: XmlElement = rdf_roots[0]
         self.cache: dict[Any, Any] = {}

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -267,6 +267,18 @@ def test_pdfa_xmp_metadata_without_values():
     assert xmp.pdfaid_conformance is None
 
 
+def test_xmp_information__missing_rdf_root():
+    """Well-formed XML without an rdf:RDF root raises PdfReadError, not IndexError."""
+    co = ContentStream(None, None)
+    co.set_data(
+        b'<?xml version="1.0"?>'
+        b'<x:xmpmeta xmlns:x="adobe:ns:meta/"><foo>bar</foo></x:xmpmeta>'
+    )
+    with pytest.raises(PdfReadError) as exc:
+        XmpInformation(co)
+    assert exc.value.args[0].startswith("XML in XmpInformation was invalid")
+
+
 @pytest.mark.enable_socket
 def test_xmp_metadata__content_stream_is_dictionary_object():
     url = "https://github.com/user-attachments/files/18943249/testing.pdf"


### PR DESCRIPTION
**Uncaught IndexError parsing XMP without an rdf:RDF root**

`XmpInformation.__init__` reads the RDF root with `getElementsByTagNameNS(RDF_NAMESPACE, "RDF")[0]`, so a `/Metadata` stream that is well-formed XML but carries no `rdf:RDF` element makes that subscript raise `IndexError` when `reader.xmp_metadata` is accessed on an untrusted file. The surrounding code only catches `AttributeError`/`ExpatError` and the class already documents `PdfReadError` as the failure mode for invalid XML, so the empty-result case slips through.

Fixed by checking for an empty match and raising `PdfReadError` with the same message prefix, keeping the failure handling consistent for callers that already guard against it. Reviewer note: this is the only unguarded `[0]` on a DOM lookup in the module; the other call sites iterate or use `len()` first.