### PR TITLE
MAINT: Fix typos in comments, docstrings, and docs

### DIFF
--- a/docs/dev/documentation.md
+++ b/docs/dev/documentation.md
@@ -27,7 +27,7 @@ It is also possible to run it locally:
    ```
 
 3. Run `doctest` build. It uses indirectly `sphinx-build` command line tool
-    installed with docs requrements. See
+    installed with docs requirements. See
    [Sphinx's docs](https://www.sphinx-doc.org/en/master/usage/quickstart.html#running-the-build)
    for details.
 

--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -655,7 +655,7 @@ class Font:
         # If we have an embedded Truetype font, we assume that we need to produce a Type 2 CID font resource.
         if self.font_descriptor.font_file and self.sub_type == "TrueType":
             # Begin with creating the widths array (part of the descendant font) and the unicode cmap (part
-            # of the Type 0 font obect).
+            # of the Type 0 font object).
             widths_list, to_unicode_stream = self._create_widths_list_and_unicode_stream()
 
             # Create the descendant font object

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1852,7 +1852,7 @@ def test_iss2761():
 
 @pytest.mark.enable_socket
 def test_iss2817():
-    """Test for rebuiling Xref_ObjStm"""
+    """Test for rebuilding Xref_ObjStm"""
     url = "https://github.com/user-attachments/files/16764070/crash-7e1356f1179b4198337f282304cb611aea26a199.pdf"
     name = "iss2817.pdf"
     reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1705,7 +1705,7 @@ def test_merge_content_stream_to_page():
     """Test that new content data is correctly added to page contents
     in the form of an ArrayObject or StreamObject. The
     test_add_apstream_object code already correctly checks that
-    _merge_content_stream_to_page works for an emtpy page.
+    _merge_content_stream_to_page works for an empty page.
     """
     writer = PdfWriter()
     page = writer.add_blank_page(100, 100)


### PR DESCRIPTION
Fixes several small typos found via codespell:

- \`pypdf/_font.py\`: \`obect\` -> \`object\` in inline comment
- \`tests/test_writer.py\`: \`emtpy\` -> \`empty\` in docstring
- \`tests/test_reader.py\`: \`rebuiling\` -> \`rebuilding\` in docstring
- \`docs/dev/documentation.md\`: \`requrements\` -> \`requirements\`