### PR TITLE
SEC: Speed up recovery when reading broken cross-reference table

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -888,6 +888,7 @@ class PdfReader(PdfDocCommon):
         read_non_whitespace(stream)
         stream.seek(-1, 1)
         first_time = True  # check if the first time looking at the xref table
+        recovery_cache: Optional[dict[int, tuple[int, int]]] = None
         while True:
             num = cast(int, read_object(stream, self))
             if first_time and num != 0:
@@ -952,8 +953,15 @@ class PdfReader(PdfDocCommon):
                         buf = stream.read(-1)
                         stream.seek(p)
 
-                    f = re.search(rf"{num}\s+(\d+)\s+obj".encode(), buf)
-                    if f is None:
+                    if recovery_cache is None:
+                        recovery_cache = {}
+                        for cache_number, cache_generation, cache_start in self._find_pdf_objects(buf):
+                            if cache_number in recovery_cache:
+                                # Always use the first match.
+                                continue
+                            recovery_cache[cache_number] = (cache_start, cache_generation)
+
+                    if num not in recovery_cache:
                         logger_warning(
                             "entry %(num)d in Xref table invalid; object not found",
                             source=__name__,
@@ -968,8 +976,7 @@ class PdfReader(PdfDocCommon):
                             source=__name__,
                             num=num,
                         )
-                        generation = int(f.group(1))
-                        offset = f.start()
+                        generation, offset = recovery_cache[num]
                         entry_type_b = b"n"
 
                 if generation not in self.xref:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -880,6 +880,15 @@ class PdfReader(PdfDocCommon):
             break
         raise PdfReadError("startxref not found")
 
+    def _load_recovery_cache(self, data: bytes) -> dict[int, tuple[int, int]]:
+        cache = {}
+        for object_number, generation_number, object_start in self._find_pdf_objects(data):
+            if object_number in cache:
+                # Always use the first match.
+                continue
+            cache[object_number] = (object_start, generation_number)
+        return cache
+
     def _read_standard_xref_table(self, stream: StreamType) -> None:
         # standard cross-reference table
         ref = stream.read(3)
@@ -954,12 +963,7 @@ class PdfReader(PdfDocCommon):
                         stream.seek(p)
 
                     if recovery_cache is None:
-                        recovery_cache = {}
-                        for cache_number, cache_generation, cache_start in self._find_pdf_objects(buf):
-                            if cache_number in recovery_cache:
-                                # Always use the first match.
-                                continue
-                            recovery_cache[cache_number] = (cache_start, cache_generation)
+                        recovery_cache = self._load_recovery_cache(buf)
 
                     if num not in recovery_cache:
                         logger_warning(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2512,3 +2512,30 @@ def test_named_destinations_cache():
             reader.named_destinations.get("foo")
 
         get_mock.assert_called_once()
+
+
+@pytest.mark.timeout(10)
+def test_read_standard_xref_table__malformed__speed():
+    body = (
+        b"%PDF-1.7\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>\nendobj\n"
+    )
+    xref_offset = len(body)
+    corrupt_entry = b"xxxxxxxxxxxxxxxx 0\r\n"
+    assert len(corrupt_entry) == 20
+    entry_count = 20_000
+    data = (
+        body
+        + f"xref\n1 {entry_count}\n".encode("ascii")
+        + corrupt_entry * entry_count
+        + b"trailer\n<< /Size "
+        + str(entry_count + 1).encode("ascii")
+        + b" /Root 1 0 R >>\nstartxref\n"
+        + str(xref_offset).encode("ascii")
+        + b"\n%%EOF\n"
+    )
+
+    reader = PdfReader(BytesIO(data))
+    assert len(reader.pages) == 1

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2539,3 +2539,16 @@ def test_read_standard_xref_table__malformed__speed():
 
     reader = PdfReader(BytesIO(data))
     assert len(reader.pages) == 1
+
+
+def test_load_recovery_cache():
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+
+    pdf_objects = [
+        (1, 0, 10),
+        (1, 1, 20),
+        (2, 0, 30),
+        (3, 1, 42),
+    ]
+    with mock.patch.object(reader, "_find_pdf_objects", return_value=iter(pdf_objects)):
+        assert reader._load_recovery_cache(b"") == {1: (10, 0), 2: (30, 0), 3: (42, 1)}


### PR DESCRIPTION
Replaces the regex-based search per object number by a string-based parse of the full file in the first problematic call and re-using this cached data for further problematic calls.