### PR TITLE
Add text alignment support for FreeText annotation, Update _markup_an…

### DIFF
--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -143,7 +143,7 @@ class FreeText(MarkupAnnotation):
         font_color: str = "000000",
         border_color: Optional[str] = "000000",
         background_color: Optional[str] = "ffffff",
-        align: str = "center",
+        align: str = "left",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/pypdf/annotations/_markup_annotations.py
+++ b/pypdf/annotations/_markup_annotations.py
@@ -143,6 +143,7 @@ class FreeText(MarkupAnnotation):
         font_color: str = "000000",
         border_color: Optional[str] = "000000",
         background_color: Optional[str] = "ffffff",
+        align: str = "center",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -160,7 +161,7 @@ class FreeText(MarkupAnnotation):
         else:
             font_str = f"{font_str}normal "
         font_str = f"{font_str}{font_size} {font}"
-        font_str = f"{font_str};text-align:left;color:#{font_color}"
+        font_str = f"{font_str};text-align:{align};color:#{font_color}"
 
         default_appearance_string = ""
         if border_color:


### PR DESCRIPTION
# Add text alignment support for FreeText annotations

## Summary

This pull request adds support for specifying text alignment when creating FreeText annotations.

## Motivation

Currently, FreeText annotations do not provide an option to set the text alignment. This makes it difficult to create annotations with centered or right-aligned text when needed.

## Changes

* Added an `alignment` option for FreeText annotations.
* Updated the FreeText annotation generation to apply the specified alignment.
* Preserves the existing behavior when no alignment is specified.

## Testing

* Verified that left, center, and right alignment are correctly written to the annotation.
* Confirmed that existing code continues to work without modification.
