### PR TITLE
ROB: Tolerate undefined Tf font name in layout mode extraction

### DIFF
--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -57,14 +57,13 @@ def resolve_font(fonts: dict[str, Font], name: str) -> Font:
         Font: the matching font, or an uninterpretable placeholder font.
 
     """
-    try:
+    if name in fonts:
         return fonts[name]
-    except KeyError:
-        logger_warning(
-            "Font %(name)s is not in the page resources.",
-            name=name, source=__name__
-        )
-        return Font("Unknown", encoding={}, interpretable=False)
+    logger_warning(
+        "Font %(name)s is not in the page resources.",
+        name=name, source=__name__
+    )
+    return Font("Unknown", encoding={}, interpretable=False)
 
 
 def bt_group(tj_op: TextStateParams, rendered_text: str, displaced_tx: float) -> BTGroup:

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -41,6 +41,32 @@ class BTGroup(TypedDict):
     flip_sort: Literal[-1, 1]
 
 
+def resolve_font(fonts: dict[str, Font], name: str) -> Font:
+    """
+    Resolve a Tf font name to a layout mode Font.
+
+    A content stream may select a font name that is not declared in the page
+    resources. Fall back to an uninterpretable font so extraction degrades to
+    the existing incomplete-output path instead of raising KeyError.
+
+    Args:
+        fonts: font dictionary as returned by PageObject._layout_mode_fonts()
+        name: font name supplied by a Tf operator
+
+    Returns:
+        Font: the matching font, or an uninterpretable placeholder font.
+
+    """
+    try:
+        return fonts[name]
+    except KeyError:
+        logger_warning(
+            "Font %(name)s is not in the page resources.",
+            name=name, source=__name__
+        )
+        return Font("Unknown", encoding={}, interpretable=False)
+
+
 def bt_group(tj_op: TextStateParams, rendered_text: str, displaced_tx: float) -> BTGroup:
     """
     BTGroup constructed from a TextStateParams instance, rendered text, and
@@ -203,7 +229,7 @@ def recurse_to_target_op(
                 operands = [0, -text_state_mgr.TL]
             text_state_mgr.add_tm(operands)
         elif op == b"Tf":
-            text_state_mgr.set_font(fonts[operands[0]], operands[1])
+            text_state_mgr.set_font(resolve_font(fonts, operands[0]), operands[1])
         else:  # handle Tc, Tw, Tz, TL, and Ts operators
             text_state_mgr.set_state_param(op, operands)
     else:
@@ -293,7 +319,7 @@ def text_show_operations(
             bt_groups.extend(bts)
             tj_ops.extend(tjs)
         elif op == b"Tf":
-            state_mgr.set_font(fonts[operands[0]], operands[1])
+            state_mgr.set_font(resolve_font(fonts, operands[0]), operands[1])
         else:  # set Tc, Tw, Tz, TL, and Ts if required. ignores all other ops
             state_mgr.set_state_param(op, operands)
 

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -22,7 +22,12 @@ from pypdf._text_extraction._layout_mode._fixed_width_page import (
 from pypdf._text_extraction._layout_mode._text_state_manager import TextStateManager
 from pypdf._text_extraction._layout_mode._text_state_params import TextStateParams
 from pypdf.errors import PdfReadError
-from pypdf.generic import ContentStream, DictionaryObject, NameObject
+from pypdf.generic import (
+    ContentStream,
+    DecodedStreamObject,
+    DictionaryObject,
+    NameObject,
+)
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
 
@@ -226,6 +231,41 @@ def test_layout_mode_warnings(caplog):
     assert expected not in caplog.messages
     page.extract_text(extraction_mode="layout", visitor_text=dummy_visitor_text)
     assert expected in caplog.messages
+
+
+def test_layout_mode_undefined_font_name(caplog):
+    # A Tf operator may name a font that is not declared in the page resources,
+    # both inside a BT/ET block and at the top level. Layout mode should warn
+    # and continue instead of raising KeyError.
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=200, height=200)
+
+    helvetica = DictionaryObject()
+    helvetica[NameObject("/Type")] = NameObject("/Font")
+    helvetica[NameObject("/Subtype")] = NameObject("/Type1")
+    helvetica[NameObject("/BaseFont")] = NameObject("/Helvetica")
+    font_resources = DictionaryObject()
+    font_resources[NameObject("/F1")] = writer._add_object(helvetica)
+    resources = DictionaryObject()
+    resources[NameObject("/Font")] = font_resources
+    page[NameObject("/Resources")] = resources
+
+    # /F9 (top level) and /F2 (inside BT) are never declared; only /F1 is.
+    content = DecodedStreamObject()
+    content.set_data(
+        b"/F9 12 Tf BT /F1 12 Tf 10 150 Td (Hi) Tj ET "
+        b"BT /F2 12 Tf 10 100 Td (X) Tj ET"
+    )
+    page[NameObject("/Contents")] = writer._add_object(content)
+
+    buffer = BytesIO()
+    writer.write(buffer)
+    buffer.seek(0)
+
+    text = PdfReader(buffer).pages[0].extract_text(extraction_mode="layout")
+    assert "Hi" in text
+    assert "Font /F9 is not in the page resources." in caplog.messages
+    assert "Font /F2 is not in the page resources." in caplog.messages
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
layout mode text extraction resolves the font named by a Tf operator with a bare fonts[operands[0]] subscript in both recurse_to_target_op and text_show_operations, so a content stream that selects a font absent from the page /Resources /Font dictionary aborts extract_text(extraction_mode="layout") with an uncaught KeyError on otherwise readable input. the plain extractor already tolerates this in _handle_tf by falling back to an unknown font, so the layout path is the odd one out here. both Tf sites now go through a small resolve_font helper that returns an uninterpretable placeholder and warns, which lets the existing incomplete-output path deal with it rather than crashing. behaviour for declared fonts is unchanged as far as i can tell; the added test exercises an undefined Tf name both inside a BT/ET block and at the top level.