### PR TITLE
ENH: Allow keeping original PDF header in non-incremental clone mode

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -169,6 +169,9 @@ class PdfWriter(PdfDocCommon):
             If false, pypdf will try to be forgiving and do something reasonable, but it will log
             a warning message. It is a best-effort approach.
 
+        keep_initial_header: If true, the PDF header of the cloned document is kept
+            when using ``clone_from`` in non-incremental mode.
+
     """
 
     def __init__(
@@ -179,6 +182,7 @@ class PdfWriter(PdfDocCommon):
         full: bool = False,
         strict: bool = False,
         *,
+        keep_initial_header: bool = False,
         incremental_clone_object_count_limit: Optional[int] = 500_000,
         incremental_clone_object_id_limit: Optional[int] = 1_000_000,
     ) -> None:
@@ -304,6 +308,8 @@ class PdfWriter(PdfDocCommon):
                 clone_from = PdfReader(clone_from)
             self.clone_document_from_reader(clone_from)
             self._cloned = True
+            if keep_initial_header and not self.incremental:
+                self._header = clone_from.pdf_header.encode()
         else:
             self._pages = self._add_object(pages)
             self._root_object = DictionaryObject(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -994,6 +994,15 @@ def test_pdf_header():
     assert writer.pdf_header == "%PDF-1.6"
 
 
+def test_pdf_header_keep_initial_header():
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+    writer = PdfWriter(clone_from=reader)
+    assert writer.pdf_header == "%PDF-1.3"
+
+    writer = PdfWriter(clone_from=reader, keep_initial_header=True)
+    assert writer.pdf_header == reader.pdf_header
+
+
 def test_write_dict_stream_object(pdf_file_path):
     stream = (
         b"BT "

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1000,7 +1000,7 @@ def test_pdf_header_keep_initial_header():
     assert writer.pdf_header == "%PDF-1.3"
 
     writer = PdfWriter(clone_from=reader, keep_initial_header=True)
-    assert writer.pdf_header == reader.pdf_header
+    assert writer.pdf_header == "%PDF-1.5"
 
 
 def test_write_dict_stream_object(pdf_file_path):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -994,7 +994,7 @@ def test_pdf_header():
     assert writer.pdf_header == "%PDF-1.6"
 
 
-def test_pdf_header_keep_initial_header():
+def test_pdf_header__keep_initial_header():
     reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
     writer = PdfWriter(clone_from=reader)
     assert writer.pdf_header == "%PDF-1.3"


### PR DESCRIPTION
Fixes #3386

Adds a keep_initial_header parameter to PdfWriter.__init__ so that clone_from can preserve the source document's PDF header in non-incremental mode. When the parameter is not set, the existing PDF 1.3 default is retained for backwards compatibility.

This PR was prepared with AI assistance and reviewed by the contributor.