### PR TITLE
ENH: AppearanceStream: Allow arbitrary rotations and apply rotations for annotation appearance streams

### DIFF
--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -746,8 +746,19 @@ class TextStreamAppearance(BaseStreamAppearance):
             border_width = cast(DictionaryObject, field["/BS"]).get("/W", border_width)
             border_style = cast(DictionaryObject, field["/BS"]).get("/S", border_style)
 
+        rotation = 0
+        appearance_characteristics = field.get_inherited("/MK", None)
+        if isinstance(appearance_characteristics, DictionaryObject):
+            rotation = int(appearance_characteristics.get("/R", 0))
+
         # Create the TextStreamAppearance instance
-        layout = BaseStreamConfig(rectangle=rectangle, border_width=border_width, border_style=border_style)
+        layout = BaseStreamConfig(
+            rectangle=rectangle,
+            border_width=border_width,
+            border_style=border_style,
+            rotation=rotation
+        )
+
         new_appearance_stream = cls(
             layout,
             text,

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -58,6 +58,27 @@ class BaseStreamConfig:
 class BaseStreamAppearance(DecodedStreamObject):
     """A class representing the very base of an appearance stream, that is, a rectangle and a border."""
 
+    def _add_matrix(self, rotation: int) -> None:
+        # We need to rotate our rectangle while keeping its origin to (0, 0).
+        # Rotation goes counterclockwise. We want to know the furthest points to which we rotated left and down.
+        # These will serve as our X and Y offsets to translate the entire object origin back to (0, 0).
+        # If a corner rotates into negative space, that is our offset. If none does, the minimum is 0.0.
+        matrix = Transformation().rotate(rotation)
+        bottom_right_corner = (self._layout.rectangle.width, 0.0)
+        top_left_corner = (0.0, self._layout.rectangle.height)
+        top_right_corner = (self._layout.rectangle.width, self._layout.rectangle.height)
+        rotated_bottom_right_corner = matrix.apply_on(bottom_right_corner)
+        rotated_top_left_corner = matrix.apply_on(top_left_corner)
+        rotated_top_right_corner = matrix.apply_on(top_right_corner)
+        translation_x_offset = -min(
+            0.0, rotated_bottom_right_corner[0], rotated_top_left_corner[0], rotated_top_right_corner[0]
+        )
+        translation_y_offset = -min(
+            0.0, rotated_bottom_right_corner[1], rotated_top_left_corner[1], rotated_top_right_corner[1]
+        )
+        matrix = matrix.translate(translation_x_offset, translation_y_offset)
+        self[NameObject("/Matrix")] = ArrayObject([FloatObject(round(i, 3)) for i in matrix.ctm])
+
     def __init__(self, layout: BaseStreamConfig | None) -> None:
         """
         Takes the appearance stream layout as an argument.
@@ -74,25 +95,7 @@ class BaseStreamAppearance(DecodedStreamObject):
         # Define the rotation matrix
         rotation = self._layout.rotation % 360
         if rotation:
-            matrix = Transformation().rotate(rotation)
-
-            # Rotation goes counterclockwise. We want to know the furthest points to which we rotated left and down.
-            # These will serve as our X and Y offsets to translate the entire object origin back to (0, 0).
-            # If a corner rotates into negative space, that is our offset. If none does, the minimum is 0.0.
-            bottom_right_corner = (self._layout.rectangle.width, 0.0)
-            top_left_corner = (0.0, self._layout.rectangle.height)
-            top_right_corner = (self._layout.rectangle.width, self._layout.rectangle.height)
-            rotated_bottom_right_corner = matrix.apply_on(bottom_right_corner)
-            rotated_top_left_corner = matrix.apply_on(top_left_corner)
-            rotated_top_right_corner = matrix.apply_on(top_right_corner)
-            translation_x_offset = -min(
-                0.0, rotated_bottom_right_corner[0], rotated_top_left_corner[0], rotated_top_right_corner[0]
-            )
-            translation_y_offset = -min(
-                0.0, rotated_bottom_right_corner[1], rotated_top_left_corner[1], rotated_top_right_corner[1]
-            )
-            matrix = matrix.translate(translation_x_offset, translation_y_offset)
-            self[NameObject("/Matrix")] = ArrayObject([FloatObject(round(i, 3)) for i in matrix.ctm])
+            self._add_matrix(rotation)
 
 
 class TextAlignment(IntEnum):

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -11,12 +11,15 @@ from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from .._codecs import encoding_dict_from_named_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
 from .._font import Font
+from .._page import Transformation
 from .._utils import is_char_rtl, logger_warning
 from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes, PageAttributes
 from ..errors import PdfReadError
 from ..generic import (
+    ArrayObject,
     DecodedStreamObject,
     DictionaryObject,
+    FloatObject,
     IndirectObject,
     NameObject,
     NumberObject,
@@ -49,6 +52,7 @@ class BaseStreamConfig:
     rectangle: RectangleObject = field(default_factory=lambda: RectangleObject((0.0, 0.0, 0.0, 0.0)))
     border_width: int = 1  # The width of the border in points
     border_style: str = BorderStyles.SOLID
+    rotation: int = 0
 
 
 class BaseStreamAppearance(DecodedStreamObject):
@@ -66,6 +70,29 @@ class BaseStreamAppearance(DecodedStreamObject):
         self[NameObject("/Type")] = NameObject("/XObject")
         self[NameObject("/Subtype")] = NameObject("/Form")
         self[NameObject("/BBox")] = self._layout.rectangle
+
+        # Define the rotation matrix
+        rotation = self._layout.rotation % 360
+        if rotation:
+            matrix = Transformation().rotate(rotation)
+
+            # Rotation goes counterclockwise. We want to know the furthest points to which we rotated left and down.
+            # These will serve as our X and Y offsets to translate the entire object origin back to (0, 0).
+            # If a corner rotates into negative space, that is our offset. If none does, the minimum is 0.0.
+            bottom_right_corner = (self._layout.rectangle.width, 0.0)
+            top_left_corner = (0.0, self._layout.rectangle.height)
+            top_right_corner = (self._layout.rectangle.width, self._layout.rectangle.height)
+            rotated_bottom_right_corner = matrix.apply_on(bottom_right_corner)
+            rotated_top_left_corner = matrix.apply_on(top_left_corner)
+            rotated_top_right_corner = matrix.apply_on(top_right_corner)
+            translation_x_offset = -min(
+                0.0, rotated_bottom_right_corner[0], rotated_top_left_corner[0], rotated_top_right_corner[0]
+            )
+            translation_y_offset = -min(
+                0.0, rotated_bottom_right_corner[1], rotated_top_left_corner[1], rotated_top_right_corner[1]
+            )
+            matrix = matrix.translate(translation_x_offset, translation_y_offset)
+            self[NameObject("/Matrix")] = ArrayObject([FloatObject(round(i, 3)) for i in matrix.ctm])
 
 
 class TextAlignment(IntEnum):

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from io import BytesIO
 from operator import attrgetter
@@ -46,7 +46,7 @@ TEXT_SPACE_TO_GLYPH_SPACE_FACTOR = 1000
 @dataclass
 class BaseStreamConfig:
     """A container representing the basic layout of an appearance stream."""
-    rectangle: RectangleObject | tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    rectangle: RectangleObject = field(default_factory=lambda: RectangleObject((0.0, 0.0, 0.0, 0.0)))
     border_width: int = 1  # The width of the border in points
     border_style: str = BorderStyles.SOLID
 
@@ -65,7 +65,7 @@ class BaseStreamAppearance(DecodedStreamObject):
         self._layout = layout or BaseStreamConfig()
         self[NameObject("/Type")] = NameObject("/XObject")
         self[NameObject("/Subtype")] = NameObject("/Form")
-        self[NameObject("/BBox")] = RectangleObject(self._layout.rectangle)
+        self[NameObject("/BBox")] = self._layout.rectangle
 
 
 class TextAlignment(IntEnum):
@@ -223,8 +223,6 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         """
         rectangle = self._layout.rectangle
-        if isinstance(rectangle, tuple):
-            rectangle = RectangleObject(rectangle)
         leading_factor = (
             (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
         )

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -588,7 +588,11 @@ class TextStreamAppearance(BaseStreamAppearance):
         """
         # Calculate rectangle dimensions
         _rectangle = cast(RectangleObject, annotation[AnnotationDictionaryAttributes.Rect])
-        rectangle = RectangleObject((0, 0, abs(_rectangle[2] - _rectangle[0]), abs(_rectangle[3] - _rectangle[1])))
+        # Normalize the rectangle, apply page rotation if applicable
+        if page.get_inherited("/Rotate") in {90, 270}:
+            rectangle = RectangleObject((0, 0, abs(_rectangle[3] - _rectangle[1]), abs(_rectangle[2] - _rectangle[0])))
+        else:
+            rectangle = RectangleObject((0, 0, abs(_rectangle[2] - _rectangle[0]), abs(_rectangle[3] - _rectangle[1])))
 
         # Get default appearance dictionary from annotation
         default_appearance = annotation.get_inherited(

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -663,7 +663,11 @@ class TextStreamAppearance(BaseStreamAppearance):
         """
         # Calculate rectangle dimensions
         _rectangle = cast(RectangleObject, annotation[AnnotationDictionaryAttributes.Rect])
-        rectangle = RectangleObject((0, 0, abs(_rectangle[2] - _rectangle[0]), abs(_rectangle[3] - _rectangle[1])))
+        # Normalize the rectangle, apply page rotation if applicable
+        if page.get_inherited("/Rotate") in {90, 270}:
+            rectangle = RectangleObject((0, 0, abs(_rectangle[3] - _rectangle[1]), abs(_rectangle[2] - _rectangle[0])))
+        else:
+            rectangle = RectangleObject((0, 0, abs(_rectangle[2] - _rectangle[0]), abs(_rectangle[3] - _rectangle[1])))
 
         # Get default appearance dictionary from annotation
         default_appearance = annotation.get_inherited(

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -671,8 +671,20 @@ class TextStreamAppearance(BaseStreamAppearance):
             border_width = cast(DictionaryObject, field["/BS"]).get("/W", border_width)
             border_style = cast(DictionaryObject, field["/BS"]).get("/S", border_style)
 
+        rotation = 0
+        if "/MK" in field:
+            appearance_characteristics = cast(DictionaryObject, field["/MK"])
+            if "/R" in appearance_characteristics:
+                rotation = cast(int, appearance_characteristics.get("/R", 0))
+
         # Create the TextStreamAppearance instance
-        layout = BaseStreamConfig(rectangle=rectangle, border_width=border_width, border_style=border_style)
+        layout = BaseStreamConfig(
+            rectangle=rectangle,
+            border_width=border_width,
+            border_style=border_style,
+            rotation=rotation
+        )
+
         new_appearance_stream = cls(
             layout,
             text,

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -9,12 +9,15 @@ from typing import TYPE_CHECKING, Any, cast
 from .._codecs import fill_from_encoding
 from .._codecs.core_font_metrics import CORE_FONT_METRICS
 from .._font import Font
+from .._page import Transformation
 from .._utils import logger_warning
 from ..constants import AnnotationDictionaryAttributes, BorderStyles, FieldDictionaryAttributes, PageAttributes
 from ..errors import PdfReadError
 from ..generic import (
+    ArrayObject,
     DecodedStreamObject,
     DictionaryObject,
+    FloatObject,
     IndirectObject,
     NameObject,
     NumberObject,
@@ -43,6 +46,7 @@ class BaseStreamConfig:
     rectangle: RectangleObject = field(default_factory=lambda: RectangleObject((0.0, 0.0, 0.0, 0.0)))
     border_width: int = 1  # The width of the border in points
     border_style: str = BorderStyles.SOLID
+    rotation: int = 0
 
 
 class BaseStreamAppearance(DecodedStreamObject):
@@ -60,6 +64,29 @@ class BaseStreamAppearance(DecodedStreamObject):
         self[NameObject("/Type")] = NameObject("/XObject")
         self[NameObject("/Subtype")] = NameObject("/Form")
         self[NameObject("/BBox")] = self._layout.rectangle
+
+        # Define the rotation matrix
+        rotation = self._layout.rotation % 360
+        if rotation:
+            matrix = Transformation().rotate(rotation)
+
+            # Rotation goes counterclockwise. We want to know the furthest points to which we rotated left and down.
+            # These will serve as our X and Y offsets to translate the entire object origin back to (0, 0).
+            # If a corner rotates into negative space, that is our offset. If none does, the minimum is 0.0.
+            bottom_right_corner = (self._layout.rectangle.width, 0.0)
+            top_left_corner = (0.0, self._layout.rectangle.height)
+            top_right_corner = (self._layout.rectangle.width, self._layout.rectangle.height)
+            rotated_bottom_right_corner = matrix.apply_on(bottom_right_corner)
+            rotated_top_left_corner = matrix.apply_on(top_left_corner)
+            rotated_top_right_corner = matrix.apply_on(top_right_corner)
+            translation_x_offset = -min(
+                0.0, rotated_bottom_right_corner[0], rotated_top_left_corner[0], rotated_top_right_corner[0]
+            )
+            translation_y_offset = -min(
+                0.0, rotated_bottom_right_corner[1], rotated_top_left_corner[1], rotated_top_right_corner[1]
+            )
+            matrix = matrix.translate(translation_x_offset, translation_y_offset)
+            self[NameObject("/Matrix")] = ArrayObject([FloatObject(round(i, 3)) for i in matrix.ctm])
 
 
 class TextAlignment(IntEnum):

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from io import BytesIO
 from typing import TYPE_CHECKING, Any, cast
@@ -40,7 +40,7 @@ DEFAULT_FONT_SIZE_IN_MULTILINE = 12
 @dataclass
 class BaseStreamConfig:
     """A container representing the basic layout of an appearance stream."""
-    rectangle: RectangleObject | tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    rectangle: RectangleObject = field(default_factory=lambda: RectangleObject((0.0, 0.0, 0.0, 0.0)))
     border_width: int = 1  # The width of the border in points
     border_style: str = BorderStyles.SOLID
 
@@ -59,7 +59,7 @@ class BaseStreamAppearance(DecodedStreamObject):
         self._layout = layout or BaseStreamConfig()
         self[NameObject("/Type")] = NameObject("/XObject")
         self[NameObject("/Subtype")] = NameObject("/Form")
-        self[NameObject("/BBox")] = RectangleObject(self._layout.rectangle)
+        self[NameObject("/BBox")] = self._layout.rectangle
 
 
 class TextAlignment(IntEnum):
@@ -196,8 +196,6 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         """
         rectangle = self._layout.rectangle
-        if isinstance(rectangle, tuple):
-            rectangle = RectangleObject(rectangle)
         leading_factor = (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / 1000.0
 
         # Set margins based on border width and style, but never less than 1 point

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -16,7 +16,7 @@ from . import RESOURCE_ROOT
 
 
 def test_comb():
-    layout=BaseStreamConfig(rectangle=(0.0, 0.0, 197.285, 18.455))
+    layout=BaseStreamConfig(rectangle=RectangleObject((0.0, 0.0, 197.285, 18.455)))
     font_size = 10.0
     text = "01234567"
     max_length = 10
@@ -36,7 +36,7 @@ def test_comb():
         b"19.728499999999997 0.0 Td\n(7) Tj\nET\nQ\nEMC\nQ\n"
     )
 
-    layout.rectangle = (0.0, 0.0, 20.852, 20.84)
+    layout.rectangle = RectangleObject((0.0, 0.0, 20.852, 20.84))
     text = "AA"
     max_length = 1
     appearance_stream = TextStreamAppearance(
@@ -48,7 +48,7 @@ def test_comb():
 
 
 def test_scale_text():
-    layout=BaseStreamConfig(rectangle=(0, 0, 9.1, 55.4))
+    layout=BaseStreamConfig(rectangle=RectangleObject((0, 0, 9.1, 55.4)))
     font_size = 10.1
     text = "Hello World"
     is_multiline = False
@@ -64,7 +64,7 @@ def test_scale_text():
     )
     assert b"4.0 Tf" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 160, 360)
+    layout.rectangle = RectangleObject((0, 0, 160, 360))
     font_size = 0.0
     text = """Welcome to pypdf!
 أهلاً بكم في pypdf!
@@ -82,13 +82,13 @@ See pdfly for a CLI application that uses pypdf to interact with PDFs.
     assert b"pypdf is a free and open" in appearance_stream.get_data()
     assert b"/Span << /ActualText" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 160, 160)
+    layout.rectangle = RectangleObject((0, 0, 160, 160))
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline
     )
     assert b"9.6 Tf" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 160, 12)
+    layout.rectangle = RectangleObject((0, 0, 160, 12))
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline
     )
@@ -106,7 +106,7 @@ Option D
     )
     assert b"7.3 Tf" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 10, 100)
