### PR TITLE
ROB: raise ValueError for under-length page boxes in _get_rectangle

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -106,14 +106,21 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
                 break
     if isinstance(retval, IndirectObject):
         retval = self.pdf.get_object(retval)
-    if isinstance(retval, ArrayObject) and (length := len(retval)) > 4:
-        logger_warning(
-            "Expected four values, got %(length)d: %(retval)s",
-            source=__name__,
-            length=length,
-            retval=retval,
-        )
-        retval = RectangleObject(tuple(retval[:4]))
+    if isinstance(retval, ArrayObject) and (length := len(retval)) != 4:
+        if length > 4:
+            # Keep backwards-compatibility with files previously written in a
+            # broken way by pypdf, which carried more than four values.
+            logger_warning(
+                "Expected four values, got %(length)d: %(retval)s",
+                source=__name__,
+                length=length,
+                retval=retval,
+            )
+            retval = RectangleObject(tuple(retval[:4]))
+        else:
+            raise ValueError(
+                f"Expected four values for {name}, got {length}: {retval}"
+            )
     else:
         retval = RectangleObject(retval)  # type: ignore[arg-type]
     _set_rectangle(self, name, retval)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1572,3 +1572,11 @@ def test_get_rectangle__size_handling(caplog):
     page[NameObject("/MediaBox")] = ArrayObject([0, 0, 13, 37, 0, 0, 13, 37])
     assert page.mediabox == RectangleObject((0, 0, 13, 37))
     assert "Expected four values, got 8: [0, 0, 13, 37, 0, 0, 13, 37]\n" in caplog.text
+
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+    page = reader.pages[0]
+    page[NameObject("/MediaBox")] = ArrayObject([0, 0, 13])
+    with pytest.raises(
+        ValueError, match=r"Expected four values for /MediaBox, got 3: \[0, 0, 13\]"
+    ):
+        _ = page.mediabox


### PR DESCRIPTION
**Uncaught AssertionError on short page boxes**

`_get_rectangle` already warns and truncates a box array with more than four values, but a box with fewer than four (e.g. `/MediaBox [0 0 612]`) falls through to `RectangleObject`, whose `__init__` asserts a length of four. Accessing `page.mediabox` on such a file therefore raises a bare `AssertionError`, which is the wrong exception type to surface from the public API and is stripped entirely under `python -O`.

**Cause**

The length guard only handled the over-length case; anything shorter than four reached the assertion.

**Fix**

Keep the existing over-length truncation untouched, since that path exists for backwards-compatibility with files previously written in a broken way by pypdf. For the under-length case raise a proper `ValueError` instead of letting the assertion fire, so callers get a meaningful, catchable error. Updated `test_get_rectangle__size_handling` to cover the short array.

I do not have a real-world file that triggers this; I came across it feeding malformed boxes through the reader, so this is purely about turning the internal assertion into a sensible exception rather than silently accepting the input.
