### PR TITLE
ENH: Add ActualText tag when we produce RTL appearance stream

### DIFF
--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -8,10 +8,11 @@ import math
 from typing import Any, Callable, Optional, Union
 
 from .._font import Font
+from .._utils import is_char_rtl
 from ..generic import DictionaryObject, TextStringObject, encode_pdfdocencoding
 
-CUSTOM_RTL_MIN: int = -1
-CUSTOM_RTL_MAX: int = -1
+CUSTOM_RTL_MIN: str = ""
+CUSTOM_RTL_MAX: str = ""
 CUSTOM_RTL_SPECIAL_CHARS: list[int] = []
 LAYOUT_NEW_BT_GROUP_SPACE_WIDTHS: int = 5
 
@@ -21,10 +22,10 @@ class OrientationNotFoundError(Exception):
 
 
 def set_custom_rtl(
-    _min: Union[str, int, None] = None,
-    _max: Union[str, int, None] = None,
+    _min: Union[str, int, None] = "",
+    _max: Union[str, int, None] = "",
     specials: Union[str, list[int], None] = None,
-) -> tuple[int, int, list[int]]:
+) -> tuple[str, str, list[int]]:
     """
     Change the Right-To-Left and special characters custom parameters.
 
@@ -32,13 +33,13 @@ def set_custom_rtl(
         _min: The new minimum value for the range of custom characters that
             will be written right to left.
             If set to ``None``, the value will not be changed.
-            If set to an integer or string, it will be converted to its ASCII code.
-            The default value is -1, which sets no additional range to be converted.
+            If set to a valid integer, it will be converted to its corresponding character.
+            The default value is "", which sets no additional range to be converted.
         _max: The new maximum value for the range of custom characters that will
             be written right to left.
             If set to ``None``, the value will not be changed.
-            If set to an integer or string, it will be converted to its ASCII code.
-            The default value is -1, which sets no additional range to be converted.
+            If set to a valid integer, it will be converted to its corresponding character.
+            The default value is "", which sets no additional range to be converted.
         specials: The new list of special characters to be inserted in the
             current insertion order.
             If set to ``None``, the current value will not be changed.
@@ -52,13 +53,13 @@ def set_custom_rtl(
     """
     global CUSTOM_RTL_MIN, CUSTOM_RTL_MAX, CUSTOM_RTL_SPECIAL_CHARS
     if isinstance(_min, int):
-        CUSTOM_RTL_MIN = _min
+        CUSTOM_RTL_MIN = chr(_min) if 0 <= _min <= 0x10FFFF else ""
     elif isinstance(_min, str):
-        CUSTOM_RTL_MIN = ord(_min)
+        CUSTOM_RTL_MIN = _min
     if isinstance(_max, int):
-        CUSTOM_RTL_MAX = _max
+        CUSTOM_RTL_MAX = chr(_max) if 0 <= _max <= 0x10FFFF else ""
     elif isinstance(_max, str):
-        CUSTOM_RTL_MAX = ord(_max)
+        CUSTOM_RTL_MAX = _max
     if isinstance(specials, str):
         CUSTOM_RTL_SPECIAL_CHARS = [ord(x) for x in specials]
     elif isinstance(specials, list):
@@ -224,10 +225,7 @@ def get_display_str(
         ):
             text = x + text if rtl_dir else text + x
         elif (  # right-to-left characters set
-            0x0590 <= xx <= 0x08FF
-            or 0xFB1D <= xx <= 0xFDFF
-            or 0xFE70 <= xx <= 0xFEFF
-            or CUSTOM_RTL_MIN <= xx <= CUSTOM_RTL_MAX
+            len(x) == 1 and is_char_rtl(x, CUSTOM_RTL_MIN, CUSTOM_RTL_MAX)
         ):
             if not rtl_dir:
                 rtl_dir = True

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -8,12 +8,12 @@ import math
 from typing import Any, Callable, Optional, Union
 
 from .._font import Font
-from .._utils import is_char_rtl
+from .._utils import is_char_neutral, is_char_rtl
 from ..generic import DictionaryObject, TextStringObject, encode_pdfdocencoding
 
 CUSTOM_RTL_MIN: str = ""
 CUSTOM_RTL_MAX: str = ""
-CUSTOM_RTL_SPECIAL_CHARS: list[int] = []
+CUSTOM_RTL_SPECIAL_CHARS: str = ""
 LAYOUT_NEW_BT_GROUP_SPACE_WIDTHS: int = 5
 
 
