### PR TITLE
ROB: tolerate malformed /Decode array in image extraction

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -398,6 +398,18 @@ def _apply_decode(
         and color_space[0].get_object() == "/Separation"
     ):
         decode = [1.0, 0.0] * len(img.getbands())
+    if decode is not None and (
+        not isinstance(decode, (list, tuple)) or len(decode) % 2 != 0
+    ):
+        # /Decode is read straight from the image dictionary and must hold an
+        # even number of values (a [min max] pair per component). A malformed
+        # array would otherwise read past its end at decode[i + 1]; drop it and
+        # render the image without the remap.
+        logger_warning(
+            "Ignoring malformed /Decode array; expected an even number of values.",
+            source=__name__,
+        )
+        decode = None
     if decode is not None and not all(decode[i] == i % 2 for i in range(len(decode))):
         lut: list[int] = []
         for i in range(0, len(decode), 2):

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -399,15 +399,16 @@ def _apply_decode(
     ):
         decode = [1.0, 0.0] * len(img.getbands())
     if decode is not None and (
-        not isinstance(decode, (list, tuple)) or len(decode) % 2 != 0
+        not isinstance(decode, list) or len(decode) % 2 != 0
     ):
         # /Decode is read straight from the image dictionary and must hold an
         # even number of values (a [min max] pair per component). A malformed
         # array would otherwise read past its end at decode[i + 1]; drop it and
         # render the image without the remap.
         logger_warning(
-            "Ignoring malformed /Decode array; expected an even number of values.",
+            "Ignoring malformed /Decode array %(decode)s; expected an even number of values.",
             source=__name__,
+            decode=decode,
         )
         decode = None
     if decode is not None and not all(decode[i] == i % 2 for i in range(len(decode))):

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 from pypdf import PdfReader
 from pypdf._utils import Version
-from pypdf.constants import FilterTypes, ImageAttributes, StreamAttributes
+from pypdf.constants import ColorSpaces, FilterTypes, ImageAttributes, StreamAttributes
 from pypdf.errors import EmptyImageDataError, LimitReachedError, PdfReadError
 from pypdf.generic import (
     ArrayObject,
@@ -419,6 +419,7 @@ def test_xobj_to_image__color_components_out_of_range() -> None:
         ArrayObject([NumberObject(1)]),
         NumberObject(1),
     ],
+    ids=["odd-length-array", "single-value-array", "not-an-array"],
 )
 def test_xobj_to_image__malformed_decode(
     decode: PdfObject, caplog: pytest.LogCaptureFixture
@@ -427,8 +428,8 @@ def test_xobj_to_image__malformed_decode(
     x_object = StreamObject()
     x_object[NameObject(ImageAttributes.WIDTH)] = NumberObject(2)
     x_object[NameObject(ImageAttributes.HEIGHT)] = NumberObject(2)
-    x_object[NameObject("/BitsPerComponent")] = NumberObject(8)
-    x_object[NameObject(ImageAttributes.COLOR_SPACE)] = NameObject("/DeviceGray")
+    x_object[NameObject(ImageAttributes.BITS_PER_COMPONENT)] = NumberObject(8)
+    x_object[NameObject(ImageAttributes.COLOR_SPACE)] = NameObject(ColorSpaces.DEVICE_GRAY)
     x_object[NameObject(StreamAttributes.FILTER)] = NameObject(FilterTypes.FLATE_DECODE)
     x_object[NameObject(ImageAttributes.DECODE)] = decode
     x_object.set_data(zlib.compress(bytes([0, 64, 128, 255])))

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -1,4 +1,5 @@
 """Test the pypdf.generic._image_xobject module."""
+import zlib
 from io import BytesIO
 
 import PIL
@@ -9,7 +10,15 @@ from pypdf import PdfReader
 from pypdf._utils import Version
 from pypdf.constants import FilterTypes, ImageAttributes, StreamAttributes
 from pypdf.errors import EmptyImageDataError, LimitReachedError, PdfReadError
-from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject, StreamObject, TextStringObject
+from pypdf.generic import (
+    ArrayObject,
+    DecodedStreamObject,
+    NameObject,
+    NumberObject,
+    PdfObject,
+    StreamObject,
+    TextStringObject,
+)
 from pypdf.generic._image_xobject import (
     _get_image_mode,
     _handle_flate,
@@ -401,6 +410,33 @@ def test_xobj_to_image__color_components_out_of_range() -> None:
 
     with pytest.raises(PdfReadError, match=r"^ColorSpace field not found in .+"):
         _xobj_to_image(x_object)
+
+
+@pytest.mark.parametrize(
+    "decode",
+    [
+        ArrayObject([NumberObject(1), NumberObject(0), NumberObject(1)]),
+        ArrayObject([NumberObject(1)]),
+        NumberObject(1),
+    ],
+)
+def test_xobj_to_image__malformed_decode(
+    decode: PdfObject, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A /Decode without an even number of values must not raise IndexError."""
+    x_object = StreamObject()
+    x_object[NameObject(ImageAttributes.WIDTH)] = NumberObject(2)
+    x_object[NameObject(ImageAttributes.HEIGHT)] = NumberObject(2)
+    x_object[NameObject("/BitsPerComponent")] = NumberObject(8)
+    x_object[NameObject(ImageAttributes.COLOR_SPACE)] = NameObject("/DeviceGray")
+    x_object[NameObject(StreamAttributes.FILTER)] = NameObject(FilterTypes.FLATE_DECODE)
+    x_object[NameObject(ImageAttributes.DECODE)] = decode
+    x_object.set_data(zlib.compress(bytes([0, 64, 128, 255])))
+
+    _, _, image = _xobj_to_image(x_object)
+    image.load()
+    assert image.size == (2, 2)
+    assert "Ignoring malformed /Decode array" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When extracting an image, `_apply_decode` reads the image XObject's `/Decode` entry and walks it in `[min, max]` pairs to build the remap table, taking `decode[i + 1]` at each step. That value comes straight from the PDF and is only meaningful as an even-length array of numbers, but the length was never checked, so an object whose `/Decode` carries an odd number of entries reads past the end of the list and a non-array `/Decode` has no length at all. Both escape through `reader.pages[i].images`, which is the public path that reaches `_xobj_to_image` and then `_apply_decode`, so a crafted file aborts image extraction rather than degrading. I came across it on a fuzzed image whose `/Decode` held three numbers, where the `decode[i + 1]` access went out of range. The guard rejects a `/Decode` that is not a list or tuple of even length, warns, and falls back to rendering the image without the remap, which keeps a malformed array a best-effort image instead of an exception. I kept the change inside `_apply_decode` so valid even-length arrays are unaffected, and added a regression test alongside the existing decode cases.