+    layout.rectangle = RectangleObject((0, 0, 10, 100))
     text = "OneWord"
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -16,7 +16,7 @@ from . import RESOURCE_ROOT
 
 
 def test_comb():
-    layout=BaseStreamConfig(rectangle=(0.0, 0.0, 197.285, 18.455))
+    layout=BaseStreamConfig(rectangle=RectangleObject((0.0, 0.0, 197.285, 18.455)))
     font_size = 10.0
     text = "01234567"
     max_length = 10
@@ -36,7 +36,7 @@ def test_comb():
         b"19.728499999999997 0.0 Td\n(7) Tj\nET\nQ\nEMC\nQ\n"
     )
 
-    layout.rectangle = (0.0, 0.0, 20.852, 20.84)
+    layout.rectangle = RectangleObject((0.0, 0.0, 20.852, 20.84))
     text = "AA"
     max_length = 1
     appearance_stream = TextStreamAppearance(
@@ -48,7 +48,7 @@ def test_comb():
 
 
 def test_scale_text():
-    layout=BaseStreamConfig(rectangle=(0, 0, 9.1, 55.4))
+    layout=BaseStreamConfig(rectangle=RectangleObject((0, 0, 9.1, 55.4)))
     font_size = 10.1
     text = "Hello World"
     is_multiline = False
@@ -64,7 +64,7 @@ def test_scale_text():
     )
     assert b"4.0 Tf" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 160, 360)
