### PR TITLE
BUG: Avoid flattening single-colorant /DeviceN images to grayscale

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -89,13 +89,12 @@ def _get_image_mode(
         original_color_space = color_space
         color_components = len(color_space[1])
         color_space_str = color_space[2].get_object()
-        if color_space_str == "/DeviceCMYK" and color_components == 1:
-            if original_color_space[1][0] != "/Black":
-                logger_warning(
-                    "Color %(color)s converted to Gray. Please share PDF with pypdf dev team",
-                    source=__name__,
-                    color=original_color_space[1][0],
-                )
+        if (
+            color_space_str == "/DeviceCMYK"
+            and color_components == 1
+            and original_color_space[1][0] == "/Black"
+        ):
+            # A lone /Black colorant maps directly onto grayscale.
             return "L", True
         mode, invert_color = _get_image_mode(
             color_space_str, color_components, prev_mode, depth + 1

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -1,4 +1,5 @@
 """Test the pypdf.generic._image_xobject module."""
+import zlib
 from io import BytesIO
 
 import PIL
@@ -9,7 +10,15 @@ from pypdf import PdfReader
 from pypdf._utils import Version
 from pypdf.constants import FilterTypes, ImageAttributes, StreamAttributes
 from pypdf.errors import EmptyImageDataError, LimitReachedError, PdfReadError
-from pypdf.generic import ArrayObject, DecodedStreamObject, NameObject, NumberObject, StreamObject, TextStringObject
+from pypdf.generic import (
+    ArrayObject,
+    DecodedStreamObject,
+    EncodedStreamObject,
+    NameObject,
+    NumberObject,
+    StreamObject,
+    TextStringObject,
+)
 from pypdf.generic._image_xobject import (
     _get_image_mode,
     _handle_flate,
@@ -387,6 +396,58 @@ def test_get_imagemode__color_components_out_of_range() -> None:
     # it should now fall back to the previous mode.
     assert _get_image_mode("/Unknown", 99, "L") == ("L", False)
     assert _get_image_mode("/Unknown", 99, "") == ("", False)
+
+
+def test_get_imagemode__devicen_single_colorant() -> None:
+    """
+    A single-colorant /DeviceN with a /DeviceCMYK alternate is derived through
+    that alternate space, the same way /Separation is handled above it.
+
+    Regression test for issue #3302, where e.g. a lone /Cyan colorant was
+    always flattened to grayscale.
+    """
+    color_space = ArrayObject([
+        NameObject("/DeviceN"),
+        ArrayObject([NameObject("/Cyan")]),
+        NameObject("/DeviceCMYK"),
+        NameObject("/Identity"),
+    ])
+    assert _get_image_mode(color_space, 1, "") == ("CMYK", True)
+
+    # A lone /Black colorant is the one case that maps onto grayscale exactly,
+    # so it keeps its dedicated shortcut.
+    color_space[1] = ArrayObject([NameObject("/Black")])
+    assert _get_image_mode(color_space, 1, "") == ("L", True)
+
+
+def test_xobj_to_image__devicen_single_colorant(caplog: pytest.LogCaptureFixture) -> None:
+    """
+    Extracting a single-colorant /DeviceN image no longer collapses to a flat
+    gray image or warns about it; darker tint now means darker pixels.
+
+    Regression test for issue #3302.
+    """
+    color_space = ArrayObject([
+        NameObject("/DeviceN"),
+        ArrayObject([NameObject("/Cyan")]),
+        NameObject("/DeviceCMYK"),
+        NameObject("/Identity"),
+    ])
+    x_object = EncodedStreamObject()
+    x_object[NameObject(ImageAttributes.WIDTH)] = NumberObject(3)
+    x_object[NameObject(ImageAttributes.HEIGHT)] = NumberObject(1)
+    x_object[NameObject("/BitsPerComponent")] = NumberObject(8)
+    x_object[NameObject(ImageAttributes.COLOR_SPACE)] = color_space
+    x_object[NameObject("/Colors")] = NumberObject(1)
+    x_object[NameObject(StreamAttributes.FILTER)] = NameObject(FilterTypes.FLATE_DECODE)
+    x_object._data = zlib.compress(bytes([0, 128, 255]))  # no, half, full tint
+
+    _extension, _data, img = _xobj_to_image(x_object)
+
+    assert img.mode == "CMYK"
+    no_tint, half_tint, full_tint = (img.convert("RGB").getpixel((x, 0)) for x in range(3))
+    assert no_tint > half_tint > full_tint
+    assert "converted to Gray" not in caplog.text
 
 
 def test_xobj_to_image__color_components_out_of_range() -> None:


### PR DESCRIPTION
Fixes #3302.

_get_image_mode has a /Separation branch that resolves its Pillow mode by recursing into the color space's alternate space, and a /DeviceN branch a few lines below that does mostly the same thing except for one special case. Any single colorant paired with a /DeviceCMYK alternate went straight to grayscale, warning "Color %s converted to Gray" for every colorant besides /Black. That shortcut was added in #2322 for K-only scanner images, where grayscale is exact, but it swallowed every other single-colorant DeviceN image the same way, which is what the reporter's /Cyan image was hitting.

The fix narrows that shortcut to require the colorant literally be /Black before returning grayscale directly. Everything else now falls through to the same recursive alternate-space lookup /Separation already uses (that recursion resolves a /DeviceCMYK alternate straight to CMYK on its own, no new codepath needed). I also checked whether _apply_decode's Separation-only decode-inversion override should be extended to DeviceN too, and it should not. _image_from_bytes's existing byte-replication fallback already gets the light-to-dark direction right on its own, and stacking Separation's decode reversal on top would double-invert it. Left it alone since it is a separate, pre-existing issue outside the scope of #3302.

I did not have a working copy of the reporter's PDF (an issuu.com viewer link with time-limited AWS download links, 50 MB), so I built a synthetic single-colorant /Cyan DeviceN CMYK image to verify. Before the fix, the extracted pixels for tints 0/128/255 come out (255,255,255), (127,127,127), (0,0,0), identical byte for byte to what a /Black-colorant image produces (mode L, plus the warning). After the fix, they come out (255,255,255), (63,63,63), (0,0,0) in mode CMYK with no warning. The /Black case is unchanged, still mode L, byte for byte.

Added two regression tests in tests/generic/test_image_xobject.py, one at the _get_image_mode level and one round-tripping through _xobj_to_image. Ran the full test_filters.py and tests/generic/ suites (162 passed, 5 pre-existing skips) plus ruff, mypy, and pyupgrade, all clean.