@@ -25,7 +25,7 @@ def set_custom_rtl(
     _min: Union[str, int, None] = "",
     _max: Union[str, int, None] = "",
     specials: Union[str, list[int], None] = None,
-) -> tuple[str, str, list[int]]:
+) -> tuple[str, str, str]:
     """
     Change the Right-To-Left and special characters custom parameters.
 
@@ -61,9 +61,9 @@ def set_custom_rtl(
     elif isinstance(_max, str):
         CUSTOM_RTL_MAX = _max
     if isinstance(specials, str):
-        CUSTOM_RTL_SPECIAL_CHARS = [ord(x) for x in specials]
-    elif isinstance(specials, list):
         CUSTOM_RTL_SPECIAL_CHARS = specials
+    elif isinstance(specials, list):
+        CUSTOM_RTL_SPECIAL_CHARS = "".join(chr(char) for char in specials if 0 <= char <= 0x10FFFF)
     return CUSTOM_RTL_MIN, CUSTOM_RTL_MAX, CUSTOM_RTL_SPECIAL_CHARS
 
 
@@ -209,36 +209,30 @@ def get_display_str(
     for raw_character in text_operands:
         widths += font.space_width if raw_character == font.space_char else font.get_text_width(raw_character)
         x = font.character_map.get(raw_character, raw_character)
-        # x can be a sequence of bytes ; ex: habibi.pdf
+        # Test whether x is a sequence of bytes; ex: habibi.pdf
         if len(x) == 1:
-            xx = ord(x)
+            if (
+                # cases where the current inserting order is kept
+                is_char_neutral(x, CUSTOM_RTL_SPECIAL_CHARS)
+            ):
+                text = x + text if rtl_dir else text + x
+            elif (  # right-to-left characters set
+                is_char_rtl(x, CUSTOM_RTL_MIN, CUSTOM_RTL_MAX)
+            ):
+                if not rtl_dir:
+                    rtl_dir = True
+                    if visitor_text is not None:
+                        visitor_text(text, cm_matrix, tm_matrix, font_resource, font_size)
+                    text = ""
+                text = x + text
+            else:  # left-to-right
+                if rtl_dir:
+                    rtl_dir = False
+                    if visitor_text is not None:
+                        visitor_text(text, cm_matrix, tm_matrix, font_resource, font_size)
+                    text = ""
+                text = text + x
         else:
-            xx = 1
-        # fmt: off
-        if (
-            # cases where the current inserting order is kept
-            (xx <= 0x2F)                        # punctuations but...
-            or 0x3A <= xx <= 0x40               # numbers (x30-39)
-            or 0x2000 <= xx <= 0x206F           # upper punctuations..
-            or 0x20A0 <= xx <= 0x21FF           # but (numbers) indices/exponents
-            or xx in CUSTOM_RTL_SPECIAL_CHARS   # customized....
-        ):
+            # Treat a sequence of bytes as a neutral character.
             text = x + text if rtl_dir else text + x
-        elif (  # right-to-left characters set
-            len(x) == 1 and is_char_rtl(x, CUSTOM_RTL_MIN, CUSTOM_RTL_MAX)
-        ):
-            if not rtl_dir:
-                rtl_dir = True
-                if visitor_text is not None:
-                    visitor_text(text, cm_matrix, tm_matrix, font_resource, font_size)
-                text = ""
-            text = x + text
-        else:  # left-to-right
-            if rtl_dir:
-                rtl_dir = False
-                if visitor_text is not None:
-                    visitor_text(text, cm_matrix, tm_matrix, font_resource, font_size)
-                text = ""
-            text = text + x
-        # fmt: on
     return text, rtl_dir, widths

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -216,11 +216,12 @@ def get_display_str(
         # Test whether x is a sequence of bytes; ex: habibi.pdf
         if len(x) == 1:
             if (
-                # cases where the current inserting order is kept
+                # Cases where the current inserting order is kept
                 is_char_neutral(x, CUSTOM_RTL_SPECIAL_CHARS)
             ):
                 text = x + text if rtl_dir else text + x
-            elif (  # right-to-left characters set
+            elif (
+                # Right-to-left characters
                 is_char_rtl(x, CUSTOM_RTL_MIN, CUSTOM_RTL_MAX)
             ):
                 if not rtl_dir:
@@ -229,7 +230,8 @@ def get_display_str(
                         visitor_text(text, cm_matrix, tm_matrix, font_resource, font_size)
                     text = ""
                 text = x + text
-            else:  # left-to-right
+            else:
+                # Left-to-right characters
                 if rtl_dir:
                     rtl_dir = False
                     if visitor_text is not None:

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -15,6 +15,8 @@ CUSTOM_RTL_MIN: str = ""
 CUSTOM_RTL_MAX: str = ""
 CUSTOM_RTL_SPECIAL_CHARS: str = ""
 LAYOUT_NEW_BT_GROUP_SPACE_WIDTHS: int = 5
+UNICODE_LOWER_LIMIT = 0
+UNICODE_UPPER_LIMIT = 0x10FFFF
 
 
 class OrientationNotFoundError(Exception):
@@ -53,17 +55,19 @@ def set_custom_rtl(
     """
     global CUSTOM_RTL_MIN, CUSTOM_RTL_MAX, CUSTOM_RTL_SPECIAL_CHARS
     if isinstance(_min, int):
-        CUSTOM_RTL_MIN = chr(_min) if 0 <= _min <= 0x10FFFF else ""
+        CUSTOM_RTL_MIN = chr(_min) if UNICODE_LOWER_LIMIT <= _min <= UNICODE_UPPER_LIMIT else ""
     elif isinstance(_min, str):
         CUSTOM_RTL_MIN = _min
     if isinstance(_max, int):
