### PR TITLE
ROB: tolerate malformed argument counts in destination arrays

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -975,7 +975,7 @@ class PdfDocCommon(ABC):
         # handle outline items with missing or invalid destination
         if (
             isinstance(array, (NullObject, str))
-            or (isinstance(array, ArrayObject) and len(array) == 0)
+            or (isinstance(array, ArrayObject) and len(array) < 2)
             or array is None
         ):
             page = NullObject()

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1702,20 +1702,29 @@ class Destination(TreeObject):
                 args.append(NumberObject(0.0))
             if len(args) < 3:  # zoom is missing
                 args.append(NumberObject(0.0))
+            # surplus arguments are ignored rather than failing the unpacking
             (
                 self[NameObject(TA.LEFT)],
                 self[NameObject(TA.TOP)],
                 self[NameObject("/Zoom")],
-            ) = args
+            ) = args[:3]
         elif len(args) == 0:
             pass
         elif typ == TF.FIT_R:
-            (
-                self[NameObject(TA.LEFT)],
-                self[NameObject(TA.BOTTOM)],
-                self[NameObject(TA.RIGHT)],
-                self[NameObject(TA.TOP)],
-            ) = args
+            try:  # Prefer to be more robust against a wrong number of arguments
+                (
+                    self[NameObject(TA.LEFT)],
+                    self[NameObject(TA.BOTTOM)],
+                    self[NameObject(TA.RIGHT)],
+                    self[NameObject(TA.TOP)],
+                ) = args
+            except Exception:
+                (
+                    self[NameObject(TA.LEFT)],
+                    self[NameObject(TA.BOTTOM)],
+                    self[NameObject(TA.RIGHT)],
+                    self[NameObject(TA.TOP)],
+                ) = (NullObject(), NullObject(), NullObject(), NullObject())
         elif typ in [TF.FIT_H, TF.FIT_BH]:
             try:  # Prefer to be more robust not only to null parameters
                 (self[NameObject(TA.TOP)],) = args

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1711,14 +1711,14 @@ class Destination(TreeObject):
         elif len(args) == 0:
             pass
         elif typ == TF.FIT_R:
-            try:  # Prefer to be more robust against a wrong number of arguments
+            if len(args) == 4:  # a wrong number of arguments degrades to null
                 (
                     self[NameObject(TA.LEFT)],
                     self[NameObject(TA.BOTTOM)],
                     self[NameObject(TA.RIGHT)],
                     self[NameObject(TA.TOP)],
                 ) = args
-            except Exception:
+            else:
                 (
                     self[NameObject(TA.LEFT)],
                     self[NameObject(TA.BOTTOM)],

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -192,6 +192,22 @@ def test_viewer_preferences__indirect_reference():
     assert id(viewer_preferences) == id(reader.resolved_objects[(0, 24)])
 
 
+def test_build_destination__short_array():
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+
+    # An array too short to hold a page reference and a fit type degrades to a
+    # null destination instead of raising on the unpacking.
+    dest = writer._build_destination("title", ArrayObject([NumberObject(0)]))
+    assert isinstance(dest["/Page"], NullObject)
+
+    # A trailing fit type with the wrong number of arguments still builds.
+    dest = writer._build_destination(
+        "title", ArrayObject([NumberObject(0), NameObject("/FitR"), NumberObject(1), NumberObject(2)])
+    )
+    assert dest["/Type"] == "/FitR"
+
+
 @pytest.mark.enable_socket
 def test_named_destinations__tree_is_null_object():
     url = "https://github.com/user-attachments/files/20885216/test.pdf"

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -309,6 +309,22 @@ def test_destination_fit_v():
     Destination(NameObject("title"), NullObject(), Fit.fit_vertically(left=None))
 
 
+def test_destination_malformed_fit_arguments():
+    # /XYZ with surplus arguments keeps the first three coordinates
+    d = Destination(NameObject("title"), NullObject(), Fit(fit_type="/XYZ", fit_args=(1, 2, 3, 4)))
+    assert d.left == FloatObject(1)
+    assert d.top == FloatObject(2)
+    assert d.zoom == FloatObject(3)
+
+    # /FitR with a wrong number of arguments falls back to null coordinates
+    d = Destination(NameObject("title"), NullObject(), Fit(fit_type="/FitR", fit_args=(1, 2)))
+    assert d.typ == "/FitR"
+    assert isinstance(d.left, NullObject)
+    assert isinstance(d.bottom, NullObject)
+    assert isinstance(d.right, NullObject)
+    assert isinstance(d.top, NullObject)
+
+
 def test_outline_item_write_to_stream():
     stream = BytesIO()
     oi = OutlineItem(NameObject("title"), NullObject(), Fit.fit_vertically(left=0))


### PR DESCRIPTION
**Malformed destination arrays crash outline parsing**

A `/Dest` array carrying the wrong number of entries makes `reader.outline` and `reader.named_destinations` raise a bare `ValueError` rather than degrading. `_build_destination` only skips an empty array, so a single-element array still reaches the `page, typ, *array` unpacking, and the `/XYZ` and `/FitR` branches of `Destination` unpack their arguments without the tolerance the neighbouring `/FitH` and `/FitV` branches already have. Extended the short-array guard and brought the two branches in line with their siblings, so a broken destination falls back to a sensible default instead of aborting the read.