### PR TITLE
ROB: Tolerate malformed /FontBBox when building font descriptors

### DIFF
--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -274,9 +274,14 @@ class Font:
         """
         Convert a raw /FontBBox value into four floats.
 
-        Returns ``None`` when the value is not a sequence of exactly four
-        numbers, so a malformed entry falls back to the default bounding box
-        rather than raising.
+        Args:
+            raw_bbox: The raw /FontBBox value read from the PDF.
+
+        Returns:
+            The four bounding box values, or ``None`` when the value is not
+            a sequence of exactly four numbers, so that a malformed entry
+            falls back to the default bounding box rather than raising.
+
         """
         try:
             bbox = [float(value) for value in raw_bbox]

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import unicodedata
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from pypdf.generic import (
     ArrayObject,
@@ -60,6 +60,8 @@ class FontDescriptor:
     to 100.
     """
 
+    DEFAULT_BBOX: ClassVar[tuple[float, float, float, float]] = (-100.0, -200.0, 1000.0, 900.0)
+
     name: str = "Unknown"
     family: str = "Unknown"
     weight: str = "Unknown"
@@ -70,7 +72,7 @@ class FontDescriptor:
     x_height: float = 500.0
     italic_angle: float = 0.0  # Non-italic
     flags: int = 32  # Non-serif, non-symbolic, not fixed width
-    bbox: tuple[float, float, float, float] = field(default_factory=lambda: (-100.0, -200.0, 1000.0, 900.0))
+    bbox: tuple[float, float, float, float] = DEFAULT_BBOX
     font_file: StreamObject | None = None
 
     def as_font_descriptor_resource(self) -> DictionaryObject:
@@ -279,9 +281,8 @@ class Font:
         try:
             bbox = [float(value) for value in raw_bbox]
         except (TypeError, ValueError):
-            bbox = []
+            return None
         if len(bbox) != 4:
-            logger_warning(f"Ignoring invalid /FontBBox {raw_bbox!r}", source=__name__)
             return None
         return bbox[0], bbox[1], bbox[2], bbox[3]
 
@@ -380,12 +381,11 @@ class Font:
                     font_descriptor = FontDescriptor(**cls._parse_font_descriptor(font_descriptor_obj))
                 elif "/FontBBox" in pdf_font_dict:
                     # For Type3 without Font Descriptor but with FontBBox, see Table 110 in the PDF specification 2.0
+                    font_descriptor_kwargs: dict[str, Any] = {"name": name}
                     bbox = cls._parse_bbox(pdf_font_dict["/FontBBox"])
-                    font_descriptor = (
-                        FontDescriptor(name=name, bbox=bbox)
-                        if bbox is not None
-                        else FontDescriptor(name=name)
-                    )
+                    if bbox is not None:
+                        font_descriptor_kwargs["bbox"] = bbox
+                    font_descriptor = FontDescriptor(**font_descriptor_kwargs)
 
         else:
             # Composite font or CID font - CID fonts have a /W array mapping character codes

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -60,7 +60,7 @@ class FontDescriptor:
     to 100.
     """
 
-    DEFAULT_BBOX: ClassVar[tuple[float, float, float, float]] = (-100.0, -200.0, 1000.0, 900.0)
+    _DEFAULT_BBOX: ClassVar[tuple[float, float, float, float]] = (-100.0, -200.0, 1000.0, 900.0)
 
     name: str = "Unknown"
     family: str = "Unknown"
@@ -72,7 +72,7 @@ class FontDescriptor:
     x_height: float = 500.0
     italic_angle: float = 0.0  # Non-italic
     flags: int = 32  # Non-serif, non-symbolic, not fixed width
-    bbox: tuple[float, float, float, float] = DEFAULT_BBOX
+    bbox: tuple[float, float, float, float] = _DEFAULT_BBOX
     font_file: StreamObject | None = None
 
     def as_font_descriptor_resource(self) -> DictionaryObject:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -268,6 +268,24 @@ class Font:
         return character_widths["default"] // 2
 
     @staticmethod
+    def _parse_bbox(raw_bbox: Any) -> tuple[float, float, float, float] | None:
+        """
+        Convert a raw /FontBBox value into four floats.
+
+        Returns ``None`` when the value is not a sequence of exactly four
+        numbers, so a malformed entry falls back to the default bounding box
+        rather than raising.
+        """
+        try:
+            bbox = [float(value) for value in raw_bbox]
+        except (TypeError, ValueError):
+            bbox = []
+        if len(bbox) != 4:
+            logger_warning(f"Ignoring invalid /FontBBox {raw_bbox!r}", source=__name__)
+            return None
+        return bbox[0], bbox[1], bbox[2], bbox[3]
+
+    @staticmethod
     def _parse_font_descriptor(font_descriptor_obj: DictionaryObject) -> dict[str, Any]:
         font_descriptor_kwargs: dict[Any, Any] = {}
         for source_key, target_key in [
@@ -284,11 +302,13 @@ class Font:
         ]:
             if source_key in font_descriptor_obj:
                 font_descriptor_kwargs[target_key] = font_descriptor_obj[source_key]
-        # Handle missing bbox gracefully - PDFs may have fonts without valid bounding boxes
+        # Handle missing or malformed bbox gracefully - PDFs may have fonts without valid bounding boxes
         if "bbox" in font_descriptor_kwargs:
-            bbox_tuple = tuple(map(float, font_descriptor_kwargs["bbox"]))
-            assert len(bbox_tuple) == 4, bbox_tuple
-            font_descriptor_kwargs["bbox"] = bbox_tuple
+            bbox = Font._parse_bbox(font_descriptor_kwargs["bbox"])
+            if bbox is None:
+                del font_descriptor_kwargs["bbox"]
+            else:
+                font_descriptor_kwargs["bbox"] = bbox
 
         # Find the binary stream for this font if there is one
         for source_key in ["/FontFile", "/FontFile2", "/FontFile3"]:
@@ -360,9 +380,12 @@ class Font:
                     font_descriptor = FontDescriptor(**cls._parse_font_descriptor(font_descriptor_obj))
                 elif "/FontBBox" in pdf_font_dict:
                     # For Type3 without Font Descriptor but with FontBBox, see Table 110 in the PDF specification 2.0
-                    bbox_tuple = tuple(map(float, cast(ArrayObject, pdf_font_dict["/FontBBox"])))
-                    assert len(bbox_tuple) == 4, bbox_tuple
-                    font_descriptor = FontDescriptor(name=name, bbox=bbox_tuple)
+                    bbox = cls._parse_bbox(pdf_font_dict["/FontBBox"])
+                    font_descriptor = (
+                        FontDescriptor(name=name, bbox=bbox)
+                        if bbox is not None
+                        else FontDescriptor(name=name)
+                    )
 
         else:
             # Composite font or CID font - CID fonts have a /W array mapping character codes

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -94,7 +94,7 @@ def test_font_descriptor_malformed_bbox(bbox):
         }),
     })
     font = Font.from_font_resource(font_res)