-        CUSTOM_RTL_MAX = chr(_max) if 0 <= _max <= 0x10FFFF else ""
+        CUSTOM_RTL_MAX = chr(_max) if UNICODE_LOWER_LIMIT <= _max <= UNICODE_UPPER_LIMIT else ""
     elif isinstance(_max, str):
         CUSTOM_RTL_MAX = _max
     if isinstance(specials, str):
         CUSTOM_RTL_SPECIAL_CHARS = specials
     elif isinstance(specials, list):
-        CUSTOM_RTL_SPECIAL_CHARS = "".join(chr(char) for char in specials if 0 <= char <= 0x10FFFF)
+        CUSTOM_RTL_SPECIAL_CHARS = "".join(
+            chr(char) for char in specials if UNICODE_LOWER_LIMIT <= char <= UNICODE_UPPER_LIMIT
+        )
     return CUSTOM_RTL_MIN, CUSTOM_RTL_MAX, CUSTOM_RTL_SPECIAL_CHARS
 
 

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -235,10 +235,10 @@ def check_if_whitespace_only(value: bytes) -> bool:
 
 
 NEUTRAL_CHARACTER_RANGES = (
-    ("\x00", "\x2F"),      # punctuations but...
-    ("\x3A", "\x40"),      # numbers (x30-39)
-    ("\u2000", "\u206F"),  # upper punctuations..
-    ("\u20A0", "\u21FF"),  # but (numbers) indices/exponents
+    ("\x00", "\x2F"),      # ASCII control codes, space, and early punctuation (!"#$%)
+    ("\x3A", "\x40"),      # ASCII operators and punctuation between digits & A (:;<=>?@)
+    ("\u2000", "\u206F"),  # General punctuation
+    ("\u20A0", "\u21FF"),  # Currency symbols, diacritical marks, letter-like symbols, number forms, arrows
 )
 
 

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -234,6 +234,22 @@ def check_if_whitespace_only(value: bytes) -> bool:
     return all(b in WHITESPACES_AS_BYTES for b in value)
 
 
+NEUTRAL_CHARACTER_RANGES = (
+    ("\x00", "\x2F"),      # punctuations but...
+    ("\x3A", "\x40"),      # numbers (x30-39)
+    ("\u2000", "\u206F"),  # upper punctuations..
+    ("\u20A0", "\u21FF"),  # but (numbers) indices/exponents
+)
+
+
+def is_char_neutral(char: str, custom_special_characters: str = "") -> bool:
+    """Check if a character is part of neutral character ranges"""
+    if any(start <= char <= end for start, end in NEUTRAL_CHARACTER_RANGES):
+        return True
+
+    return bool(custom_special_characters and char in custom_special_characters)
+
+
 RTL_CHARACTER_RANGES = (
     ("\u0590", "\u08FF"),  # Hebrew, Arabic, Syriac, Thaana, N'Ko, etc.
     ("\uFB1D", "\uFDFF"),  # Hebrew & Arabic Presentation Forms-A

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -234,6 +234,21 @@ def check_if_whitespace_only(value: bytes) -> bool:
     return all(b in WHITESPACES_AS_BYTES for b in value)
 
 
+RTL_CHARACTER_RANGES = (
+    ("\u0590", "\u08FF"),  # Hebrew, Arabic, Syriac, Thaana, N'Ko, etc.
+    ("\uFB1D", "\uFDFF"),  # Hebrew & Arabic Presentation Forms-A
+    ("\uFE70", "\uFEFF"),  # Arabic Presentation Forms-B
+)
+
+
+def is_char_rtl(char: str, custom_rtl_min: str = "", custom_rtl_max: str = "") -> bool:
+    """Check if a character is part of RTL character ranges"""
+    if any(start <= char <= end for start, end in RTL_CHARACTER_RANGES):
+        return True
+
+    return bool(custom_rtl_min and custom_rtl_max and (custom_rtl_min <= char <= custom_rtl_max))
+
+
 def skip_over_comment(stream: StreamType) -> None:
     tok = stream.read(1)
     stream.seek(-1, 1)

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -86,10 +86,10 @@ class TextStreamAppearance(BaseStreamAppearance):
         leading_factor: float,
         field_width: float,
         field_height: float,
-        paragraphs: list[str],
+        paragraphs: list[list[tuple[float, str, str]]],
         min_font_size: float,
         font_size_step: float = 0.2
-    ) -> tuple[list[tuple[float, str]], float]:
+    ) -> tuple[list[tuple[float, str, str]], float]:
         """
         Takes a piece of text and scales it to field_width or field_height, given font_name
         and font_size. Wraps text where necessary.
@@ -100,7 +100,8 @@ class TextStreamAppearance(BaseStreamAppearance):
             leading_factor: The line distance.
             field_width: The width of the field in which to fit the text.
             field_height: The height of the field in which to fit the text.
-            paragraphs: The text paragraphs to fit with the field.
+            paragraphs: The list of text paragraphs to fit with the field, where each paragraph is
+                a list of tuples of unscaled width, unencoded text, and glyphs (font-encoded text).
             min_font_size: The minimum font size at which to scale the text.
             font_size_step: The amount by which to decrement font size per step while scaling.
 
@@ -109,32 +110,36 @@ class TextStreamAppearance(BaseStreamAppearance):
             and its contents, and the font_size for these lines and lengths.
         """
         wrapped_lines = []
