### PR TITLE
ROB: Guard text operators against missing operands in extract_text

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -1758,7 +1758,7 @@ class PageObject(DictionaryObject):
             if operator == b"'":
                 extractor.process_operation(b"T*", [])
                 extractor.process_operation(b"Tj", operands)
-            elif operator == b'"':
+            elif operator == b'"' and len(operands) >= 3:
                 extractor.process_operation(b"Tw", [operands[0]])
                 extractor.process_operation(b"Tc", [operands[1]])
                 extractor.process_operation(b"T*", [])
@@ -1776,7 +1776,7 @@ class PageObject(DictionaryObject):
                             and extractor.text[-1] != " "
                         ):
                             extractor.process_operation(b"Tj", [" "])
-            elif operator == b"TD":
+            elif operator == b"TD" and len(operands) >= 2:
                 extractor.process_operation(b"TL", [-operands[1]])
                 extractor.process_operation(b"Td", operands)
             elif operator == b"Do":

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -288,7 +288,7 @@ class TextExtraction:
         try:
             self.font_resource = self.font_resources[operands[0]]
             self.font = self.fonts[operands[0]]
-        except KeyError:  # font not found
+        except (KeyError, IndexError):  # font not found / operand missing
             self.font_resource = None
             font_descriptor = FontDescriptor()
             self.font = Font(
@@ -310,7 +310,8 @@ class TextExtraction:
         # A special case is a translating only tm:
         # tm = [1, 0, 0, 1, e, f]
         # i.e. tm[4] += tx, tm[5] += ty.
-        tx, ty = float(operands[0]), float(operands[1])
+        tx = float(operands[0]) if len(operands) > 0 else 0.0
+        ty = float(operands[1]) if len(operands) > 1 else 0.0
         self.tm_matrix[4] += tx * self.tm_matrix[0] + ty * self.tm_matrix[2]
         self.tm_matrix[5] += tx * self.tm_matrix[1] + ty * self.tm_matrix[3]
         str_widths = self.compute_str_widths(self._actual_str_size["str_widths"])

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -408,6 +408,27 @@ def test_layout_mode_warns_on_malformed_content_stream(op, msg, caplog):
     assert caplog.records[-1].getMessage() == msg
 
 
+def test_text_operators_with_missing_operands():
+    """Text operators carrying too few operands must not crash extraction."""
+    writer = PdfWriter(clone_from=RESOURCE_ROOT / "crazyones.pdf")
+    page = writer.pages[0]
+    # Each malformed operator below previously raised IndexError/ValueError on
+    # the default extraction path: TD/Td with a single operand, the show-and-
+    # move " operator with fewer than three operands, and a bare Tf.
+    content = (
+        b"BT /F1 12 Tf 100 700 Td (Hello) Tj "
+        b"5 TD (A) Tj "
+        b"3 Td (B) Tj "
+        b'(C) " '
+        b"Tf (D) Tj "
+        b"ET"
+    )
+    stream = ContentStream(stream=None, pdf=writer)
+    stream.set_data(content)
+    page.replace_contents(stream)
+    assert "Hello" in page.extract_text()
+
+
 def test_process_operation__cm_multiplication_issue():
     """Test for #3262."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "crazyones.pdf")


### PR DESCRIPTION
**Crash on text operators with missing operands**

A malformed content stream whose `"`, `TD`, `Td` or `Tf` operator supplies fewer operands than the operator needs makes `extract_text()` raise an uncaught `IndexError` (the `"` case can also surface as a `ValueError`), because the operands are read by fixed index with no arity check. Guarded each access where it is read so a short operator is skipped or falls back to a zero translation, matching the `if operands else` handling already used on the neighbouring text-state operators.