### PR TITLE
ROB: tolerate non-array outline color when reading and cloning

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1050,7 +1050,13 @@ class PdfDocCommon(ABC):
         if outline_item:
             if "/C" in node:
                 # Color of outline item font in (R, G, B) with values ranging 0.0-1.0
-                outline_item[NameObject("/C")] = ArrayObject(FloatObject(c) for c in node["/C"])  # type: ignore[attr-defined]
+                color = node["/C"]
+                if isinstance(color, (list, tuple)):
+                    outline_item[NameObject("/C")] = ArrayObject(FloatObject(c) for c in color)
+                else:
+                    logger_warning(
+                        f"Ignoring non-array outline colour {color!r}", source=__name__
+                    )
             if "/F" in node:
                 # specifies style characteristics bold and/or italic
                 # with 1=italic, 2=bold, 3=both

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1055,7 +1055,7 @@ class PdfDocCommon(ABC):
                     outline_item[NameObject("/C")] = ArrayObject(FloatObject(c) for c in color)
                 else:
                     logger_warning(
-                        f"Ignoring non-array outline colour {color!r}", source=__name__
+                        f"Ignoring non-array outline color {color!r}", source=__name__
                     )
             if "/F" in node:
                 # specifies style characteristics bold and/or italic

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1051,7 +1051,7 @@ class PdfDocCommon(ABC):
             if "/C" in node:
                 # Color of outline item font in (R, G, B) with values ranging 0.0-1.0
                 color = node["/C"]
-                if isinstance(color, (list, tuple)):
+                if isinstance(color, list):
                     outline_item[NameObject("/C")] = ArrayObject(FloatObject(c) for c in color)
                 else:
                     logger_warning(

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1055,7 +1055,9 @@ class PdfDocCommon(ABC):
                     outline_item[NameObject("/C")] = ArrayObject(FloatObject(c) for c in color)
                 else:
                     logger_warning(
-                        f"Ignoring non-array outline color {color!r}", source=__name__
+                        "Ignoring non-array outline color %(color)r",
+                        source=__name__,
+                        color=color,
                     )
             if "/F" in node:
                 # specifies style characteristics bold and/or italic

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3139,10 +3139,8 @@ class PdfWriter(PdfDocCommon):
         # TODO: /SE
         if dest.node is not None:
             n_ol[NameObject("/F")] = NumberObject(dest.node.get("/F", 0))
-            color = dest.node.get("/C")
-            if color is not None:
-                color = color.get_object()
-            if not isinstance(color, (list, tuple)):
+            color = dest.node.get("/C", NullObject()).get_object()
+            if not isinstance(color, list):
                 color = [FloatObject(0.0), FloatObject(0.0), FloatObject(0.0)]
             n_ol[NameObject("/C")] = ArrayObject(color)
         return n_ol

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3139,11 +3139,12 @@ class PdfWriter(PdfDocCommon):
         # TODO: /SE
         if dest.node is not None:
             n_ol[NameObject("/F")] = NumberObject(dest.node.get("/F", 0))
-            n_ol[NameObject("/C")] = ArrayObject(
-                dest.node.get(
-                    "/C", [FloatObject(0.0), FloatObject(0.0), FloatObject(0.0)]
-                )
-            )
+            color = dest.node.get("/C")
+            if color is not None:
+                color = color.get_object()
+            if not isinstance(color, (list, tuple)):
+                color = [FloatObject(0.0), FloatObject(0.0), FloatObject(0.0)]
+            n_ol[NameObject("/C")] = ArrayObject(color)
         return n_ol
 
     def _insert_filtered_outline(

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -678,3 +678,38 @@ def test_get_qualified_field_name__cyclic() -> None:
             match=r"^Detected cycle in /Parent hierarchy when retrieving qualified field name\.$"
     ):
         _ = writer._get_qualified_field_name(parent=dictionary1)
+
+
+def test_build_outline_item__non_array_color(caplog):
+    """A malformed outline item whose /C is not an array must not crash."""
+    writer = PdfWriter()
+    writer.add_blank_page(72, 72)
+
+    item = DictionaryObject()
+    writer._add_object(item)
+    item.update({
+        NameObject("/Title"): TextStringObject("Bad colour"),
+        NameObject("/Dest"): ArrayObject(
+            [writer.pages[0].indirect_reference, NameObject("/Fit")]
+        ),
+        NameObject("/C"): NumberObject(5),  # should be an [r, g, b] array
+    })
+    outlines = DictionaryObject()
+    writer._add_object(outlines)
+    outlines.update({
+        NameObject("/Type"): NameObject("/Outlines"),
+        NameObject("/First"): item.indirect_reference,
+        NameObject("/Last"): item.indirect_reference,
+    })
+    item[NameObject("/Parent")] = outlines.indirect_reference
+    writer._root_object[NameObject("/Outlines")] = outlines.indirect_reference
+
+    outline = writer.outline
+    assert outline[0]["/Title"] == "Bad colour"
+    assert "/C" not in outline[0]
+    assert any("outline colour" in message for message in caplog.messages)
+
+    # The same value is read again, unsanitised, while cloning the outline
+    # during append, so that path must tolerate it too.
+    target = PdfWriter()
+    target.append(writer)

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -688,7 +688,7 @@ def test_build_outline_item__non_array_color(caplog):
     item = DictionaryObject()
     writer._add_object(item)
     item.update({
-        NameObject("/Title"): TextStringObject("Bad colour"),
+        NameObject("/Title"): TextStringObject("Bad color"),
         NameObject("/Dest"): ArrayObject(
             [writer.pages[0].indirect_reference, NameObject("/Fit")]
         ),
@@ -705,9 +705,9 @@ def test_build_outline_item__non_array_color(caplog):
     writer._root_object[NameObject("/Outlines")] = outlines.indirect_reference
 
     outline = writer.outline
-    assert outline[0]["/Title"] == "Bad colour"
+    assert outline[0]["/Title"] == "Bad color"
     assert "/C" not in outline[0]
-    assert any("outline colour" in message for message in caplog.messages)
+    assert any("outline color" in message for message in caplog.messages)
 
     # The same value is read again, unsanitised, while cloning the outline
     # during append, so that path must tolerate it too.


### PR DESCRIPTION
Reading reader.outline (or writer.outline) builds each item color from the /C entry of the outline dictionary, which is attacker-controlled and only valid as an [r, g, b] array. _build_outline_item assumed that and iterated it directly with ArrayObject(FloatObject(c) for c in node["/C"]), so an item whose /C is a single number, or an indirect reference to one, raises an uncaught TypeError ("object is not iterable") rather than the PdfReadError/degrade behaviour used elsewhere in the function. I hit it while feeding malformed outlines through the reader, and noticed the same raw value is read a second time, still unsanitised, in PdfWriter._clone_outline during append/clone of a source document, so guarding only the reader just moves the crash onto the clone path. Both sites now check the value is a list/tuple first: the reader skips a malformed color with a warning and the writer falls back to black, which should keep behaviour identical for well-formed files while leaving the rest of the outline intact for broken ones. I kept the changes inside those two functions so nothing else shifts.