-        current_line_words: list[str] = []
+        current_line_words: list[tuple[float, str, str]] = []
         current_line_width: float = 0
         space_width = font.space_width * font_size / 1000
         for paragraph in paragraphs:
-            if not paragraph.strip():
-                wrapped_lines.append((0.0, ""))
-                continue
-            words = paragraph.split(font.space_char)
-            for i, word in enumerate(words):
-                word_width = font.get_text_width(word) * font_size / 1000
+            for i, width_word_glyphs in enumerate(paragraph):
+                word_width = width_word_glyphs[0] * font_size
                 test_width = current_line_width + word_width + (space_width if i else 0)
                 if test_width > field_width and current_line_words:
-                    wrapped_lines.append((current_line_width, font.space_char.join(current_line_words)))
-                    current_line_words = [word]
+                    wrapped_lines.append((
+                        current_line_width,
+                        " ".join([word[1] for word in current_line_words]),
+                        font.space_char.join([word[2] for word in current_line_words])
+                    ))
+                    current_line_words = [width_word_glyphs]
                     current_line_width = word_width
                 elif not current_line_words and word_width > field_width:
-                    wrapped_lines.append((word_width, word))
+                    wrapped_lines.append((word_width, width_word_glyphs[1], width_word_glyphs[2]))
                     current_line_words = []
                     current_line_width = 0
                 else:
                     if current_line_words:
                         current_line_width += space_width
-                    current_line_words.append(word)
+                    current_line_words.append(width_word_glyphs)
                     current_line_width += word_width
             if current_line_words:
-                wrapped_lines.append((current_line_width, font.space_char.join(current_line_words)))
+                wrapped_lines.append((
+                    current_line_width,
+                    " ".join([word[1] for word in current_line_words]),
+                    font.space_char.join([word[2] for word in current_line_words])
+                ))
                 current_line_words = []
                 current_line_width = 0
         # Estimate total height.
@@ -225,21 +230,31 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         # If font_size is 0, apply the logic for multiline or large-as-possible font
         if font_size == 0:
-            min_font_size = 4.0       # The mininum font size
+            min_font_size = 4.0       # The minimum font size
             if selection:             # Don't wrap text when dealing with a /Ch field, in order to prevent problems
                 is_multiline = False  # with matching "selection" with "line" later on.
             if is_multiline:
                 font_size = DEFAULT_FONT_SIZE_IN_MULTILINE
-                glyph_paragraphs = [
-                    _unicode_to_glyph_id(paragraph, reverse_cmap) for paragraph in text.splitlines()
-                ]
+                # We create a list of paragraphs, here each paragraph is a list of tuples, where each
+                # tuple signifies an unscaled word width, the word itself, and the glyphs that encode it.
+                paragraphs: list[list[tuple[float, str, str]]] = []
+                for line in text.splitlines():
+                    if not line.strip():
+                        paragraphs.append([(0.0, "", "")])
+                        continue
+                    line_by_widths_words_glyphs: list[tuple[float, str, str]] = []
+                    words = line.split(" ")
+                    for word in words:
+                        glyph_word = _unicode_to_glyph_id(word, reverse_cmap)
+                        line_by_widths_words_glyphs.append((font.get_text_width(word) / 1000, word, glyph_word))
+                    paragraphs.append(line_by_widths_words_glyphs)
                 lines, font_size = self._scale_text(
                     font,
                     font_size,
                     leading_factor,
                     field_width,
                     field_height,
-                    glyph_paragraphs,
+                    paragraphs,
                     min_font_size
                 )
             else:
@@ -248,7 +263,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                 text_width_unscaled = font.get_text_width(glyphs) / 1000
                 max_horizontal_size = field_width / (text_width_unscaled or 1)
                 font_size = round(max(min(max_vertical_size, max_horizontal_size), min_font_size), 1)
-                lines = [(text_width_unscaled * font_size, glyphs)]
+                lines = [(text_width_unscaled * font_size, text, glyphs)]
         elif is_comb:
             if max_length and len(text) > max_length:
                 logger_warning(
@@ -265,12 +280,12 @@ class TextStreamAppearance(BaseStreamAppearance):
             for index, char in enumerate(text):
                 if index < (max_length or len(text)):
                     glyphs = _unicode_to_glyph_id(char, reverse_cmap)
-                    lines.append((font.get_text_width(glyphs) * font_size / 1000, glyphs))
+                    lines.append((font.get_text_width(glyphs) * font_size / 1000, char, glyphs))
         else:
             lines = []
             for line in text.splitlines():
                 glyphs = _unicode_to_glyph_id(line, reverse_cmap)
-                lines.append((font.get_text_width(glyphs) * font_size / 1000, glyphs))
+                lines.append((font.get_text_width(glyphs) * font_size / 1000, line, glyphs))
 
         # Set the vertical offset
         if is_multiline:
@@ -285,7 +300,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         ).encode()
         current_x_pos: float = 0  # Initial virtual position within the text object.
 
