### PR TITLE
ROB: guard out-of-range colour components in _get_image_mode

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -113,9 +113,14 @@ def _get_image_mode(
         "4bit": "4bits",
     }
 
+    mode_values = list(mode_map.values())
     mode = (
         mode_map.get(color_space_str)
-        or list(mode_map.values())[color_components]
+        or (
+            mode_values[color_components]
+            if 0 <= color_components < len(mode_values)
+            else None
+        )
         or prev_mode
     )
 

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -10,7 +10,13 @@ from pypdf._utils import Version
 from pypdf.constants import FilterTypes, ImageAttributes, StreamAttributes
 from pypdf.errors import EmptyImageDataError, LimitReachedError, PdfReadError
 from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject, StreamObject, TextStringObject
-from pypdf.generic._image_xobject import _extended_image_from_bytes, _handle_flate, _xobj_to_image, bits2byte
+from pypdf.generic._image_xobject import (
+    _extended_image_from_bytes,
+    _get_image_mode,
+    _handle_flate,
+    _xobj_to_image,
+    bits2byte,
+)
 
 from .. import RESOURCE_ROOT, get_data_from_url
 from ..utils import get_image_data
@@ -371,3 +377,27 @@ def test_handle_flate__truncated_2bit_image(caplog: pytest.LogCaptureFixture) ->
         (0, 0, 0), (0, 0, 0), (0, 0, 0),
     )
     assert "Image data is not rectangular. Adding padding." in caplog.text
+
+
+def test_get_imagemode__color_components_out_of_range() -> None:
+    """A component count above the known modes must not raise IndexError."""
+    # The colour space is not one of the recognised names, so the mode is
+    # otherwise picked by indexing the mode table with the component count.
+    # A crafted value larger than that table previously raised IndexError;
+    # it should now fall back to the previous mode.
+    assert _get_image_mode("/Unknown", 99, "L") == ("L", False)
+    assert _get_image_mode("/Unknown", 99, "") == ("", False)
+
+
+def test_xobj_to_image__color_components_out_of_range() -> None:
+    """An image with an out-of-range /Colors value degrades to PdfReadError."""
+    x_object = StreamObject()
+    x_object[NameObject(ImageAttributes.WIDTH)] = NumberObject(4)
+    x_object[NameObject(ImageAttributes.HEIGHT)] = NumberObject(4)
+    x_object[NameObject("/BitsPerComponent")] = NumberObject(8)
+    x_object[NameObject(ImageAttributes.COLOR_SPACE)] = NameObject("/Unknown")
+    x_object[NameObject("/Colors")] = NumberObject(8)
+    x_object.set_data(b"\x00" * 16)
+
+    with pytest.raises(PdfReadError, match=r"^ColorSpace field not found in .+"):
+        _xobj_to_image(x_object)


### PR DESCRIPTION
**IndexError when an image declares more colour components than known modes**

`_get_image_mode` derives the mode by indexing the mode table with the component count, which comes from the image `/Colors` value (or a `/DeviceN` colourant count) and is never range-checked, so an unrecognised `/ColorSpace` together with `/Colors` of 7 or more raises an uncaught `IndexError` when `page.images` is read. The lookup now only happens when the count is within range and otherwise falls back to the previous mode, so an uninterpretable colour space lands on the existing `PdfReadError` path rather than crashing. A regression test covers both the helper and the public image path.