-    assert font.font_descriptor.bbox == FontDescriptor.DEFAULT_BBOX
+    assert font.font_descriptor.bbox == FontDescriptor._DEFAULT_BBOX
 
 
 @pytest.mark.parametrize("bbox", [
@@ -110,7 +110,7 @@ def test_type3_font_malformed_bbox(bbox):
         NameObject("/FontBBox"): bbox,
     })
     font = Font.from_font_resource(font_res)
-    assert font.font_descriptor.bbox == FontDescriptor.DEFAULT_BBOX
+    assert font.font_descriptor.bbox == FontDescriptor._DEFAULT_BBOX
 
 
 def test_font_file():

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -77,6 +77,45 @@ def test_collect_cid_character_widths_truncated_w(w_array):
     Font.from_font_resource(font_res)
 
 
+DEFAULT_BBOX = (-100.0, -200.0, 1000.0, 900.0)
+
+
+@pytest.mark.parametrize("bbox", [
+    ArrayObject([NumberObject(0), NumberObject(0), NumberObject(100)]),  # too short
+    ArrayObject(NumberObject(v) for v in range(6)),  # too long
+    ArrayObject([NameObject("/x"), NumberObject(0), NumberObject(1), NumberObject(2)]),  # non-numeric
+    NumberObject(0),  # not a sequence
+])
+def test_font_descriptor_malformed_bbox(bbox):
+    # A /FontBBox that is not four numbers must fall back to the default
+    # bounding box instead of crashing text extraction.
+    font_res = DictionaryObject({
+        NameObject("/BaseFont"): NameObject("/Foo"),
+        NameObject("/Subtype"): NameObject("/Type1"),
+        NameObject("/FontDescriptor"): DictionaryObject({
+            NameObject("/FontBBox"): bbox,
+        }),
+    })
+    font = Font.from_font_resource(font_res)
+    assert font.font_descriptor.bbox == DEFAULT_BBOX
+
+
+@pytest.mark.parametrize("bbox", [
+    ArrayObject([NumberObject(0), NumberObject(0)]),  # too short
+    ArrayObject([NameObject("/x"), NumberObject(0), NumberObject(1), NumberObject(2)]),  # non-numeric
+])
+def test_type3_font_malformed_bbox(bbox):
+    # Type3 font without a /FontDescriptor but carrying a malformed /FontBBox.
+    font_res = DictionaryObject({
+        NameObject("/BaseFont"): NameObject("/Foo"),
+        NameObject("/Subtype"): NameObject("/Type3"),
+        NameObject("/ToUnicode"): NumberObject(0),
+        NameObject("/FontBBox"): bbox,
+    })
+    font = Font.from_font_resource(font_res)
+    assert font.font_descriptor.bbox == DEFAULT_BBOX
+
+
 def test_font_file():
     reader = PdfReader(RESOURCE_ROOT / "multilang.pdf")
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -8,7 +8,7 @@ import pytest
 from fontTools.ttLib import TTFont
 
 from pypdf import PdfReader, PdfWriter
