### PR TITLE
ROB: tolerate malformed page label entries in get_label_from_nums

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -167,8 +167,9 @@ def get_label_from_nums(dictionary_object: DictionaryObject, index: int) -> str:
     if mapping_function is None:
         # Unknown /S numbering style; fall back to the page position.
         logger_warning(
-            "Ignoring unknown page label numbering style in /Nums.",
+            "Ignoring unknown page label numbering style %(style)r in /Nums.",
             source=__name__,
+            style=value.get("/S"),
         )
         return str(index + 1)  # Fallback
     try:
@@ -176,7 +177,10 @@ def get_label_from_nums(dictionary_object: DictionaryObject, index: int) -> str:
     except (TypeError, ValueError):
         # Malformed /St or /P value; fall back to the page position.
         logger_warning(
-            "Ignoring malformed page label entry in /Nums.", source=__name__
+            "Ignoring malformed page label entry in /Nums (/St=%(start)r, /P=%(prefix)r).",
+            source=__name__,
+            start=start,
+            prefix=prefix,
         )
         return str(index + 1)  # Fallback
 

--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -163,8 +163,22 @@ def get_label_from_nums(dictionary_object: DictionaryObject, index: int) -> str:
         return str(index + 1)  # Fallback
     start = value.get("/St", 1)
     prefix = cast(str, value.get("/P", ""))
-    mapping_function = m[value.get("/S")]
-    return prefix + mapping_function(index - start_index + start)
+    mapping_function = m.get(value.get("/S"))
+    if mapping_function is None:
+        # Unknown /S numbering style; fall back to the page position.
+        logger_warning(
+            "Ignoring unknown page label numbering style in /Nums.",
+            source=__name__,
+        )
+        return str(index + 1)  # Fallback
+    try:
+        return prefix + mapping_function(index - start_index + start)
+    except (TypeError, ValueError):
+        # Malformed /St or /P value; fall back to the page position.
+        logger_warning(
+            "Ignoring malformed page label entry in /Nums.", source=__name__
+        )
+        return str(index + 1)  # Fallback
 
 
 def index2label(reader: PdfCommonDocProtocol, index: int) -> str:

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -195,7 +195,7 @@ def test_get_label_from_nums__unknown_style(caplog):
     dictionary_object = DictionaryObject()
     dictionary_object[NameObject("/Nums")] = ArrayObject([NumberObject(0), value])
     assert get_label_from_nums(dictionary_object, 3) == "4"
-    assert "Ignoring unknown page label numbering style in /Nums." in caplog.text
+    assert "Ignoring unknown page label numbering style '/X' in /Nums." in caplog.text
 
 
 def test_get_label_from_nums__malformed_start(caplog):
@@ -206,7 +206,7 @@ def test_get_label_from_nums__malformed_start(caplog):
     dictionary_object = DictionaryObject()
     dictionary_object[NameObject("/Nums")] = ArrayObject([NumberObject(0), value])
     assert get_label_from_nums(dictionary_object, 3) == "4"
-    assert "Ignoring malformed page label entry in /Nums." in caplog.text
+    assert "Ignoring malformed page label entry in /Nums (/St='/bad', /P='')." in caplog.text
 
 
 def test_index2label__empty_kids_list():

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -188,6 +188,27 @@ def test_get_label_from_nums__truncated_pair(caplog):
     assert "Ignoring last /Nums key without a value." in caplog.text
 
 
+def test_get_label_from_nums__unknown_style(caplog):
+    # /S carries a numbering style that is not part of the specification.
+    value = DictionaryObject()
+    value[NameObject("/S")] = NameObject("/X")
+    dictionary_object = DictionaryObject()
+    dictionary_object[NameObject("/Nums")] = ArrayObject([NumberObject(0), value])
+    assert get_label_from_nums(dictionary_object, 3) == "4"
+    assert "Ignoring unknown page label numbering style in /Nums." in caplog.text
+
+
+def test_get_label_from_nums__malformed_start(caplog):
+    # /St is not an integer, so the label arithmetic cannot be performed.
+    value = DictionaryObject()
+    value[NameObject("/S")] = NameObject("/D")
+    value[NameObject("/St")] = NameObject("/bad")
+    dictionary_object = DictionaryObject()
+    dictionary_object[NameObject("/Nums")] = ArrayObject([NumberObject(0), value])
+    assert get_label_from_nums(dictionary_object, 3) == "4"
+    assert "Ignoring malformed page label entry in /Nums." in caplog.text
+
+
 def test_index2label__empty_kids_list():
     reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
     number_tree = DictionaryObject()


### PR DESCRIPTION
reader.page_labels aborts on a malformed pagelabels /nums entry. get_label_from_nums picks the numbering style with a direct subscript m[value.get("/s")] and then evaluates prefix + mapping_function(index - start_index + start), so a /nums value whose /s names a style outside the spec set raises keyerror, and a non-numeric /st (or /p) raises typeerror, neither caught on the public page_labels path. the guard just above already falls back to str(index+1) when the value is not a dict, so a malformed entry ought to degrade the same way rather than take down the whole label list. the safest place for that is the lookup itself: /s now goes through m.get with the str(index+1) fallback for unknown styles, and the label arithmetic is wrapped so a bad /st or /p falls back too. valid /nums are unchanged. this is a different defect from #3823, which fixed the out-of-bounds read on a truncated /nums array in the same function.