### PR TITLE
ROB: tolerate malformed inline image settings in _read_inline_image

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1410,7 +1410,11 @@ class ContentStream(DecodedStreamObject):
         filtr = settings.get("/F", settings.get("/Filter", "not set"))
         savpos = stream.tell()
         if isinstance(filtr, list):
-            filtr = filtr[0]  # used forencoding
+            filtr = filtr[0] if filtr else "not set"  # used forencoding
+        if not isinstance(filtr, str):
+            # A valid filter is a name or an array of names; anything else
+            # cannot match the abbreviations below, so treat it as unfiltered.
+            filtr = "not set"
         if "AHx" in filtr or "ASCIIHexDecode" in filtr:
             data = extract_inline__ascii_hex_decode(stream)
         elif "A85" in filtr or "ASCII85Decode" in filtr:
@@ -1422,9 +1426,11 @@ class ContentStream(DecodedStreamObject):
         elif filtr == "not set":
             cs = settings.get("/CS", "")
             if isinstance(cs, list):
-                cs = cs[0]
+                cs = cs[0] if cs else ""
+            if not isinstance(cs, str):
+                cs = ""
             if "RGB" in cs:
-                lcs = 3
+                lcs: float = 3
             elif "CMYK" in cs:
                 lcs = 4
             else:
@@ -1432,15 +1438,19 @@ class ContentStream(DecodedStreamObject):
                     "/BPC",
                     8 if cs in {"/I", "/G", "/Indexed", "/DeviceGray"} else -1,
                 )
-                if bits > 0:
+                if isinstance(bits, (int, float)) and bits > 0:
                     lcs = bits / 8.0
                 else:
                     data = extract_inline_default(stream)
                     lcs = -1
-            if lcs > 0:
-                data = stream.read(
-                    ceil(cast(int, settings["/W"]) * lcs) * cast(int, settings["/H"])
-                )
+            width = settings.get("/W")
+            height = settings.get("/H")
+            if lcs > 0 and isinstance(width, int) and isinstance(height, int):
+                data = stream.read(ceil(width * lcs) * height)
+            elif lcs > 0:
+                # Without usable dimensions the raw sample length is unknown;
+                # fall back to scanning for the `EI` marker.
+                data = extract_inline_default(stream)
             # Move to the `EI` if possible.
             ei = read_non_whitespace(stream)
             stream.seek(-1, 1)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -622,6 +622,8 @@ EI Q
     [
         # Empty `/Filter` array (a spec-legal way to say "no filter").
         b"q BI /W 2 /H 2 /CS /RGB /BPC 8 /F [] ID " + b"\x00" * 12 + b" EI Q",
+        # `/Filter` that is not a name.
+        b"q BI /W 2 /H 2 /CS /RGB /BPC 8 /F 5 ID " + b"\x00" * 12 + b" EI Q",
         # Empty `/ColorSpace` array.
         b"q BI /W 2 /H 2 /CS [] /BPC 8 ID " + b"\x00" * 12 + b" EI Q",
         # `/ColorSpace` that is not a name.

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -617,6 +617,35 @@ EI Q
         )
 
 
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Empty `/Filter` array (a spec-legal way to say "no filter").
+        b"q BI /W 2 /H 2 /CS /RGB /BPC 8 /F [] ID " + b"\x00" * 12 + b" EI Q",
+        # Empty `/ColorSpace` array.
+        b"q BI /W 2 /H 2 /CS [] /BPC 8 ID " + b"\x00" * 12 + b" EI Q",
+        # `/ColorSpace` that is not a name.
+        b"q BI /W 2 /H 2 /CS 5 /BPC 8 ID " + b"\x00" * 12 + b" EI Q",
+        # `/BitsPerComponent` that is not a number.
+        b"q BI /W 2 /H 2 /CS /DeviceGray /BPC /X ID " + b"\x00" * 12 + b" EI Q",
+        # Missing `/Height`.
+        b"q BI /W 2 /CS /RGB /BPC 8 ID " + b"\x00" * 12 + b" EI Q",
+        # Missing `/Width`.
+        b"q BI /H 2 /CS /CMYK /BPC 8 ID " + b"\x00" * 16 + b" EI Q",
+        # `/Width` that is not a number.
+        b"q BI /W (x) /H 2 /CS /RGB /BPC 8 ID " + b"\x00" * 12 + b" EI Q",
+    ],
+)
+def test_contentstream__read_inline_image__malformed_settings(data):
+    """A malformed inline image dictionary must not crash content stream parsing."""
+    stream = ContentStream(stream=None, pdf=None)
+    stream.set_data(data)
+
+    operations = stream.operations
+
+    assert any(operator == b"INLINE IMAGE" for _, operator in operations)
+
+
 @pytest.mark.enable_socket
 def test_inline_image_containing_ei_in_body():
     """Tests for #3107"""


### PR DESCRIPTION
_read_inline_image reads the /F (/Filter), /CS, /BPC, /W and /H entries of a BI ... ID ... EI block straight from the content stream and assumes each is well formed, so a malformed inline image crashes content-stream parsing rather than degrading. an empty /Filter array hits filtr[0], an empty /CS array hits cs[0], a non-name /CS or non-numeric /BPC raises a typeerror on the membership and comparison checks, and a missing or non-integer /W or /H raises keyerror/typeerror when sizing the raw sample data; all are reachable from page.get_contents().operations, and anything else that walks a page's operations, on untrusted input. the guards keep the function on its existing fallbacks, treating an unusable filter or colour space as unfiltered or unknown and routing missing dimensions through extract_inline_default, which scans for the EI marker, so well-formed inline images decode exactly as before.