### PR TITLE
ROB: guard empty link destination arrays during page transfer

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3036,6 +3036,8 @@ class PdfWriter(PdfDocCommon):
                             outlist.append(ano.clone(self).indirect_reference)
                     else:
                         d = cast("ArrayObject", d)
+                        if not isinstance(d, list) or not d:
+                            continue
                         p = self._get_cloned_page(d[0], pages, reader)
                         if p is not None:
                             anc = ano.clone(self, ignore_fields=("/Dest",))
@@ -3051,6 +3053,8 @@ class PdfWriter(PdfDocCommon):
                         outlist.append(ano.clone(self).indirect_reference)
                 else:
                     d = cast("ArrayObject", d)
+                    if not isinstance(d, list) or not d:
+                        continue
                     p = self._get_cloned_page(d[0], pages, reader)
                     if p is not None:
                         anc = ano.clone(self, ignore_fields=("/D",))

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3035,8 +3035,7 @@ class PdfWriter(PdfDocCommon):
                         if str(d) in self.get_named_dest_root():
                             outlist.append(ano.clone(self).indirect_reference)
                     else:
-                        d = cast("ArrayObject", d)
-                        if not isinstance(d, list) or not d:
+                        if not isinstance(d, ArrayObject) or not d:
                             continue
                         p = self._get_cloned_page(d[0], pages, reader)
                         if p is not None:
@@ -3052,8 +3051,7 @@ class PdfWriter(PdfDocCommon):
                     if str(d) in self.get_named_dest_root():
                         outlist.append(ano.clone(self).indirect_reference)
                 else:
-                    d = cast("ArrayObject", d)
-                    if not isinstance(d, list) or not d:
+                    if not isinstance(d, ArrayObject) or not d:
                         continue
                     p = self._get_cloned_page(d[0], pages, reader)
                     if p is not None:

--- a/pypdf/generic/_link.py
+++ b/pypdf/generic/_link.py
@@ -65,7 +65,9 @@ class DirectReferenceLink:
         """reference: an ArrayObject whose first element is the Page indirect object"""
         self._reference = reference
 
-    def find_referenced_page(self) -> IndirectObject:
+    def find_referenced_page(self) -> Union[IndirectObject, None]:
+        if not self._reference:
+            return None
         return cast(IndirectObject, self._reference[0])
 
     def patch_reference(self, target_pdf: "PdfWriter", new_page: IndirectObject) -> None:

--- a/tests/generic/test_link.py
+++ b/tests/generic/test_link.py
@@ -120,3 +120,10 @@ def test_extract_links_ignores_uri_annotation_offsets(caplog: pytest.LogCaptureF
     assert isinstance(links[0][0], DirectReferenceLink)
     assert isinstance(links[0][1], DirectReferenceLink)
     assert caplog.messages == []
+
+
+def test_direct_reference_link_empty_reference() -> None:
+    # An empty destination array has no target page to resolve.
+    assert DirectReferenceLink(ArrayObject([])).find_referenced_page() is None
+    # A populated array still resolves to its first element.
+    assert DirectReferenceLink(ArrayObject([NumberObject(7)])).find_referenced_page() == 7

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -899,6 +899,56 @@ def test_link_annotation(pdf_file_path):
         writer.write(output_stream)
 
 
+def _reader_with_link_annotation(annotation: DictionaryObject) -> PdfReader:
+    """A one-page PDF whose single page carries the given link annotation."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Annots")] = ArrayObject([writer._add_object(annotation)])
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+    return PdfReader(stream)
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        # Empty /Dest array.
+        DictionaryObject({
+            NameObject("/Subtype"): NameObject("/Link"),
+            NameObject("/Dest"): ArrayObject([]),
+        }),
+        # Empty /GoTo action destination.
+        DictionaryObject({
+            NameObject("/Subtype"): NameObject("/Link"),
+            NameObject("/A"): DictionaryObject({
+                NameObject("/S"): NameObject("/GoTo"),
+                NameObject("/D"): ArrayObject([]),
+            }),
+        }),
+        # /Dest that is not an array at all.
+        DictionaryObject({
+            NameObject("/Subtype"): NameObject("/Link"),
+            NameObject("/Dest"): NumberObject(5),
+        }),
+    ],
+)
+def test_malformed_link_destination_does_not_crash_transfer(annotation):
+    """A link with an empty or non-array destination must not abort page transfer."""
+    reader = _reader_with_link_annotation(annotation)
+
+    # append() routes the annotation through _insert_filtered_annotations.
+    appended = PdfWriter()
+    appended.append(reader)
+    appended.write(BytesIO())
+
+    # add_page() + write() routes it through extract_links()/_resolve_links().
+    added = PdfWriter()
+    for page in reader.pages:
+        added.add_page(page)
+    added.write(BytesIO())
+
+
 def test_io_streams():
     """This is the example from the docs ("Streaming data")."""
     filepath = RESOURCE_ROOT / "pdflatex-outline.pdf"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -899,17 +899,6 @@ def test_link_annotation(pdf_file_path):
         writer.write(output_stream)
 
 
-def _reader_with_link_annotation(annotation: DictionaryObject) -> PdfReader:
-    """A one-page PDF whose single page carries the given link annotation."""
-    writer = PdfWriter()
-    writer.add_blank_page(width=72, height=72)
-    writer.pages[0][NameObject("/Annots")] = ArrayObject([writer._add_object(annotation)])
-    stream = BytesIO()
-    writer.write(stream)
-    stream.seek(0)
-    return PdfReader(stream)
-
-
 @pytest.mark.parametrize(
     "annotation",
     [
@@ -932,10 +921,17 @@ def _reader_with_link_annotation(annotation: DictionaryObject) -> PdfReader:
             NameObject("/Dest"): NumberObject(5),
         }),
     ],
+    ids=["empty-dest-array", "empty-goto-action-dest", "non-array-dest"],
 )
 def test_malformed_link_destination_does_not_crash_transfer(annotation):
     """A link with an empty or non-array destination must not abort page transfer."""
-    reader = _reader_with_link_annotation(annotation)
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Annots")] = ArrayObject([writer._add_object(annotation)])
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+    reader = PdfReader(stream)
 
     # append() routes the annotation through _insert_filtered_annotations.
     appended = PdfWriter()


### PR DESCRIPTION
**Empty link destination arrays crash page transfer**

A `/Link` annotation whose `/Dest` (or `/GoTo` action `/D`) is an empty array makes page transfer read the target page from `d[0]` with no length check, so `append()`/`merge()` raise `IndexError` in `_insert_filtered_annotations`, and `add_page()` followed by `write()` raises it from `DirectReferenceLink.find_referenced_page` via `_resolve_links`; a non-array `/Dest` trips `TypeError` likewise. Both sites now skip a destination that is not a non-empty array, matching the existing drop-when-unresolvable handling and the `None` path already present in `_resolve_links`.

Repro:

```python
from io import BytesIO
from pypdf import PdfReader, PdfWriter
from pypdf.generic import ArrayObject, DictionaryObject, NameObject

src = PdfWriter()
src.add_blank_page(width=72, height=72)
link = DictionaryObject({
    NameObject("/Subtype"): NameObject("/Link"),
    NameObject("/Dest"): ArrayObject([]),  # empty destination
})
src.pages[0][NameObject("/Annots")] = ArrayObject([src._add_object(link)])
buf = BytesIO(); src.write(buf); buf.seek(0)

writer = PdfWriter()
writer.append(PdfReader(buf))   # IndexError before this change
writer.write(BytesIO())
```
