### PR TITLE
ROB: Tolerate malformed Tm operand count in extract_text

### DIFF
--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -320,7 +320,14 @@ class TextExtraction:
 
     def _handle_tm(self, operands: list[Any]) -> float:
         """Handle Tm (Set text matrix) operation - Table 5.5 page 406."""
-        self.tm_matrix = [float(operand) for operand in operands[:6]]
+        try:
+            tm_matrix = [float(operand) for operand in operands[:6]]
+        except (TypeError, ValueError):
+            tm_matrix = []
+        # Fall back to the identity matrix when Tm carries the wrong number of
+        # operands, mirroring _handle_cm, so the text matrix stays a six-element
+        # list and later positioning operators do not read past its end.
+        self.tm_matrix = tm_matrix if len(tm_matrix) == 6 else [1.0, 0.0, 0.0, 1.0, 0.0, 0.0]
         str_widths = self.compute_str_widths(self._actual_str_size["str_widths"])
         self._actual_str_size["str_widths"] = 0.0
         return str_widths

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -469,6 +469,26 @@ def test_text_operators_with_missing_operands():
     assert "Hello" in page.extract_text()
 
 
+def test_tm_operator_with_wrong_operand_count():
+    """A Tm operator with the wrong number of operands must not crash extraction."""
+    writer = PdfWriter(clone_from=RESOURCE_ROOT / "crazyones.pdf")
+    page = writer.pages[0]
+    # A short Tm left the text matrix with fewer than six entries, so the next
+    # positioning operator read past its end (IndexError in mult()); a bare Tm
+    # had the same effect.
+    content = (
+        b"BT /F1 12 Tf 100 700 Td (Hello) Tj "
+        b"1 0 0 Tm (A) Tj "
+        b"T* (B) Tj "
+        b"Tm (C) Tj "
+        b"ET"
+    )
+    stream = ContentStream(stream=None, pdf=writer)
+    stream.set_data(content)
+    page.replace_contents(stream)
+    assert "Hello" in page.extract_text()
+
+
 def test_process_operation__cm_multiplication_issue():
     """Test for #3262."""
     writer = PdfWriter(clone_from=RESOURCE_ROOT / "crazyones.pdf")

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -553,10 +553,10 @@ def test_extract_text__restore_cm_stack_pop_error():
     reader = PdfReader(stream)
     page = reader.pages[10]
 
-    # There is a previous error we already omit ("pop from empty list"), thus
-    # check for the message explicitly here.
-    with pytest.raises(IndexError, match="list index out of range"):
-        page.extract_text()
+    # The cm stack pop error ("pop from empty list") is already omitted. This
+    # page also carries a short Tm operator that used to raise IndexError in
+    # mult(); it is now tolerated as well, so extraction completes.
+    page.extract_text()
 
 
 @pytest.mark.timeout(60)

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -475,12 +475,13 @@ def test_tm_operator_with_wrong_operand_count():
     page = writer.pages[0]
     # A short Tm left the text matrix with fewer than six entries, so the next
     # positioning operator read past its end (IndexError in mult()); a bare Tm
-    # had the same effect.
+    # had the same effect. A non-numeric operand makes float() raise instead.
     content = (
         b"BT /F1 12 Tf 100 700 Td (Hello) Tj "
         b"1 0 0 Tm (A) Tj "
         b"T* (B) Tj "
         b"Tm (C) Tj "
+        b"(x) 0 0 1 0 0 Tm (D) Tj "
         b"ET"
     )
     stream = ContentStream(stream=None, pdf=writer)


### PR DESCRIPTION
**Crash on a short Tm operator during text extraction**

`_handle_tm` built the text matrix from `operands[:6]` without checking how many operands the `Tm` operator actually carried, so a content stream with a short `Tm` (for example `1 0 0 Tm`, or a bare `Tm`) left `tm_matrix` with fewer than six entries. The next positioning operator then read past its end, raising an uncaught `IndexError` in `mult()` from `reader.pages[i].extract_text()` on untrusted input. The sibling `_handle_cm` already falls back to the identity matrix here, so the fix keeps the text matrix at six elements the same way. Well-formed `Tm` operators always carry six numbers and are unaffected.