### PR TITLE
ROB: return None for unparsable metadata and attachment dates

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -208,7 +208,14 @@ class DocumentInformation(DictionaryObject):
     @property
     def creation_date(self) -> Optional[datetime]:
         """Read-only property accessing the document's creation date."""
-        return parse_iso8824_date(self._get_text(DI.CREATION_DATE))
+        try:
+            return parse_iso8824_date(self._get_text(DI.CREATION_DATE))
+        except ValueError:
+            logger_warning(
+                "Invalid creation date; use creation_date_raw for the unparsed value",
+                source=__name__,
+            )
+            return None
 
     @property
     def creation_date_raw(self) -> Optional[str]:
@@ -227,7 +234,14 @@ class DocumentInformation(DictionaryObject):
 
         The date and time the document was most recently modified.
         """
-        return parse_iso8824_date(self._get_text(DI.MOD_DATE))
+        try:
+            return parse_iso8824_date(self._get_text(DI.MOD_DATE))
+        except ValueError:
+            logger_warning(
+                "Invalid modification date; use modification_date_raw for the unparsed value",
+                source=__name__,
+            )
+            return None
 
     @property
     def modification_date_raw(self) -> Optional[str]:

--- a/pypdf/generic/_files.py
+++ b/pypdf/generic/_files.py
@@ -4,7 +4,7 @@ import bisect
 from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
-from pypdf._utils import format_iso8824_date, parse_iso8824_date
+from pypdf._utils import format_iso8824_date, logger_warning, parse_iso8824_date
 from pypdf.constants import CatalogAttributes as CA
 from pypdf.constants import FileSpecificationDictionaryEntries
 from pypdf.constants import PageAttributes as PG
@@ -289,7 +289,11 @@ class EmbeddedFile:
     @property
     def creation_date(self) -> datetime.datetime | None:
         """Retrieve the file creation datetime."""
-        return parse_iso8824_date(self._params.get("/CreationDate"))
+        try:
+            return parse_iso8824_date(self._params.get("/CreationDate"))
+        except ValueError:
+            logger_warning("Invalid creation date in embedded file params", source=__name__)
+            return None
 
     @creation_date.setter
     def creation_date(self, value: datetime.datetime | None) -> None:
@@ -304,7 +308,11 @@ class EmbeddedFile:
     @property
     def modification_date(self) -> datetime.datetime | None:
         """Retrieve the datetime of the last file modification."""
-        return parse_iso8824_date(self._params.get("/ModDate"))
+        try:
+            return parse_iso8824_date(self._params.get("/ModDate"))
+        except ValueError:
+            logger_warning("Invalid modification date in embedded file params", source=__name__)
+            return None
 
     @modification_date.setter
     def modification_date(self, value: datetime.datetime | None) -> None:

--- a/tests/generic/test_files.py
+++ b/tests/generic/test_files.py
@@ -346,6 +346,16 @@ def test_embedded_file__modification_date_setter() -> None:
     assert embedded_file._ensure_params[NameObject("/ModDate")] == NullObject()
 
 
+def test_embedded_file__malformed_date_getter() -> None:
+    writer = PdfWriter()
+    embedded_file = writer.add_attachment("test.txt", b"content")
+
+    embedded_file._ensure_params[NameObject("/CreationDate")] = TextStringObject("not a date")
+    embedded_file._ensure_params[NameObject("/ModDate")] = TextStringObject("D:20210408T054711Z")
+    assert embedded_file.creation_date is None
+    assert embedded_file.modification_date is None
+
+
 def test_embedded_file__checksum_setter() -> None:
     writer = PdfWriter()
     embedded_file = writer.add_attachment("test.txt", b"content")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -144,6 +144,20 @@ def test_iss1943():
         assert docinfo.creation_date is None
 
 
+def test_metadata_malformed_date():
+    with PdfReader(RESOURCE_ROOT / "crazyones.pdf") as reader:
+        docinfo = reader.metadata
+        docinfo.update(
+            {
+                NameObject("/CreationDate"): TextStringObject("not a date"),
+                NameObject("/ModDate"): TextStringObject("D:20210408T054711Z"),
+            }
+        )
+        assert docinfo.creation_date is None
+        assert docinfo.modification_date is None
+        assert docinfo.creation_date_raw == "not a date"
+
+
 @pytest.mark.samples
 @pytest.mark.parametrize(
     "pdf_path", [SAMPLE_ROOT / "017-unreadable-meta-data/unreadablemetadata.pdf"]


### PR DESCRIPTION
**Uncaught date error in metadata and attachment date properties**

`parse_iso8824_date` is a strict parser that raises `ValueError` for any string it cannot match, so `reader.metadata.creation_date` / `modification_date` and the matching properties on attachment objects raise on a present but malformed `/CreationDate` or `/ModDate`, even though they already return `None` when the field is absent and expose the unparsed value via the `*_raw` / params accessors. A document with a slightly off date string therefore breaks ordinary metadata access on otherwise readable files.

The four getters now fall back to `None` with a warning, which keeps behaviour consistent with the missing-field case while leaving the parser strict (its raise is part of its tested contract). I have kept the change to the property layer rather than relaxing `parse_iso8824_date`, since other callers may want to rely on the strict behaviour.