### PR TITLE
ENH: AppearanceStream: Consider more encodings for Type1 core fonts

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -64,14 +64,21 @@ def _parse_encoding(
     ft: DictionaryObject
 ) -> Union[str, dict[int, str]]:
     encoding: Union[str, list[str], dict[int, str]] = []
+    # If ft["/Encoding"] exists, then use that for encoding. Otherwise, use StandardEncoding as a basis,
+    # and add what the embedded font file says, if present. See Table 114, PDF Reference 1.7 / 2.0
     if "/Encoding" not in ft:
         if "/BaseFont" in ft and cast(str, ft["/BaseFont"]) in charset_encoding:
-            encoding = dict(
+            # This will match Symbol and ZapfDingBats
+            return dict(
                 zip(range(256), charset_encoding[cast(str, ft["/BaseFont"])])
             )
-        else:
-            encoding = "charmap"
-        return encoding
+
+        # Return StandardEncoding as fallback option. Note that a font's internal encoding can be used
+        # to overwrite this, which we do for Type1 fonts in _type1_alternative.
+        return dict(
+            zip(range(256), charset_encoding["/StandardEncoding"].copy())
+        )
+
     enc: Union[str, DictionaryObject, NullObject] = cast(
         Union[str, DictionaryObject, NullObject], ft["/Encoding"].get_object()
     )

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -76,7 +76,7 @@ def _parse_encoding(
         # Return StandardEncoding as fallback option. Note that a font's internal encoding can be used
         # to overwrite this, which we do for Type1 fonts in _type1_alternative.
         return dict(
-            zip(range(256), charset_encoding["/StandardEncoding"].copy())
+            zip(range(256), charset_encoding["/StandardEncoding"])
         )
 
     enc: Union[str, DictionaryObject, NullObject] = cast(

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -3,7 +3,7 @@ from binascii import unhexlify
 from functools import partial
 from typing import Any, Union, cast
 
-from ._codecs import adobe_glyphs, charset_encoding, encoding_dict_from_named_encoding
+from ._codecs import adobe_glyphs, charset_encoding
 from ._utils import logger_error, logger_warning
 from .errors import LimitReachedError
 from .generic import (
@@ -69,11 +69,15 @@ def _parse_encoding(
     if "/Encoding" not in ft:
         if "/BaseFont" in ft and cast(str, ft["/BaseFont"]) in charset_encoding:
             # This will match Symbol and ZapfDingBats
-            return encoding_dict_from_named_encoding(charset_encoding[cast(str, ft["/BaseFont"])])
+            return dict(
+                zip(range(256), charset_encoding[cast(str, ft["/BaseFont"])])
+            )
 
         # Return StandardEncoding as fallback option. Note that a font's internal encoding can be used
         # to overwrite this, which we do for Type1 fonts in _type1_alternative.
-        return encoding_dict_from_named_encoding(charset_encoding["/StandardEncoding"])
+        return dict(
+            zip(range(256), charset_encoding["/StandardEncoding"].copy())
+        )
 
     enc: Union[str, DictionaryObject, NullObject] = cast(
         Union[str, DictionaryObject, NullObject], ft["/Encoding"].get_object()

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -3,7 +3,7 @@ from binascii import unhexlify
 from functools import partial
 from typing import Any, Union, cast
 
-from ._codecs import adobe_glyphs, charset_encoding
+from ._codecs import adobe_glyphs, charset_encoding, encoding_dict_from_named_encoding
 from ._utils import logger_error, logger_warning
 from .errors import LimitReachedError
 from .generic import (
@@ -69,15 +69,11 @@ def _parse_encoding(
     if "/Encoding" not in ft:
         if "/BaseFont" in ft and cast(str, ft["/BaseFont"]) in charset_encoding:
             # This will match Symbol and ZapfDingBats
-            return dict(
-                zip(range(256), charset_encoding[cast(str, ft["/BaseFont"])])
-            )
+            return encoding_dict_from_named_encoding(charset_encoding[cast(str, ft["/BaseFont"])])
 
         # Return StandardEncoding as fallback option. Note that a font's internal encoding can be used
         # to overwrite this, which we do for Type1 fonts in _type1_alternative.
-        return dict(
-            zip(range(256), charset_encoding["/StandardEncoding"].copy())
-        )
+        return encoding_dict_from_named_encoding(charset_encoding["/StandardEncoding"])
 
     enc: Union[str, DictionaryObject, NullObject] = cast(
         Union[str, DictionaryObject, NullObject], ft["/Encoding"].get_object()

--- a/pypdf/_codecs/__init__.py
+++ b/pypdf/_codecs/__init__.py
@@ -26,6 +26,10 @@ def rev_encoding(enc: list[str]) -> dict[str, int]:
     return rev
 
 
+def encoding_dict_from_named_encoding(encoding: str) -> dict[int, str]:
+    return dict(zip(range(256), fill_from_encoding(encoding)))
+
+
 _win_encoding = fill_from_encoding("cp1252")
 _mac_encoding = fill_from_encoding("mac_roman")
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -18,7 +18,7 @@ from pypdf.generic import (
 )
 
 from ._cmap import get_encoding
-from ._codecs import fill_from_encoding
+from ._codecs import encoding_dict_from_named_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs
 from ._utils import logger_warning
 from .constants import FontFlags
@@ -739,10 +739,10 @@ class Font:
             })
 
         # Fallback: Return a font resource for one of the 14 Adobe Core fonts.
-        win_ansi_encoding_list = fill_from_encoding("cp1252")
+        win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")
         differences_list: list[NumberObject | NameObject] = []
         reverse_adobe_glyphs = {value: key for key, value in adobe_glyphs.items()}
-        for idx, character_code in enumerate(win_ansi_encoding_list):
+        for idx, character_code in win_ansi_encoding.items():
             encoding_char = cast(dict[int, str], self.encoding).get(idx)
             if encoding_char and encoding_char != character_code:
                 differences_list.extend([NumberObject(idx), NameObject(reverse_adobe_glyphs[encoding_char])])

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -603,6 +603,30 @@ class Font:
             interpretable=True
         )
 
+    @classmethod
+    def from_core_font_name(cls, core_font_name: str = "/Helvetica") -> Font:
+        from pypdf._codecs.core_font_metrics import CORE_FONT_METRICS  # noqa: PLC0415
+
+        font_name = core_font_name.removeprefix("/")
+        core_font_metrics = CORE_FONT_METRICS[font_name]
+        win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")  # WinAnsiEncoding
+
+        font = cls(
+            name=font_name,
+            character_map={},
+            encoding=win_ansi_encoding,
+            sub_type="Type1",
+            font_descriptor=core_font_metrics.font_descriptor,
+            character_widths={
+                char: core_font_metrics.character_widths[character]
+                for code, character in win_ansi_encoding.items()
+                if (char := chr(code)) in core_font_metrics.character_widths
+            }
+        )
+        font.character_widths["default"] = core_font_metrics.character_widths["default"]
+
+        return font
+
     def _get_typographic_maps(self) -> tuple[dict[str, str], dict[str, bytes]]:
         """
         Generates maps to translate input unicode text to bytes in two steps:

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -689,44 +689,13 @@ class Font:
         from pypdf._codecs.core_font_metrics import CORE_FONT_METRICS  # noqa: PLC0415
 
         widths_list = []
-        unicode_map: list[str] = []
-
-        tmp_list: list[tuple[int, list[int]]] = []
-        previous_unipoint_plus_one: int | None = None
-        previous_cid_plus_one: int |  None = None
+        unicode_map = []
         bfchar_map: list[str] = []
-        bfrange_map: list[str] = []
-        current_bfrange: bool = False  # Set to True when finding two sequential cid-unicode pairs
-        previous_bfrange: bool = False  # Set to True when the previous was also a range.
+
         # Composite/CID fonts use 4-hex digits, simple fonts use 2-hex digits
         src_hex_format = "{cid:04X}" if self.sub_type == "Type0" else "{cid:02X}"
         codespace_min = "0000" if self.sub_type == "Type0" else "00"
         codespace_max = "FFFF" if self.sub_type == "Type0" else "FF"
-
-        def _append_mapping(unicode_map_list: list[str], appended_list: list[str], bf_type: str) -> None:
-            while partial_list := appended_list[:CMAP_MAX_ENTRIES_PER_GROUP]:
-                del appended_list[:CMAP_MAX_ENTRIES_PER_GROUP]
-                unicode_map_list.append(f"{len(partial_list)} beginbf{bf_type}")
-                unicode_map_list.extend(partial_list)
-                unicode_map_list.append(f"endbf{bf_type}")
-
-        def _append_bfrange_line(bfrange_map_list: list[str], map_list: list[tuple[int, list[int]]]) -> None:
-            bfrange_start, [bfrange_start_unipoint] = map_list[0]
-            bfrange_end = map_list[-1][0]
-            bfrange_start_hex = src_hex_format.format(cid=bfrange_start)
-            bfrange_end_hex = src_hex_format.format(cid=bfrange_end)
-            bfrange_start_unipoint_hex = f"{bfrange_start_unipoint:04X}"
-            bfrange_map_list.append(f"<{bfrange_start_hex}> <{bfrange_end_hex}> <{bfrange_start_unipoint_hex}>")
-            map_list.clear()
-
-        def _append_bfchar_line(bfchar_map_list: list[str], map_list: list[tuple[int, list[int]]]) -> None:
-            # We add bfchar lines one by one, so map_list always has only one entry when it is passed here
-            bfchar_cid, bfchar_unipoints = map_list[0]
-            bfchar_cid_hex = src_hex_format.format(cid=bfchar_cid)
-            bfchar_unipoints_hex = "".join(f"{uni_point:04X}" for uni_point in bfchar_unipoints)
-            bfchar_map_list.append(f"<{bfchar_cid_hex}> <{bfchar_unipoints_hex}>")
-            map_list.clear()
-
         cmap_name = "Adobe-Identity-UCS" if self.sub_type == "Type0" else "Custom-Simple-8Bit"
         cid_system_info = (
             "/CIDSystemInfo <<\n/Registry (Adobe)\n/Ordering (UCS)\n/Supplement 0\n>> def\n"
@@ -748,37 +717,9 @@ class Font:
             # TODO: Add all characters.
             if all(uni_point <= 0xFFFF for uni_point in uni_points):
                 cid = ord(src_id) if isinstance(src_id, str) else src_id
-                current_bfrange = (
-                    len(uni_points) == 1 and
-                    uni_points[0] == previous_unipoint_plus_one and
-                    cid == previous_cid_plus_one
-                )
-                if not current_bfrange:
-                    if previous_bfrange:
-                        if bfchar_map:
-                            # Append the lines in bfchar_map to unicode_map
-                            _append_mapping(unicode_map, bfchar_map, "char")
-                        # Write out tmp_dict to a new bfrange line
-                        _append_bfrange_line(bfrange_map, tmp_list)
-                    elif tmp_list:
-                        if bfrange_map:
-                            # Append the lines in bfrange_map to unicode_map
-                            _append_mapping(unicode_map, bfrange_map, "range")
-                        # Write our tmp_dict to a new bf_char line
-                        _append_bfchar_line(bfchar_map, tmp_list)
-
-                # Temporarily store current value until we know whether to put it in bfrange or bfchar
-                tmp_list.append((cid, uni_points))
-
-                if len(uni_points) == 1:
-                    previous_unipoint_plus_one = uni_points[0] + 1
-                else:
-                    previous_unipoint_plus_one = None
-                previous_cid_plus_one = cid + 1
-                if current_bfrange:
-                    previous_bfrange = True
-                else:
-                    previous_bfrange = False
+                cid_hex = src_hex_format.format(cid=cid)
+                uni_hex = "".join(f"{uni_point:04X}" for uni_point in uni_points)
+                bfchar_map.append(f"<{cid_hex}> <{uni_hex}>")
 
                 # Width mapping, but not for the 14 Adobe code fonts, which are dealt with elsewhere.
                 if self.name not in CORE_FONT_METRICS:
@@ -788,15 +729,11 @@ class Font:
                     width = self.character_widths.get(cast(str, src_id), self.character_widths["default"])
                     widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
 
-        # Deal with whatever was left in tmp_list
-        if previous_bfrange:  # The last item belonged to a range and sits in tmp_list
-            _append_bfrange_line(bfrange_map, tmp_list)
-            _append_mapping(unicode_map, bfrange_map, "range")
-        elif tmp_list:  # Final run was a single character
-            if bfrange_map:
-                _append_mapping(unicode_map, bfrange_map, "range")
-            _append_bfchar_line(bfchar_map, tmp_list)
-            _append_mapping(unicode_map, bfchar_map, "char")
+        while partial_list := bfchar_map[:CMAP_MAX_ENTRIES_PER_GROUP]:
+            del bfchar_map[:CMAP_MAX_ENTRIES_PER_GROUP]
+            unicode_map.append(f"{len(partial_list)} beginbfchar")
+            unicode_map.extend(partial_list)
+            unicode_map.append("endbfchar")
 
         # Create the /ToUnicode CMap Stream
         to_unicode_stream = StreamObject()

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -593,7 +593,7 @@ class Font:
 
         return cls(
             name=font_descriptor.name,
-            sub_type="TrueType",
+            sub_type="Type0",
             encoding=encoding,
             font_descriptor=font_descriptor,
             character_map=character_map,
@@ -706,7 +706,8 @@ class Font:
 
     def as_font_resource(self) -> DictionaryObject:
         # If we have an embedded Truetype font, we assume that we need to produce a Type 2 CID font resource.
-        if self.font_descriptor.font_file and self.sub_type == "TrueType":
+        # We check that we are 16-bit encoded, that is, Type0.
+        if self.font_descriptor.font_file and self.sub_type == "Type0":
             # Begin with creating the widths array (part of the descendant font) and the unicode cmap (part
             # of the Type 0 font object).
             widths_list, to_unicode_stream = self._create_widths_list_and_unicode_stream()

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -56,6 +56,10 @@ OS2_SFAMILYSCLASS_SCRIPTS = 10
 OS2_SFAMILYSCLASS_SYMBOLIC = 12
 
 
+# Groups of CMap mappings cannot exceed 100 entries (Adobe CMap and CIDFont Files Specification 1.0, p. 49).
+CMAP_MAX_ENTRIES_PER_GROUP = 100
+
+
 @dataclass(frozen=True)
 class FontDescriptor:
     """
@@ -685,12 +689,44 @@ class Font:
         from pypdf._codecs.core_font_metrics import CORE_FONT_METRICS  # noqa: PLC0415
 
         widths_list = []
-        unicode_map = []
+        unicode_map: list[str] = []
 
+        tmp_list: list[tuple[int, list[int]]] = []
+        previous_unipoint_plus_one: int | None = None
+        previous_cid_plus_one: int |  None = None
+        bfchar_map: list[str] = []
+        bfrange_map: list[str] = []
+        current_bfrange: bool = False  # Set to True when finding two sequential cid-unicode pairs
+        previous_bfrange: bool = False  # Set to True when the previous was also a range.
         # Composite/CID fonts use 4-hex digits, simple fonts use 2-hex digits
         src_hex_format = "{cid:04X}" if self.sub_type == "Type0" else "{cid:02X}"
         codespace_min = "0000" if self.sub_type == "Type0" else "00"
         codespace_max = "FFFF" if self.sub_type == "Type0" else "FF"
+
+        def _append_mapping(unicode_map_list: list[str], appended_list: list[str], bf_type: str) -> None:
+            while partial_list := appended_list[:CMAP_MAX_ENTRIES_PER_GROUP]:
+                del appended_list[:CMAP_MAX_ENTRIES_PER_GROUP]
+                unicode_map_list.append(f"{len(partial_list)} beginbf{bf_type}")
+                unicode_map_list.extend(partial_list)
+                unicode_map_list.append(f"endbf{bf_type}")
+
+        def _append_bfrange_line(bfrange_map_list: list[str], map_list: list[tuple[int, list[int]]]) -> None:
+            bfrange_start, [bfrange_start_unipoint] = map_list[0]
+            bfrange_end = map_list[-1][0]
+            bfrange_start_hex = src_hex_format.format(cid=bfrange_start)
+            bfrange_end_hex = src_hex_format.format(cid=bfrange_end)
+            bfrange_start_unipoint_hex = f"{bfrange_start_unipoint:04X}"
+            bfrange_map_list.append(f"<{bfrange_start_hex}> <{bfrange_end_hex}> <{bfrange_start_unipoint_hex}>")
+            map_list.clear()
+
+        def _append_bfchar_line(bfchar_map_list: list[str], map_list: list[tuple[int, list[int]]]) -> None:
+            # We add bfchar lines one by one, so map_list always has only one entry when it is passed here
+            bfchar_cid, bfchar_unipoints = map_list[0]
+            bfchar_cid_hex = src_hex_format.format(cid=bfchar_cid)
+            bfchar_unipoints_hex = "".join(f"{uni_point:04X}" for uni_point in bfchar_unipoints)
+            bfchar_map_list.append(f"<{bfchar_cid_hex}> <{bfchar_unipoints_hex}>")
+            map_list.clear()
+
         cmap_name = "Adobe-Identity-UCS" if self.sub_type == "Type0" else "Custom-Simple-8Bit"
         cid_system_info = (
             "/CIDSystemInfo <<\n/Registry (Adobe)\n/Ordering (UCS)\n/Supplement 0\n>> def\n"
@@ -698,7 +734,6 @@ class Font:
         )
 
         # If we have self.character_map then use that. Otherwise fall back to self.encoding.
-        # instead of self.character_map GIDs
         mapping_source = (self.character_map or cast(dict[int, str], self.encoding)).items()
 
         # In the loop, src_id is the decoded GID string (the reverse unicode hack) or the character code
@@ -713,9 +748,38 @@ class Font:
             # TODO: Add all characters.
             if all(uni_point <= 0xFFFF for uni_point in uni_points):
                 cid = ord(src_id) if isinstance(src_id, str) else src_id
-                cid_hex = src_hex_format.format(cid=cid)
-                uni_hex = "".join(f"{uni_point:04X}" for uni_point in uni_points)
-                unicode_map.append(f"<{cid_hex}> <{uni_hex}>")
+                current_bfrange = (
+                    len(uni_points) == 1 and
+                    uni_points[0] == previous_unipoint_plus_one and
+                    cid == previous_cid_plus_one
+                )
+                if not current_bfrange:
+                    if previous_bfrange:
+                        if bfchar_map:
+                            # Append the lines in bfchar_map to unicode_map
+                            _append_mapping(unicode_map, bfchar_map, "char")
+                        # Write out tmp_dict to a new bfrange line
+                        _append_bfrange_line(bfrange_map, tmp_list)
+                    elif tmp_list:
+                        if bfrange_map:
+                            # Append the lines in bfrange_map to unicode_map
+                            _append_mapping(unicode_map, bfrange_map, "range")
+                        # Write our tmp_dict to a new bf_char line
+                        _append_bfchar_line(bfchar_map, tmp_list)
+
+                # Temporarily store current value until we know whether to put it in bfrange or bfchar
+                tmp_list.append((cid, uni_points))
+
+                if len(uni_points) == 1:
+                    previous_unipoint_plus_one = uni_points[0] + 1
+                else:
+                    previous_unipoint_plus_one = None
+                previous_cid_plus_one = cid + 1
+                if current_bfrange:
+                    previous_bfrange = True
+                else:
+                    previous_bfrange = False
+
                 # Width mapping, but not for the 14 Adobe code fonts, which are dealt with elsewhere.
                 if self.name not in CORE_FONT_METRICS:
                     # The widths (/W) array can have two formats:
@@ -723,6 +787,16 @@ class Font:
                     # Here we choose the first format and simply provide one array with one width for every cid.
                     width = self.character_widths.get(cast(str, src_id), self.character_widths["default"])
                     widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
+
+        # Deal with whatever was left in tmp_list
+        if previous_bfrange:  # The last item belonged to a range and sits in tmp_list
+            _append_bfrange_line(bfrange_map, tmp_list)
+            _append_mapping(unicode_map, bfrange_map, "range")
+        elif tmp_list:  # Final run was a single character
+            if bfrange_map:
+                _append_mapping(unicode_map, bfrange_map, "range")
+            _append_bfchar_line(bfchar_map, tmp_list)
+            _append_mapping(unicode_map, bfchar_map, "char")
 
         # Create the /ToUnicode CMap Stream
         to_unicode_stream = StreamObject()
@@ -735,9 +809,7 @@ class Font:
                 f"/CMapName /{cmap_name} def\n"
                 f"/CMapType 2 def\n"
                 f"1 begincodespacerange <{codespace_min}> <{codespace_max}> endcodespacerange\n"
-                f"{len(unicode_map)} beginbfchar\n"
                 + "\n".join(unicode_map) + "\n"
-                "endbfchar\n"
                 "endcmap\n"
                 "CMapName currentdict /CMap defineresource pop\n"
                 "end end"

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -682,14 +682,28 @@ class Font:
         return reverse_cmap, encoding_cmap
 
     def _create_widths_list_and_unicode_stream(self) -> tuple[list[PdfObject], StreamObject]:
+        from pypdf._codecs.core_font_metrics import CORE_FONT_METRICS  # noqa: PLC0415
+
         widths_list = []
         unicode_map = []
-        # In the loop, char is the decoded GID string (the reverse unicode hack)
-        # and character_map[char] is the actual character.
-        # The widths (/W) array can have two formats:
-        #    [first_cid [w1 w2 w3]] or [first last width]
-        # Here we choose the first format and simply provide one array with one width for every cid.
-        for gid_str, actual_char in self.character_map.items():
+
+        # Composite/CID fonts use 4-hex digits, simple fonts use 2-hex digits
+        src_hex_format = "{cid:04X}" if self.sub_type == "Type0" else "{cid:02X}"
+        codespace_min = "0000" if self.sub_type == "Type0" else "00"
+        codespace_max = "FFFF" if self.sub_type == "Type0" else "FF"
+        cmap_name = "Adobe-Identity-UCS" if self.sub_type == "Type0" else "Custom-Simple-8Bit"
+        cid_system_info = (
+            "/CIDSystemInfo <<\n/Registry (Adobe)\n/Ordering (UCS)\n/Supplement 0\n>> def\n"
+            if self.sub_type == "Type0" else ""
+        )
+
+        # If we have self.character_map then use that. Otherwise fall back to self.encoding.
+        # instead of self.character_map GIDs
+        mapping_source = (self.character_map or cast(dict[int, str], self.encoding)).items()
+
+        # In the loop, src_id is the decoded GID string (the reverse unicode hack) or the character code
+        # and actual_char is the actual character.
+        for src_id, actual_char in mapping_source:
             # Make sure that we do not include characters such as arabic presentation form characters.
             # Note that, in some cases, unicodedata.normalize() might split a ligature, resulting
             # in multiple characters.
@@ -698,13 +712,17 @@ class Font:
             # Only deal with Basic Multilingual Plane characters.
             # TODO: Add all characters.
             if all(uni_point <= 0xFFFF for uni_point in uni_points):
-                cid = ord(gid_str)
-                cid_hex = f"{cid:04X}"
+                cid = ord(src_id) if isinstance(src_id, str) else src_id
+                cid_hex = src_hex_format.format(cid=cid)
                 uni_hex = "".join(f"{uni_point:04X}" for uni_point in uni_points)
                 unicode_map.append(f"<{cid_hex}> <{uni_hex}>")
-
-                width = self.character_widths.get(gid_str, self.character_widths["default"])
-                widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
+                # Width mapping, but not for the 14 Adobe code fonts, which are dealt with elsewhere.
+                if self.name not in CORE_FONT_METRICS:
+                    # The widths (/W) array can have two formats:
+                    #    [first_cid [w1 w2 w3]] or [first last width]
+                    # Here we choose the first format and simply provide one array with one width for every cid.
+                    width = self.character_widths.get(cast(str, src_id), self.character_widths["default"])
+                    widths_list.extend([NumberObject(cid), ArrayObject([NumberObject(width)])])
 
         # Create the /ToUnicode CMap Stream
         to_unicode_stream = StreamObject()
@@ -713,10 +731,10 @@ class Font:
                 "/CIDInit /ProcSet findresource begin\n"
                 "12 dict begin\n"
                 "begincmap\n"
-                "/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n"
-                "/CMapName /Adobe-Identity-UCS def\n"
-                "/CMapType 2 def\n"
-                "1 begincodespacerange <0000> <FFFF> endcodespacerange\n"
+                f"{cid_system_info}"
+                f"/CMapName /{cmap_name} def\n"
+                f"/CMapType 2 def\n"
+                f"1 begincodespacerange <{codespace_min}> <{codespace_max}> endcodespacerange\n"
                 f"{len(unicode_map)} beginbfchar\n"
                 + "\n".join(unicode_map) + "\n"
                 "endbfchar\n"
@@ -780,13 +798,19 @@ class Font:
         else:
             encoding = NameObject("/WinAnsiEncoding")
 
-        return DictionaryObject({
+        simple_font =  DictionaryObject({
             NameObject("/Type"): NameObject("/Font"),
             NameObject("/Subtype"): NameObject("/Type1"),
             NameObject("/Name"): NameObject(f"/{self.name}"),
             NameObject("/BaseFont"): NameObject(f"/{self.name}"),
             NameObject("/Encoding"): encoding
         })
+
+        if differences_list:
+            _, to_unicode_stream = self._create_widths_list_and_unicode_stream()
+            simple_font[NameObject("/ToUnicode")] = to_unicode_stream
+
+        return simple_font
 
     def _add_to_writer(
         self,

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -804,17 +804,14 @@ class Font:
 
     def can_encode(self, text: str) -> bool:
         """Check whether the font is able to encode a text string."""
-        try:
-            if self.character_map:
-                supported_chars = set(self.character_map.values())
-                return all(char in supported_chars for char in text)
-            if isinstance(self.encoding, str):
-                text.encode(self.encoding, "surrogatepass")
-            else:
-                supported_chars = set(self.encoding.values())
-                return all(char in supported_chars for char in text)
+        if self.character_map:
+            supported_chars = set(self.character_map.values())
+            return all(char in supported_chars for char in text)
 
-        except UnicodeEncodeError:
-            return False
+        if isinstance(self.encoding, dict):
+            supported_chars = set(self.encoding.values())
+            return all(char in supported_chars for char in text)
 
-        return True
+        # Not a simple font (encoding is not a dict), and missing ToUnicode cmap (no character_map).
+        # Assume we cannot use this font for text encoding.
+        return False

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -18,6 +18,7 @@ from pypdf.generic import (
 )
 
 from ._cmap import get_encoding
+from ._codecs import fill_from_encoding
 from ._codecs.adobe_glyphs import adobe_glyphs
 from ._utils import logger_warning
 from .constants import FontFlags
@@ -734,12 +735,28 @@ class Font:
             })
 
         # Fallback: Return a font resource for one of the 14 Adobe Core fonts.
+        win_ansi_encoding_list = fill_from_encoding("cp1252")
+        differences_list: list[NumberObject | NameObject] = []
+        reverse_adobe_glyphs = {value: key for key, value in adobe_glyphs.items()}
+        for idx, character_code in enumerate(win_ansi_encoding_list):
+            encoding_char = cast(dict[int, str], self.encoding).get(idx)
+            if encoding_char and encoding_char != character_code:
+                differences_list.extend([NumberObject(idx), NameObject(reverse_adobe_glyphs[encoding_char])])
+
+        if differences_list:
+            encoding: DictionaryObject | NameObject = DictionaryObject({
+                NameObject("/BaseEncoding"): NameObject("/WinAnsiEncoding"),
+                NameObject("/Differences"): ArrayObject(differences_list),
+            })
+        else:
+            encoding = NameObject("/WinAnsiEncoding")
+
         return DictionaryObject({
             NameObject("/Type"): NameObject("/Font"),
             NameObject("/Subtype"): NameObject("/Type1"),
             NameObject("/Name"): NameObject(f"/{self.name}"),
             NameObject("/BaseFont"): NameObject(f"/{self.name}"),
-            NameObject("/Encoding"): NameObject("/WinAnsiEncoding")
+            NameObject("/Encoding"): encoding
         })
 
     def _add_to_writer(

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -766,8 +766,9 @@ class Font:
         win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")
         differences_list: list[NumberObject | NameObject] = []
         reverse_adobe_glyphs = {value: key for key, value in adobe_glyphs.items()}
+        own_encoding: dict[int, str] = cast(dict[int, str], self.encoding)
         for idx, character_code in win_ansi_encoding.items():
-            encoding_char = cast(dict[int, str], self.encoding).get(idx)
+            encoding_char = own_encoding.get(idx)
             if encoding_char and encoding_char != character_code:
                 differences_list.extend([NumberObject(idx), NameObject(reverse_adobe_glyphs[encoding_char])])
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -639,7 +639,7 @@ class Font:
                 glyph_id_str = str(glyph_id)
                 reverse_cmap[unicode_char] = glyph_id_str
                 encoding_cmap[glyph_id_str] = glyph_id_str.encode(self.encoding)
-        else:
+        else:  # Encoding is a dict, which means we are dealing with a simple font
             for character_code, unicode_char in self.encoding.items():
                 character_str = chr(character_code)
                 reverse_cmap[unicode_char] = character_str
@@ -648,9 +648,12 @@ class Font:
             unicode_to_bytes = {
                 unicode_char: bytes((character_code,)) for character_code, unicode_char in self.encoding.items()
             }
-            for glyph_id, unicode_char in self.character_map.items():  # This code is not covered nor tested
-                reverse_cmap[unicode_char] = glyph_id
-                encoding_cmap[glyph_id] = unicode_to_bytes.get(unicode_char, bytes((glyph_id,)))
+            for character_code_str, unicode_char in self.character_map.items():  # This code is not covered nor tested
+                reverse_cmap[unicode_char] = character_code_str
+                encoding_cmap[character_code_str] = unicode_to_bytes.get(
+                    unicode_char,
+                    bytes((ord(character_code_str),))
+                )
 
         return reverse_cmap, encoding_cmap
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -672,7 +672,7 @@ class Font:
             unicode_to_bytes = {
                 unicode_char: bytes((character_code,)) for character_code, unicode_char in self.encoding.items()
             }
-            for character_code_str, unicode_char in self.character_map.items():  # This code is not covered nor tested
+            for character_code_str, unicode_char in self.character_map.items():
                 reverse_cmap[unicode_char] = character_code_str
                 encoding_cmap[character_code_str] = unicode_to_bytes.get(
                     unicode_char,

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -179,17 +179,14 @@ def get_text_operands(
                 if isinstance(operands[0], str)
                 else operands[0]
             )
-            if isinstance(font.encoding, str):
+            if isinstance(font.encoding, str):  # apply str encoding
                 try:
-                    t = tt.decode(font.encoding, "surrogatepass")  # apply str encoding
+                    t = tt.decode(font.encoding, "surrogatepass")
                 except Exception:
-                    # the data does not match the expectation,
+                    # The data does not match the expectation,
                     # we use the alternative ;
-                    # text extraction may not be good
-                    t = tt.decode(
-                        "utf-16-be" if font.encoding == "charmap" else "charmap",
-                        "surrogatepass",
-                    )  # apply str encoding
+                    # text extraction may not be good.
+                    t = tt.decode("charmap", "surrogatepass")
             else:  # apply dict encoding
                 t = "".join(
                     [font.encoding[x] if x in font.encoding else bytes((x,)).decode() for x in tt]

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -179,15 +179,15 @@ def get_text_operands(
                 if isinstance(operands[0], str)
                 else operands[0]
             )
-            if isinstance(font.encoding, str):  # apply str encoding
+            if isinstance(font.encoding, str):  # Apply named encoding
                 try:
                     t = tt.decode(font.encoding, "surrogatepass")
                 except Exception:
                     # The data does not match the expectation,
-                    # we use the alternative ;
+                    # we use "charmap" encoding as an alternative;
                     # text extraction may not be good.
                     t = tt.decode("charmap", "surrogatepass")
-            else:  # apply dict encoding
+            else:  # Apply dict encoding
                 t = "".join(
                     [font.encoding[x] if x in font.encoding else bytes((x,)).decode() for x in tt]
                 )

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -30,7 +30,7 @@
 import math
 from typing import Any, Callable, Optional, Union
 
-from .._codecs import fill_from_encoding
+from .._codecs import encoding_dict_from_named_encoding
 from .._font import Font, FontDescriptor
 from ..generic import DictionaryObject, TextStringObject
 from . import OrientationNotFoundError, crlf_space_check, get_display_str, get_text_operands, mult
@@ -87,7 +87,7 @@ class TextExtraction:
         self.font = Font(
             name = "NotInitialized",
             sub_type="Unknown",
-            encoding=dict(zip(range(256),  fill_from_encoding("cp1252"))),  # WinAnsiEncoding
+            encoding=encoding_dict_from_named_encoding("cp1252"),  # WinAnsiEncoding
             font_descriptor=FontDescriptor(),
             )
         self.orientations: tuple[int, ...] = (0, 90, 180, 270)

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -30,6 +30,7 @@
 import math
 from typing import Any, Callable, Optional, Union
 
+from .._codecs import fill_from_encoding
 from .._font import Font, FontDescriptor
 from ..generic import DictionaryObject, TextStringObject
 from . import OrientationNotFoundError, crlf_space_check, get_display_str, get_text_operands, mult
@@ -86,7 +87,7 @@ class TextExtraction:
         self.font = Font(
             name = "NotInitialized",
             sub_type="Unknown",
-            encoding="charmap",
+            encoding=dict(zip(range(256),  fill_from_encoding("cp1252"))),  # WinAnsiEncoding
             font_descriptor=FontDescriptor(),
             )
         self.orientations: tuple[int, ...] = (0, 90, 180, 270)

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from operator import attrgetter
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
-from .._codecs import fill_from_encoding
+from .._codecs import encoding_dict_from_named_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
 from .._font import Font
 from .._utils import is_char_rtl, logger_warning
@@ -455,18 +455,18 @@ class TextStreamAppearance(BaseStreamAppearance):
         if not font or not font_resource:
             font_name = "/Helv"
             core_font_metrics = CORE_FONT_METRICS["Helvetica"]
-            win_ansi_encoding_list = fill_from_encoding("cp1252")  # WinAnsiEncoding
+            win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")  # WinAnsiEncoding
             font = Font(
                 name="Helvetica",
                 character_map={},
-                encoding=dict(zip(range(256), win_ansi_encoding_list)),
+                encoding=win_ansi_encoding,
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
                 character_widths={
-                    chr(code): core_font_metrics.character_widths[value] for code, value in enumerate(
-                        win_ansi_encoding_list
-                    ) if value in core_font_metrics.character_widths
-                },
+                    chr(code): core_font_metrics.character_widths[character]
+                    for code, character in win_ansi_encoding.items()
+                    if chr(code) in core_font_metrics.character_widths
+                }
             )
             font.character_widths["default"] = core_font_metrics.character_widths["default"]
             font_resource = font.as_font_resource()
@@ -526,7 +526,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                 )
                 font_name = "/Helvetica"
             core_font_metrics = CORE_FONT_METRICS[font_name.removeprefix("/")]
-            win_ansi_encoding=dict(zip(range(256), fill_from_encoding("cp1252")))  # WinAnsiEncoding
+            win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")  # WinAnsiEncoding
             font = Font(
                 name=font_name.removeprefix("/"),
                 character_map={},
@@ -568,7 +568,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                 }
                 for encoding in test_encodings:
                     test_font = copy.copy(font)
-                    test_font.encoding = dict(zip(range(256), fill_from_encoding(encoding)))
+                    test_font.encoding = encoding_dict_from_named_encoding(encoding)
                     encodable = test_font.can_encode(text)
                     if encodable:
                         font = test_font

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -463,9 +463,9 @@ class TextStreamAppearance(BaseStreamAppearance):
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
                 character_widths={
-                    chr(code): core_font_metrics.character_widths[character]
+                    char: core_font_metrics.character_widths[character]
                     for code, character in win_ansi_encoding.items()
-                    if chr(code) in core_font_metrics.character_widths
+                    if (char := chr(code)) in core_font_metrics.character_widths
                 }
             )
             font.character_widths["default"] = core_font_metrics.character_widths["default"]
@@ -534,9 +534,9 @@ class TextStreamAppearance(BaseStreamAppearance):
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
                 character_widths={
-                    chr(code): core_font_metrics.character_widths[character]
+                    char: core_font_metrics.character_widths[character]
                     for code, character in win_ansi_encoding.items()
-                    if chr(code) in core_font_metrics.character_widths
+                    if (char := chr(code)) in core_font_metrics.character_widths
                 }
             )
             font.character_widths["default"] = core_font_metrics.character_widths["default"]

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -526,14 +526,20 @@ class TextStreamAppearance(BaseStreamAppearance):
                 )
                 font_name = "/Helvetica"
             core_font_metrics = CORE_FONT_METRICS[font_name.removeprefix("/")]
+            win_ansi_encoding=dict(zip(range(256), fill_from_encoding("cp1252")))  # WinAnsiEncoding
             font = Font(
                 name=font_name.removeprefix("/"),
                 character_map={},
-                encoding=dict(zip(range(256), fill_from_encoding("cp1252"))),  # WinAnsiEncoding
+                encoding=win_ansi_encoding,
                 sub_type="Type1",
                 font_descriptor=core_font_metrics.font_descriptor,
-                character_widths=core_font_metrics.character_widths
+                character_widths={
+                    chr(code): core_font_metrics.character_widths[character]
+                    for code, character in win_ansi_encoding.items()
+                    if chr(code) in core_font_metrics.character_widths
+                }
             )
+            font.character_widths["default"] = core_font_metrics.character_widths["default"]
 
         # If we have found a font resource, it still might not be able to encode the text value we received.
         encodable = font.can_encode(text)

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -565,6 +565,12 @@ class TextStreamAppearance(BaseStreamAppearance):
                     encodable = test_font.can_encode(text)
                     if encodable:
                         font = test_font
+                        font.character_widths.clear()
+                        for code, character in test_font.encoding.items():
+                            # Look up the width using the glyph name from the encoding
+                            if character in core_font_metrics.character_widths:
+                                font.character_widths[chr(code)] = core_font_metrics.character_widths[character]
+                        font.character_widths["default"] = core_font_metrics.character_widths["default"]
                         font_name = "/PYPDF1" + encoding
                         break
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -546,7 +546,8 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         if not encodable:
             # If we have a font file, we can try to produce a new font resource with an encoding
-            # that does include the necessary characters.
+            # that does include the necessary characters. We only try this for a TrueType font, meaning
+            # that, in PDF terms, it is a simple, 8-bit encoded font.
             if font.font_descriptor.font_file and font.sub_type == "TrueType":
                 try:
                     font = font.from_truetype_font_file(BytesIO(font.font_descriptor.font_file.get_data()))

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -454,21 +454,7 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         if not font or not font_resource:
             font_name = "/Helv"
-            core_font_metrics = CORE_FONT_METRICS["Helvetica"]
-            win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")  # WinAnsiEncoding
-            font = Font(
-                name="Helvetica",
-                character_map={},
-                encoding=win_ansi_encoding,
-                sub_type="Type1",
-                font_descriptor=core_font_metrics.font_descriptor,
-                character_widths={
-                    char: core_font_metrics.character_widths[character]
-                    for code, character in win_ansi_encoding.items()
-                    if (char := chr(code)) in core_font_metrics.character_widths
-                }
-            )
-            font.character_widths["default"] = core_font_metrics.character_widths["default"]
+            font = Font.from_core_font_name()
             font_resource = font.as_font_resource()
 
         ap_stream_data = self._generate_appearance_stream_data(
@@ -525,21 +511,7 @@ class TextStreamAppearance(BaseStreamAppearance):
                     font_name=font_name,
                 )
                 font_name = "/Helvetica"
-            core_font_metrics = CORE_FONT_METRICS[font_name.removeprefix("/")]
-            win_ansi_encoding = encoding_dict_from_named_encoding("cp1252")  # WinAnsiEncoding
-            font = Font(
-                name=font_name.removeprefix("/"),
-                character_map={},
-                encoding=win_ansi_encoding,
-                sub_type="Type1",
-                font_descriptor=core_font_metrics.font_descriptor,
-                character_widths={
-                    char: core_font_metrics.character_widths[character]
-                    for code, character in win_ansi_encoding.items()
-                    if (char := chr(code)) in core_font_metrics.character_widths
-                }
-            )
-            font.character_widths["default"] = core_font_metrics.character_widths["default"]
+            font = Font.from_core_font_name(font_name)
 
         # If we have found a font resource, it still might not be able to encode the text value we received.
         encodable = font.can_encode(text)

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import re
 from dataclasses import dataclass
 from enum import IntEnum
@@ -547,6 +548,25 @@ class TextStreamAppearance(BaseStreamAppearance):
                     encodable = font.can_encode(text)
                 except (ImportError, PdfReadError) as e:
                     logger_warning("Unable to use embedded font for encoding: %(e)s", source=__name__, e=e)
+
+            # If it's one of the unembedded 14 Adobe Core Fonts, we can test other supported encodings
+            elif font.sub_type == "Type1" and font.name in CORE_FONT_METRICS:
+                core_font_metrics = CORE_FONT_METRICS[font.name]
+                test_encodings = {
+                    "cp1250",     # Central / Eastern European
+                    "cp1252",     # Western European
+                    "cp1254",     # Turkish
+                    "cp1257",     # Baltic Rim
+                    "iso8859_15"  # Western European ISO Alternate
+                }
+                for encoding in test_encodings:
+                    test_font = copy.copy(font)
+                    test_font.encoding = dict(zip(range(256), fill_from_encoding(encoding)))
+                    encodable = test_font.can_encode(text)
+                    if encodable:
+                        font = test_font
+                        font_name = "/PYPDF1" + encoding
+                        break
 
             if not encodable:
                 logger_warning(

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -358,7 +358,10 @@ def _type1_font(font_file_data: bytes) -> DictionaryObject:
 def test_get_encoding__type1_font_file_without_encoding():
     # Clear part of the embedded Type1 program has no /Encoding section.
     ft = _type1_font(b"%!PS-AdobeFont\n/FontName /Foo def\neexec\nbinary")
-    assert get_encoding(ft) == ("charmap", {})
+    assert get_encoding(ft) == (
+        dict(zip(range(256), charset_encoding["/StandardEncoding"])),
+        {}
+    )
 
 
 def test_get_encoding__type1_font_file_truncated_dup_line():

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,13 +1,17 @@
 """Test font-related functionality."""
 import os
+import re
 import subprocess
 import sys
+import unicodedata
 from io import BytesIO
+from unittest import mock
 
 import pytest
 from fontTools.ttLib import TTFont
 
 from pypdf import PdfReader, PdfWriter
+from pypdf._cmap import _parse_to_unicode
 from pypdf._font import Font, FontDescriptor
 from pypdf.errors import LimitReachedError, PdfReadError
 from pypdf.generic import (
@@ -338,3 +342,27 @@ def test_simple_font_reverse_cmap_from_character_map():
 
     reader2 = PdfReader(stream)
     assert extracted_text == reader2.pages[0].extract_text()
+
+
+def test__create_widths_list_and_unicode_stream():
+    font = Font.from_core_font_name("Helvetica")
+    # Cover the untested conditions after the loop over mapping_source
+    # in _create_widths_list_and_unicode_stream has completed.
+    # For "if previous_bfrange == True" branch:
+    font._create_widths_list_and_unicode_stream()
+    # For "elif tmp_list" and "bfrange_map" has entries branches:
+    font.encoding[255] = font.encoding[0]
+    # Assert that the ToUnicode CMap can be parsed and reflects the original encoding.
+    map_dict, _ = _parse_to_unicode(font.as_font_resource())
+    assert all(
+        map_dict[chr(chr_code)] == unicodedata.normalize("NFKC", unipoint)
+        for chr_code, unipoint in font.encoding.items()
+    )
+    # Test that we observe CMAP_MAX_ENTRIES_PER_GROUP. We mock this value
+    # (which is normally 100) to 5 to ease testing.
+    with mock.patch("pypdf._font.CMAP_MAX_ENTRIES_PER_GROUP", 5):
+        _widths_list, to_unicode_stream = font._create_widths_list_and_unicode_stream()
+        assert all(val in "12345" for val in re.findall(r"([0-9]*) begin", to_unicode_stream.get_data().decode()))
+    # Test the case of an empty encoding
+    font.encoding.clear()
+    font._create_widths_list_and_unicode_stream()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -157,15 +157,24 @@ def test_font_from_font_file():
         if font_resource == "/F6":
             crippled_font_data = BytesIO()
             with TTFont(BytesIO(font_data)) as tt_font_object:
+                # Test zero units per em
+                tt_font_object["head"].unitsPerEm = 0
+                tt_font_object.save(crippled_font_data)
+                with pytest.raises(PdfReadError, match=r"invalid unitsPerEm"):
+                    Font.from_truetype_font_file(crippled_font_data)
+                tt_font_object["head"].unitsPerEm = 2048
+
+                # Test various missing tables
                 del tt_font_object["name"]
                 del tt_font_object["OS/2"]
                 del tt_font_object["post"]
+                crippled_font_data.seek(0)
                 tt_font_object.save(crippled_font_data)
                 font = Font.from_truetype_font_file(crippled_font_data)
-                crippled_font_data.seek(0)
 
                 # Test raising AttributeError in _get_typographic_maps due to missing cmap table
                 del tt_font_object["cmap"]
+                crippled_font_data.seek(0)
                 tt_font_object.save(crippled_font_data)
                 crippled_font_data_value = crippled_font_data.getvalue()
                 font.font_descriptor.font_file.set_data(crippled_font_data_value)
@@ -187,19 +196,6 @@ def test_font_as_font_resource():
     font_data = font_resources["/F7"]["/DescendantFonts"][0]["/FontDescriptor"]["/FontFile2"].get_data()
     font = Font.from_truetype_font_file(BytesIO(font_data))
     font._add_to_writer(writer, font_resources, NameObject("/" + font.name))
-
-
-def test_font_from_font_file_zero_units_per_em():
-    reader = PdfReader(RESOURCE_ROOT / "fontsampler.pdf")
-    font_resource = reader.pages[0]["/Resources"]["/Font"]["/F1"]
-    font_data = font_resource["/DescendantFonts"][0]["/FontDescriptor"]["/FontFile2"].get_data()
-    crippled_font_data = BytesIO()
-    with TTFont(BytesIO(font_data)) as tt_font_object:
-        tt_font_object["head"].unitsPerEm = 0
-        tt_font_object.save(crippled_font_data)
-    crippled_font_data.seek(0)
-    with pytest.raises(PdfReadError, match=r"invalid unitsPerEm"):
-        Font.from_truetype_font_file(crippled_font_data)
 
 
 def test_font_from_font_file_no_fonttools(tmp_path):

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,13 +1,16 @@
 """Test font-related functionality."""
 import os
+import re
 import subprocess
 import sys
+import unicodedata
 from io import BytesIO
 
 import pytest
 from fontTools.ttLib import TTFont
 
 from pypdf import PdfReader, PdfWriter
+from pypdf._cmap import _parse_to_unicode
 from pypdf._font import Font, FontDescriptor
 from pypdf.errors import LimitReachedError, PdfReadError
 from pypdf.generic import (
@@ -338,3 +341,23 @@ def test_simple_font_reverse_cmap_from_character_map():
 
     reader2 = PdfReader(stream)
     assert extracted_text == reader2.pages[0].extract_text()
+
+
+def test__create_widths_list_and_unicode_stream():
+    font = Font.from_core_font_name("Helvetica")
+    # Make sure that we have some encoding difference so that we will include a
+    # ToUnicode CMap in a font resource.
+    font.encoding[255] = font.encoding[0]
+    # Assert that the ToUnicode CMap can be parsed and reflects the original encoding.
+    map_dict, _ = _parse_to_unicode(font.as_font_resource())
+    assert all(
+        map_dict[chr(chr_code)] == unicodedata.normalize("NFKC", unipoint)
+        for chr_code, unipoint in font.encoding.items()
+    )
+    # Test that we observe CMAP_MAX_ENTRIES_PER_GROUP; we're using a core font which
+    # has 256 characters. Hence, we should have two groups of 100 bfchar lines
+    # and one group with the remaining 56 bfchar lines.
+    _widths_list, to_unicode_stream = font._create_widths_list_and_unicode_stream()
+    assert all(
+        val in ("56", "100") for val in re.findall(r"([0-9]*) beginbfchar", to_unicode_stream.get_data().decode())
+    )

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -17,6 +17,7 @@ from pypdf.generic import (
     NameObject,
     NumberObject,
 )
+from pypdf.generic._appearance_stream import BaseStreamConfig, TextStreamAppearance
 
 from . import RESOURCE_ROOT
 
@@ -304,3 +305,36 @@ def test_font__collect_cid_character_widths__limits():
     ):
         Font._collect_cid_character_widths(d_font=d_font, current_widths=current_widths)
     assert current_widths == {}
+
+
+def test_simple_font_reverse_cmap_from_character_map():
+    pdf_path = RESOURCE_ROOT / "side-by-side-subfig.pdf"
+    reader = PdfReader(pdf_path)
+    extracted_text = reader.pages[0].extract_text()
+    font = Font.from_font_resource(reader.pages[0]["/Resources"]["/Font"]["/F33"])
+
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+    writer.pages[0]["/Resources"][NameObject("/Font")] = DictionaryObject()
+    font._add_to_writer(writer, writer.pages[0]["/Resources"]["/Font"], NameObject(f"/{font.name}"))
+    appearance_stream = TextStreamAppearance(
+        layout=BaseStreamConfig(rectangle=(0.0, 0.0, 512, 692)),
+        text=extracted_text,
+        font=font,
+        font_resource=writer.pages[0]["/Resources"]["/Font"][f"/{font.name}"],
+        is_multiline=True
+    )
+    writer._add_apstream_object(
+        page,
+        appearance_stream,
+        "LoremIpsum",
+        x_offset=100,
+        y_offset=692
+    )
+
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    reader2 = PdfReader(stream)
+    assert extracted_text == reader2.pages[0].extract_text()

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -1,17 +1,13 @@
 """Test font-related functionality."""
 import os
-import re
 import subprocess
 import sys
-import unicodedata
 from io import BytesIO
-from unittest import mock
 
 import pytest
 from fontTools.ttLib import TTFont
 
 from pypdf import PdfReader, PdfWriter
-from pypdf._cmap import _parse_to_unicode
 from pypdf._font import Font, FontDescriptor
 from pypdf.errors import LimitReachedError, PdfReadError
 from pypdf.generic import (
@@ -342,27 +338,3 @@ def test_simple_font_reverse_cmap_from_character_map():
 
     reader2 = PdfReader(stream)
     assert extracted_text == reader2.pages[0].extract_text()
-
-
-def test__create_widths_list_and_unicode_stream():
-    font = Font.from_core_font_name("Helvetica")
-    # Cover the untested conditions after the loop over mapping_source
-    # in _create_widths_list_and_unicode_stream has completed.
-    # For "if previous_bfrange == True" branch:
-    font._create_widths_list_and_unicode_stream()
-    # For "elif tmp_list" and "bfrange_map" has entries branches:
-    font.encoding[255] = font.encoding[0]
-    # Assert that the ToUnicode CMap can be parsed and reflects the original encoding.
-    map_dict, _ = _parse_to_unicode(font.as_font_resource())
-    assert all(
-        map_dict[chr(chr_code)] == unicodedata.normalize("NFKC", unipoint)
-        for chr_code, unipoint in font.encoding.items()
-    )
-    # Test that we observe CMAP_MAX_ENTRIES_PER_GROUP. We mock this value
-    # (which is normally 100) to 5 to ease testing.
-    with mock.patch("pypdf._font.CMAP_MAX_ENTRIES_PER_GROUP", 5):
-        _widths_list, to_unicode_stream = font._create_widths_list_and_unicode_stream()
-        assert all(val in "12345" for val in re.findall(r"([0-9]*) begin", to_unicode_stream.get_data().decode()))
-    # Test the case of an empty encoding
-    font.encoding.clear()
-    font._create_widths_list_and_unicode_stream()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1897,6 +1897,7 @@ def test_update_form_fields3(caplog, tmp_path):
     assert new_font_resource in writer.pages[0]["/Annots"][0]["/DA"]
     assert new_font_resource in writer.pages[0]["/Resources"]["/Font"]
     assert new_font_resource in writer._root_object["/AcroForm"]["/DR"]["/Font"]
+    # Assert that we couldn't encode the data with this font
     writer.write(output)
     output.seek(0)
     reader = PdfReader(output)
@@ -1905,6 +1906,8 @@ def test_update_form_fields3(caplog, tmp_path):
         if expected_value != "شهرزاد":
             assert expected_value in extracted_text
     assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
+    # Retry with the new font right away, to increase coverage in _appearance_stream.py
+    writer.update_page_form_field_values(writer.pages[0], {"localitatea": ("شهرزاد", "/PYPDF1", 0)}, flatten=True)
 
 
 @pytest.mark.enable_socket

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1801,7 +1801,7 @@ def test_update_form_fields2(caplog):
                     "MM": "04",
                     "DD": "21",
                     "YY": "24",
-                    "Initial": "RRG",
+                    "Initial": "ąčęėįšųūž. ĄČĘĖĮŠŲŪŽ.",
                     # "I DO NOT Agree": null,
                     # "Last Name": null
                 },
@@ -1840,7 +1840,7 @@ def test_update_form_fields2(caplog):
         writer = PdfWriter(clone_from=reader)
 
         writer.update_page_form_field_values(
-            None, my_files[file]["usage"]["fields"], auto_regenerate=True
+            None, my_files[file]["usage"]["fields"], auto_regenerate=True, flatten=True
         )
         merger.append(writer)
     assert merger.get_form_text_fields(True) == {
@@ -1849,7 +1849,7 @@ def test_update_form_fields2(caplog):
         "test1.MM": "04",
         "test1.DD": "21",
         "test1.YY": "24",
-        "test1.Initial": "RRG",
+        "test1.Initial": "ąčęėįšųūž. ĄČĘĖĮŠŲŪŽ.",
         "test1.I DO NOT Agree": None,
         "test1.Last Name": None,
         "test2.p2 First Name": "Joe",
@@ -1866,6 +1866,7 @@ def test_update_form_fields2(caplog):
         "test2.p3 DD": "25",
         "test2.p3 YY": "21",
     }
+    assert "/PYPDF1cp1257" in merger.pages[0]["/Resources"]["/Font"]
     assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -19,6 +19,7 @@ from pypdf import (
     PdfWriter,
     Transformation,
 )
+from pypdf._font import Font
 from pypdf.annotations import Link
 from pypdf.errors import DeprecationError, LimitReachedError, PageSizeNotDefinedError, PdfReadError, PyPdfError
 from pypdf.generic import (
@@ -1908,6 +1909,10 @@ def test_update_form_fields3(caplog, tmp_path):
     assert "Text string 'شهرزاد' contains characters not supported by font encoding." in caplog.text
     # Retry with the new font right away, to increase coverage in _appearance_stream.py
     writer.update_page_form_field_values(writer.pages[0], {"localitatea": ("شهرزاد", "/PYPDF1", 0)}, flatten=True)
+    # Cripple the font's ToUnicode cmap, to increase can_encode coverage in _font.py
+    del (writer.pages[0]["/Resources"]["/Font"]["/PYPDF1"]["/ToUnicode"])
+    font = Font.from_font_resource(writer.pages[0]["/Resources"]["/Font"]["/PYPDF1"])
+    assert not font.can_encode("Whatever text")
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
The unembedded Adobe core fonts contain around 315 characters and therefore support more encodings than only cp1252 (WinAnsi). I've found that the following encodings appear to be supported:
"cp1252",       # Western European (WinAnsi base)
"cp1250",       # Central / Eastern European
"cp1254",       # Turkish
"cp1257",       # Baltic Rim
"iso8859_15",   # Western European ISO Alternate

When we encounter form field text with unencodable characters with one of the 14 Adobe core fonts, we try one of the above encodings instead. If successful, we make a new Font instance with that encoding, add it to the appearance stream, and add it to the document's font resources with a differences encoding and an associated ToUnicode cmap.

Fixes https://github.com/py-pdf/pypdf/issues/3318

Achieves full coverage for _font.py.

This PR does include a small bug fix very similar in character to the added code, and refactors one test.
 
Assisted by Google Gemini, especially the changes for generating the ToUnicode cmap.

EDIT

I added some patches to always fall back to StandardEncoding for simple fonts when /Encoding is not defined in the font resource (and when a Type1 font does not provide its own encoding). This simplifies my original PR (don't need to deal with charmap encoding anymore). I've changed code elsewhere accordingly.