-from pypdf._font import Font
+from pypdf._font import Font, FontDescriptor
 from pypdf.errors import PdfReadError
 from pypdf.generic import (
     ArrayObject,
@@ -77,14 +77,11 @@ def test_collect_cid_character_widths_truncated_w(w_array):
     Font.from_font_resource(font_res)
 
 
-DEFAULT_BBOX = (-100.0, -200.0, 1000.0, 900.0)
-
-
 @pytest.mark.parametrize("bbox", [
-    ArrayObject([NumberObject(0), NumberObject(0), NumberObject(100)]),  # too short
-    ArrayObject(NumberObject(v) for v in range(6)),  # too long
-    ArrayObject([NameObject("/x"), NumberObject(0), NumberObject(1), NumberObject(2)]),  # non-numeric
-    NumberObject(0),  # not a sequence
+    pytest.param(ArrayObject([NumberObject(0), NumberObject(0), NumberObject(100)]), id="too-short"),
+    pytest.param(ArrayObject(NumberObject(v) for v in range(6)), id="too-long"),
+    pytest.param(ArrayObject([NameObject("/x"), NumberObject(0), NumberObject(1), NumberObject(2)]), id="non-numeric"),
+    pytest.param(NumberObject(0), id="not-a-sequence"),
 ])
 def test_font_descriptor_malformed_bbox(bbox):
     # A /FontBBox that is not four numbers must fall back to the default
@@ -97,12 +94,12 @@ def test_font_descriptor_malformed_bbox(bbox):
         }),
     })
     font = Font.from_font_resource(font_res)
-    assert font.font_descriptor.bbox == DEFAULT_BBOX
+    assert font.font_descriptor.bbox == FontDescriptor.DEFAULT_BBOX
 
 
 @pytest.mark.parametrize("bbox", [
-    ArrayObject([NumberObject(0), NumberObject(0)]),  # too short
-    ArrayObject([NameObject("/x"), NumberObject(0), NumberObject(1), NumberObject(2)]),  # non-numeric
+    pytest.param(ArrayObject([NumberObject(0), NumberObject(0)]), id="too-short"),
+    pytest.param(ArrayObject([NameObject("/x"), NumberObject(0), NumberObject(1), NumberObject(2)]), id="non-numeric"),
 ])
 def test_type3_font_malformed_bbox(bbox):
     # Type3 font without a /FontDescriptor but carrying a malformed /FontBBox.
@@ -113,7 +110,7 @@ def test_type3_font_malformed_bbox(bbox):
         NameObject("/FontBBox"): bbox,
     })
     font = Font.from_font_resource(font_res)
-    assert font.font_descriptor.bbox == DEFAULT_BBOX
+    assert font.font_descriptor.bbox == FontDescriptor.DEFAULT_BBOX
 
 
 def test_font_file():


### PR DESCRIPTION
**Malformed /FontBBox aborts text extraction**

A font's `/FontBBox` is validated with `assert len(...) == 4` after `map(float, ...)`, so a box that is not four numbers raises `AssertionError` and a non-numeric entry raises `ValueError`. Neither is caught by the `(AttributeError, TypeError)` guard around font resolution in `_extract_text` (nor the unguarded layout-mode path), so `page.extract_text()` aborts on an otherwise readable file. Both `/FontBBox` sites now route through a small helper that warns and falls back to the default bounding box, which keeps the existing missing-bbox behaviour and should be a little easier to reason about.