-        for line_number, (line_width, line) in enumerate(lines):
+        for line_number, (line_width, _, line) in enumerate(lines):
             if selection and line in _unicode_to_glyph_id("".join(selection), reverse_cmap):
                 # Might be improved, but cannot find how to get fill working => replaced with lined box
                 ap_stream += (

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -300,7 +300,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         ).encode()
         current_x_pos: float = 0  # Initial virtual position within the text object.
 
-        for line_number, (line_width, _, line) in enumerate(lines):
+        for line_number, (line_width, original_text, line) in enumerate(lines):
             if selection and line in _unicode_to_glyph_id("".join(selection), reverse_cmap):
                 # Might be improved, but cannot find how to get fill working => replaced with lined box
                 ap_stream += (
@@ -345,11 +345,25 @@ class TextStreamAppearance(BaseStreamAppearance):
             # This is the X position where the *current line* will start.
             current_x_pos = desired_abs_x_start
 
+            is_rtl = any(
+                0x0590 <= ord(char) <= 0x08FF or
+                0xFB1D <= ord(char) <= 0xFDFF or
+                0xFE70 <= ord(char) <= 0xFEFF
+                for char in line
+            )
             encoded_line = _glyph_id_to_bytes(line, encoding_cmap)
+            if is_rtl:
+                # Encode input text as UTF-16BE with a BOM, so that the input text is returned
+                # in the right direction when copying text from the resulting PDF
+                bom_text = b"\xfe\xff" + original_text.encode("utf-16-be")
+                hex_original_text = bom_text.hex().upper()
+                ap_stream += f"/Span << /ActualText <{hex_original_text}> >> BDC\n".encode()
             if any(len(c) >= 2 for c in encoded_line):
                 ap_stream += b"<" + (b"".join(encoded_line)).hex().encode() + b"> Tj\n"
             else:
                 ap_stream += b"(" + b"".join(encoded_line) + b") Tj\n"
+            if is_rtl:
+                ap_stream += b"EMC\n"
         ap_stream += b"ET\nQ\nEMC\nQ\n"
 
         return ap_stream

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -4,7 +4,8 @@ import re
 from dataclasses import dataclass
 from enum import IntEnum
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, cast
+from operator import attrgetter
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
@@ -70,6 +71,14 @@ class TextAlignment(IntEnum):
     RIGHT = 2
 
 
+class WidthWordGlyphs(NamedTuple):
+    """A tuple of the unscaled width of a word (unencoded text) and the font-encoded glyphs that represent it."""
+
+    width: float
+    word: str
+    glyphs: str
+
+
 class TextStreamAppearance(BaseStreamAppearance):
     """
     A class representing the appearance stream for a text-based form field.
@@ -86,10 +95,10 @@ class TextStreamAppearance(BaseStreamAppearance):
         leading_factor: float,
         field_width: float,
         field_height: float,
-        paragraphs: list[list[tuple[float, str, str]]],
+        paragraphs: list[list[WidthWordGlyphs]],
         min_font_size: float,
         font_size_step: float = 0.2
-    ) -> tuple[list[tuple[float, str, str]], float]:
+    ) -> tuple[list[WidthWordGlyphs], float]:
         """
         Takes a piece of text and scales it to field_width or field_height, given font_name
         and font_size. Wraps text where necessary.
@@ -100,8 +109,8 @@ class TextStreamAppearance(BaseStreamAppearance):
             leading_factor: The line distance.
             field_width: The width of the field in which to fit the text.
             field_height: The height of the field in which to fit the text.
-            paragraphs: The list of text paragraphs to fit with the field, where each paragraph is
-                a list of tuples of unscaled width, unencoded text, and glyphs (font-encoded text).
+            paragraphs: The list of text paragraphs to fit with the field, where each paragraph is a list
+                of tuples of unscaled width, unencoded text, and glyphs (font-encoded text).
             min_font_size: The minimum font size at which to scale the text.
             font_size_step: The amount by which to decrement font size per step while scaling.
 
@@ -110,23 +119,31 @@ class TextStreamAppearance(BaseStreamAppearance):
             and its contents, and the font_size for these lines and lengths.
         """
         wrapped_lines = []
-        current_line_words: list[tuple[float, str, str]] = []
+        current_line_words: list[WidthWordGlyphs] = []
         current_line_width: float = 0
         space_width = font.space_width * font_size / 1000
         for paragraph in paragraphs:
             for i, width_word_glyphs in enumerate(paragraph):
-                word_width = width_word_glyphs[0] * font_size
+                word_width = width_word_glyphs.width * font_size
                 test_width = current_line_width + word_width + (space_width if i else 0)
                 if test_width > field_width and current_line_words:
-                    wrapped_lines.append((
-                        current_line_width,
-                        " ".join([word[1] for word in current_line_words]),
-                        font.space_char.join([word[2] for word in current_line_words])
-                    ))
+                    wrapped_lines.append(
+                        WidthWordGlyphs(
+                            width=current_line_width,
+                            word=" ".join(map(attrgetter("word"), current_line_words)),
+                            glyphs=font.space_char.join(map(attrgetter("glyphs"), current_line_words))
+                        )
+                    )
                     current_line_words = [width_word_glyphs]
                     current_line_width = word_width
                 elif not current_line_words and word_width > field_width:
-                    wrapped_lines.append((word_width, width_word_glyphs[1], width_word_glyphs[2]))
+                    wrapped_lines.append(
+                        WidthWordGlyphs(
+                            width=word_width,
+                            word=width_word_glyphs.word,
+                            glyphs=width_word_glyphs.glyphs
+                        )
+                    )
                     current_line_words = []
                     current_line_width = 0
                 else:
@@ -135,10 +152,10 @@ class TextStreamAppearance(BaseStreamAppearance):
                     current_line_words.append(width_word_glyphs)
                     current_line_width += word_width
             if current_line_words:
-                wrapped_lines.append((
-                    current_line_width,
-                    " ".join([word[1] for word in current_line_words]),
-                    font.space_char.join([word[2] for word in current_line_words])
+                wrapped_lines.append(WidthWordGlyphs(
+                    width=current_line_width,
+                    word=" ".join(map(attrgetter("word"), current_line_words)),
+                    glyphs=font.space_char.join(map(attrgetter("glyphs"), current_line_words))
                 ))
                 current_line_words = []
                 current_line_width = 0
@@ -235,18 +252,20 @@ class TextStreamAppearance(BaseStreamAppearance):
                 is_multiline = False  # with matching "selection" with "line" later on.
             if is_multiline:
                 font_size = DEFAULT_FONT_SIZE_IN_MULTILINE
-                # We create a list of paragraphs, here each paragraph is a list of tuples, where each
+                # We create a list of paragraphs, here each paragraph is a list of tuples, where each WidthWordGlyphs
                 # tuple signifies an unscaled word width, the word itself, and the glyphs that encode it.
-                paragraphs: list[list[tuple[float, str, str]]] = []
+                paragraphs: list[list[WidthWordGlyphs]] = []
                 for line in text.splitlines():
                     if not line.strip():
-                        paragraphs.append([(0.0, "", "")])
+                        paragraphs.append([WidthWordGlyphs(width=0.0, word="", glyphs="")])
                         continue
-                    line_by_widths_words_glyphs: list[tuple[float, str, str]] = []
+                    line_by_widths_words_glyphs: list[WidthWordGlyphs] = []
                     words = line.split(" ")
                     for word in words:
                         glyph_word = _unicode_to_glyph_id(word, reverse_cmap)
-                        line_by_widths_words_glyphs.append((font.get_text_width(word) / 1000, word, glyph_word))
+                        line_by_widths_words_glyphs.append(
+                            WidthWordGlyphs(width=font.get_text_width(word) / 1000, word=word, glyphs=glyph_word)
+                        )
                     paragraphs.append(line_by_widths_words_glyphs)
                 lines, font_size = self._scale_text(
                     font,
@@ -263,7 +282,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                 text_width_unscaled = font.get_text_width(glyphs) / 1000
                 max_horizontal_size = field_width / (text_width_unscaled or 1)
                 font_size = round(max(min(max_vertical_size, max_horizontal_size), min_font_size), 1)
-                lines = [(text_width_unscaled * font_size, text, glyphs)]
+                lines = [WidthWordGlyphs(width=text_width_unscaled * font_size, word=text, glyphs=glyphs)]
         elif is_comb:
             if max_length and len(text) > max_length:
                 logger_warning(
@@ -280,12 +299,16 @@ class TextStreamAppearance(BaseStreamAppearance):
             for index, char in enumerate(text):
                 if index < (max_length or len(text)):
                     glyphs = _unicode_to_glyph_id(char, reverse_cmap)
-                    lines.append((font.get_text_width(glyphs) * font_size / 1000, char, glyphs))
+                    lines.append(
+                        WidthWordGlyphs(width=font.get_text_width(glyphs) * font_size / 1000, word=char, glyphs=glyphs)
+                    )
         else:
             lines = []
             for line in text.splitlines():
                 glyphs = _unicode_to_glyph_id(line, reverse_cmap)
-                lines.append((font.get_text_width(glyphs) * font_size / 1000, line, glyphs))
+                lines.append(
+                    WidthWordGlyphs(width=font.get_text_width(glyphs) * font_size / 1000, word=line, glyphs=glyphs)
+                )
 
         # Set the vertical offset
         if is_multiline:

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
 from .._font import Font
-from .._utils import logger_warning
+from .._utils import is_char_rtl, logger_warning
 from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes, PageAttributes
 from ..errors import PdfReadError
 from ..generic import (
@@ -390,12 +390,8 @@ class TextStreamAppearance(BaseStreamAppearance):
             # This is the X position where the *current line* will start.
             current_x_pos = desired_abs_x_start
 
-            is_rtl = any(
-                0x0590 <= ord(char) <= 0x08FF or
-                0xFB1D <= ord(char) <= 0xFDFF or
-                0xFE70 <= ord(char) <= 0xFEFF
-                for char in line
-            )
+            is_rtl = any(is_char_rtl(char) for char in line)
+
             encoded_line = _glyph_id_to_bytes(line, encoding_cmap)
             if is_rtl:
                 # Encode input text as UTF-16BE with a BOM, so that the input text is returned

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -37,6 +37,10 @@ except ImportError:
 
 DEFAULT_FONT_SIZE_IN_MULTILINE = 12
 
+# "The glyph widths shall be measured in units in which 1000 units correspond to 1 unit in text space"
+# (Table 111, PDF Specification 2.0)
+TEXT_SPACE_TO_GLYPH_SPACE_FACTOR = 1000
+
 
 @dataclass
 class BaseStreamConfig:
@@ -121,7 +125,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         wrapped_lines = []
         current_line_words: list[WidthWordGlyphs] = []
         current_line_width: float = 0
-        space_width = font.space_width * font_size / 1000
+        space_width = font.space_width * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
         for paragraph in paragraphs:
             for i, width_word_glyphs in enumerate(paragraph):
                 word_width = width_word_glyphs.width * font_size
@@ -220,7 +224,9 @@ class TextStreamAppearance(BaseStreamAppearance):
         rectangle = self._layout.rectangle
         if isinstance(rectangle, tuple):
             rectangle = RectangleObject(rectangle)
-        leading_factor = (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / 1000.0
+        leading_factor = (
+            (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
+        )
 
         # Set margins based on border width and style, but never less than 1 point
         factor = 2 if self._layout.border_style in {"/B", "/I"} else 1
@@ -264,7 +270,11 @@ class TextStreamAppearance(BaseStreamAppearance):
                     for word in words:
                         glyph_word = _unicode_to_glyph_id(word, reverse_cmap)
                         line_by_widths_words_glyphs.append(
-                            WidthWordGlyphs(width=font.get_text_width(word) / 1000, word=word, glyphs=glyph_word)
+                            WidthWordGlyphs(
+                                width=font.get_text_width(word) / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR,
+                                word=word,
+                                glyphs=glyph_word
+                            )
                         )
                     paragraphs.append(line_by_widths_words_glyphs)
                 lines, font_size = self._scale_text(
@@ -279,7 +289,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             else:
                 max_vertical_size = field_height / leading_factor
                 glyphs = _unicode_to_glyph_id(text, reverse_cmap)
-                text_width_unscaled = font.get_text_width(glyphs) / 1000
+                text_width_unscaled = font.get_text_width(glyphs) / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
                 max_horizontal_size = field_width / (text_width_unscaled or 1)
                 font_size = round(max(min(max_vertical_size, max_horizontal_size), min_font_size), 1)
                 lines = [WidthWordGlyphs(width=text_width_unscaled * font_size, word=text, glyphs=glyphs)]
@@ -300,21 +310,33 @@ class TextStreamAppearance(BaseStreamAppearance):
                 if index < (max_length or len(text)):
                     glyphs = _unicode_to_glyph_id(char, reverse_cmap)
                     lines.append(
-                        WidthWordGlyphs(width=font.get_text_width(glyphs) * font_size / 1000, word=char, glyphs=glyphs)
+                        WidthWordGlyphs(
+                            width=font.get_text_width(glyphs) * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR,
+                            word=char,
+                            glyphs=glyphs
+                        )
                     )
         else:
             lines = []
             for line in text.splitlines():
                 glyphs = _unicode_to_glyph_id(line, reverse_cmap)
                 lines.append(
-                    WidthWordGlyphs(width=font.get_text_width(glyphs) * font_size / 1000, word=line, glyphs=glyphs)
+                    WidthWordGlyphs(
+                        width=font.get_text_width(glyphs) * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR,
+                        word=line,
+                        glyphs=glyphs
+                    )
                 )
 
         # Set the vertical offset
         if is_multiline:
-            y_offset = rectangle.height + margin - font.font_descriptor.bbox[3] * font_size / 1000.0
+            y_offset = (
+                rectangle.height + margin - font.font_descriptor.bbox[3] * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
+            )
         else:
-            y_offset = margin + ((field_height - font.font_descriptor.ascent * font_size / 1000) / 2)
+            y_offset = margin + (
+                (field_height - font.font_descriptor.ascent * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR) / 2
+            )
         default_appearance = f"{font_name} {font_size} Tf {font_color}"
 
         ap_stream = (

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -144,12 +144,10 @@ def test_appearance_stream_rtl():
         font_color="0 g",
         is_multiline=False
     )
-    # The regex returns two groups. The first matches the text in /Span << /ActualText <[group 0]> >> BDC
-    # The second matches the encoded text data.
-    decoded_data = re.findall("<([a-zA-Z0-9]+?)> ", appearance.get_data().decode())
-    actual_text = bytes.fromhex(decoded_data[0]).decode("utf-16-be")
-    assert actual_text == "\ufeff" + test_string
-    hex_glyphs_rtl_enabled = decoded_data[1]
+    # The regex returns two matches. The first matches the text in /Span << /ActualText <[group 0]> >> BDC
+    # The second match concerns the encoded text data.
+    [hex_actual_text, hex_glyphs_rtl_enabled] = re.findall("<([a-zA-Z0-9]+?)> ", appearance.get_data().decode())
+    assert bytes.fromhex(hex_actual_text).decode("utf-16-be") == "\ufeff" + test_string
     assert hex_shaped_test_glyphs == hex_glyphs_rtl_enabled
 
     # RTL support disabled
@@ -164,7 +162,7 @@ def test_appearance_stream_rtl():
             font_color="0 g",
             is_multiline=False
         )
-        hex_glyphs_rtl_disabled = re.findall("<(.+?)>", appearance.get_data().decode())[1]
+        [hex_glyphs_rtl_disabled] = re.findall("^<(.+?)>", appearance.get_data().decode(), re.MULTILINE)
     assert hex_unshaped_test_glyphs == hex_glyphs_rtl_disabled
     # The hex glyph sequences should be different when RTL support is enabled vs disabled
     assert hex_glyphs_rtl_enabled != hex_glyphs_rtl_disabled
@@ -181,7 +179,9 @@ def test_appearance_stream_rtl():
             font_color="0 g",
             is_multiline=False
         )
-        hex_glyphs_rtl_enabled_fonttools_disabled  = re.findall("<(.+?)>", appearance.get_data().decode())[0]
+        [hex_glyphs_rtl_enabled_fonttools_disabled] = re.findall(
+            "^<(.+?)>", appearance.get_data().decode(), re.MULTILINE
+        )
     assert hex_shaped_test_glyphs != hex_glyphs_rtl_enabled_fonttools_disabled
 
 

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -66,7 +66,8 @@ def test_scale_text():
 
     layout.rectangle = (0, 0, 160, 360)
     font_size = 0.0
-    text = """Welcome to pypdf
+    text = """Welcome to pypdf!
+أهلاً بكم في pypdf!
 pypdf is a free and open source pure-python PDF library capable of splitting, merging, cropping, and
 transforming the pages of PDF files. It can also add custom data, viewing options, and passwords to PDF
 files. pypdf can retrieve text and metadata from PDFs as well.
@@ -79,12 +80,13 @@ See pdfly for a CLI application that uses pypdf to interact with PDFs.
     )
     assert b"12 Tf" in appearance_stream.get_data()
     assert b"pypdf is a free and open" in appearance_stream.get_data()
+    assert b"/Span << /ActualText" in appearance_stream.get_data()
 
     layout.rectangle = (0, 0, 160, 160)
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline
     )
-    assert b"9.8 Tf" in appearance_stream.get_data()
+    assert b"9.6 Tf" in appearance_stream.get_data()
 
     layout.rectangle = (0, 0, 160, 12)
     appearance_stream = TextStreamAppearance(
@@ -142,7 +144,12 @@ def test_appearance_stream_rtl():
         font_color="0 g",
         is_multiline=False
     )
-    hex_glyphs_rtl_enabled = re.findall("<(.+?)>", appearance.get_data().decode())[0]
+    # The regex returns two groups. The first matches the text in /Span << /ActualText <[group 0]> >> BDC
+    # The second matches the encoded text data.
+    decoded_data = re.findall("<([a-zA-Z0-9]+?)> ", appearance.get_data().decode())
+    actual_text = bytes.fromhex(decoded_data[0]).decode("utf-16-be")
+    assert actual_text == "\ufeff" + test_string
+    hex_glyphs_rtl_enabled = decoded_data[1]
     assert hex_shaped_test_glyphs == hex_glyphs_rtl_enabled
 
     # RTL support disabled
@@ -157,7 +164,7 @@ def test_appearance_stream_rtl():
             font_color="0 g",
             is_multiline=False
         )
-        hex_glyphs_rtl_disabled = re.findall("<(.+?)>", appearance.get_data().decode())[0]
+        hex_glyphs_rtl_disabled = re.findall("<(.+?)>", appearance.get_data().decode())[1]
     assert hex_unshaped_test_glyphs == hex_glyphs_rtl_disabled
     # The hex glyph sequences should be different when RTL support is enabled vs disabled
     assert hex_glyphs_rtl_enabled != hex_glyphs_rtl_disabled


### PR DESCRIPTION
Copying text from a PDF copies text in the order that it is encoded in the PDF. For RTL text, this means that the copied text is in reverse. To remedy that problem, this PR tags such text with /Span /ActualText, which overrides text copying to the direction and encoding in which the text was originally added.

I note that https://github.com/py-pdf/pypdf/issues/3514 was just closed. Perhaps this PR should be seen as the epilogue to that closure ;-)

This was assisted by Google Gemini, especially the code that produces that Span in AppearanceStream. But lightly!