+    layout.rectangle = RectangleObject((0, 0, 160, 360))
     font_size = 0.0
     text = """Welcome to pypdf
 pypdf is a free and open source pure-python PDF library capable of splitting, merging, cropping, and
@@ -80,13 +80,13 @@ See pdfly for a CLI application that uses pypdf to interact with PDFs.
     assert b"12 Tf" in appearance_stream.get_data()
     assert b"pypdf is a free and open" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 160, 160)
+    layout.rectangle = RectangleObject((0, 0, 160, 160))
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline
     )
     assert b"9.8 Tf" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 160, 12)
+    layout.rectangle = RectangleObject((0, 0, 160, 12))
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline
     )
@@ -104,7 +104,7 @@ Option D
     )
     assert b"7.3 Tf" in appearance_stream.get_data()
 
-    layout.rectangle = (0, 0, 10, 100)
+    layout.rectangle = RectangleObject((0, 0, 10, 100))
     text = "OneWord"
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_multiline=is_multiline

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -10,7 +10,7 @@ import pytest
 from pypdf import PdfWriter
 from pypdf._font import Font
 from pypdf.generic import RectangleObject
-from pypdf.generic._appearance_stream import BaseStreamConfig, TextStreamAppearance
+from pypdf.generic._appearance_stream import BaseStreamAppearance, BaseStreamConfig, TextStreamAppearance
 
 from . import RESOURCE_ROOT
 
@@ -216,3 +216,23 @@ assert HAS_RTL_SUPPORT is False
     )
     assert result.returncode == 0
     assert result.stdout == b""
+
+
+@pytest.mark.parametrize(
+    ("rotation", "outcome"),
+    [
+        (0, None),
+        (90, [0.0, 1, -1, 0.0, 20, 0.0]),
+        (180, [-1, 0.0, 0.0, -1, 400, 20]),
+        (270, [0.0, -1, 1, 0.0, 0.0, 400]),
+        (360, None),
+    ]
+)
+def test_base_stream_config_rotation(rotation, outcome):
+    layout = BaseStreamConfig(
+        rectangle=RectangleObject([0, 0, 400, 20]),
+        border_width=1,
+        rotation=rotation,
+    )
+    appearance = BaseStreamAppearance(layout=layout)
+    assert appearance.get("/Matrix", None) == outcome

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -13,13 +13,7 @@ from pypdf import PdfReader, PdfWriter
 from pypdf._cmap import _parse_to_unicode
 from pypdf._font import Font, FontDescriptor
 from pypdf.errors import LimitReachedError, PdfReadError
-from pypdf.generic import (
-    ArrayObject,
-    DictionaryObject,
-    EncodedStreamObject,
-    NameObject,
-    NumberObject,
-)
+from pypdf.generic import ArrayObject, DictionaryObject, EncodedStreamObject, NameObject, NumberObject, RectangleObject
 from pypdf.generic._appearance_stream import BaseStreamConfig, TextStreamAppearance
 
 from . import RESOURCE_ROOT
@@ -321,7 +315,7 @@ def test_simple_font_reverse_cmap_from_character_map():
     writer.pages[0]["/Resources"][NameObject("/Font")] = DictionaryObject()
     font._add_to_writer(writer, writer.pages[0]["/Resources"]["/Font"], NameObject(f"/{font.name}"))
     appearance_stream = TextStreamAppearance(
-        layout=BaseStreamConfig(rectangle=(0.0, 0.0, 512, 692)),
+        layout=BaseStreamConfig(rectangle=RectangleObject((0.0, 0.0, 512, 692))),
         text=extracted_text,
         font=font,
         font_resource=writer.pages[0]["/Resources"]["/Font"][f"/{font.name}"],


### PR DESCRIPTION
This PR adds a "rotation" attribute to class BaseStreamConfig. When instantiating a class BaseStreamAppearance, we apply the rotation to the appearance stream in the form of a Transformation, both rotating and translating the BaseStreamAppearance object so that its origin remains (0, 0).

When we parse an annotation to generate an appearance stream, we now read its ["/MK"]["/R"] field to determine rotation, and pass the rotation along with the other layout options. In some cases, we _also_ need to take into account page rotation (in particular, this happens in issue https://github.com/py-pdf/pypdf/issues/2737).

Finally this PR adds one patch to change the typing of BaseStreamConfig so that rectangle is always a RectangleObject. This to prevent mypy warnings or coverage problems.

Fixes: https://github.com/py-pdf/pypdf/issues/2737

I made extensive use of Google Gemini preparing this PR. Especially the Transformation code I could not have produced myself. The resulting logic, though, is mainly my own.