### PR TITLE
ROB: guard text fields without /T in get_form_text_fields

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -744,7 +744,7 @@ class PdfDocCommon(ABC):
                 if full_qualified_name:
                     ff[field] = value.get("/V")
                 else:
-                    ff[indexed_key(cast(str, value["/T"]), ff)] = value.get("/V")
+                    ff[indexed_key(cast(str, value.get("/T", field)), ff)] = value.get("/V")
         return ff
 
     def get_pages_showing_field(

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -643,6 +643,30 @@ def test_xfa__decompression_limit():
         _ = reader.xfa
 
 
+def test_get_form_text_fields__mapping_name_without_partial_name():
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+
+    # A text field carrying only a mapping name (/TM) and no partial name (/T)
+    # is tolerated when building the field tree, so reading the text fields by
+    # short name should fall back to the qualified name instead of raising.
+    field = DictionaryObject()
+    field[NameObject("/FT")] = NameObject("/Tx")
+    field[NameObject("/TM")] = TextStringObject("mappingname")
+    field[NameObject("/V")] = TextStringObject("hello")
+
+    acro = DictionaryObject()
+    acro[NameObject("/Fields")] = ArrayObject([writer._add_object(field)])
+    writer.root_object[NameObject("/AcroForm")] = writer._add_object(acro)
+
+    data = BytesIO()
+    writer.write(data)
+    data.seek(0)
+
+    reader = PdfReader(data)
+    assert reader.get_form_text_fields() == {"mappingname": "hello"}
+
+
 @pytest.mark.timeout(5)
 def test_get_pages_showing_field__cyclic() -> None:
     writer = PdfWriter()


### PR DESCRIPTION
**KeyError on text fields without a partial name**

A `/Tx` field that carries only a mapping name (`/TM`) and no partial name (`/T`) is still kept by `_build_field`, so `get_form_text_fields()` then trips over the direct `/T` lookup and raises `KeyError` on the public read path. The fallback reuses the qualified name already used by the `full_qualified_name` variant, so such a field is returned rather than aborting the whole call. Added a regression test building that field shape.