### PR TITLE
ROB: Ignore cyclic /SMask references when extracting images

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -440,21 +440,10 @@ def _get_mode_and_invert_color(
     return mode, invert_color
 
 
-def _xobject_identity(x_object: Any) -> Any:
-    """
-    Return a stable key identifying an XObject, for cycle detection.
-
-    Indirect objects are keyed by their reference so that two resolutions of the
-    same object compare equal; direct objects fall back to their identity.
-    """
-    reference = getattr(x_object, "indirect_reference", None)
-    return reference if reference is not None else id(x_object)
-
-
 def _xobj_to_image(
         x_object: dict[str, Any],
         pillow_parameters: Union[dict[str, Any], None] = None,
-        _visited: Optional[set[Any]] = None,
+        visited: Optional[set[int]] = None,
 ) -> tuple[Optional[str], bytes, Any]:
     """
     Users need to have the pillow package installed.
@@ -466,15 +455,16 @@ def _xobj_to_image(
         x_object:
         pillow_parameters: parameters provided to Pillow Image.save() method,
             cf. <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>
-        _visited: XObjects already being converted higher up the /SMask chain.
-            Internal, used to stop a cyclic soft mask from recursing forever.
+        visited: Set of id() values of XObjects already being converted higher
+            up the /SMask chain, used to detect cyclic soft masks.
 
     Returns:
         Tuple[file extension, bytes, PIL.Image.Image]
 
     """
-    visited = set() if _visited is None else _visited
-    visited.add(_xobject_identity(x_object))
+    if visited is None:
+        visited = set()
+    visited.add(id(x_object))
 
     def _apply_alpha(
         img: Image.Image,
@@ -485,7 +475,7 @@ def _xobj_to_image(
     ) -> tuple[Image.Image, str, str]:
         if ImageAttributes.S_MASK in x_object:  # add alpha channel
             s_mask = x_object[ImageAttributes.S_MASK]
-            if _xobject_identity(s_mask) in visited:
+            if id(s_mask) in visited:
                 # A soft mask that refers back to an image already being
                 # converted would recurse until the interpreter runs out of
                 # stack. Such a chain cannot describe a real alpha channel, so
@@ -496,7 +486,7 @@ def _xobj_to_image(
                     obj_as_text=obj_as_text,
                 )
                 return img, extension, image_format
-            alpha = _xobj_to_image(s_mask, _visited=visited)[2]
+            alpha = _xobj_to_image(s_mask, visited=visited)[2]
             if img.size != alpha.size:
                 logger_warning(
                     "image and mask size not matching: %(obj_as_text)s",

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -440,9 +440,21 @@ def _get_mode_and_invert_color(
     return mode, invert_color
 
 
+def _xobject_identity(x_object: Any) -> Any:
+    """
+    Return a stable key identifying an XObject, for cycle detection.
+
+    Indirect objects are keyed by their reference so that two resolutions of the
+    same object compare equal; direct objects fall back to their identity.
+    """
+    reference = getattr(x_object, "indirect_reference", None)
+    return reference if reference is not None else id(x_object)
+
+
 def _xobj_to_image(
         x_object: dict[str, Any],
-        pillow_parameters: Union[dict[str, Any], None] = None
+        pillow_parameters: Union[dict[str, Any], None] = None,
+        _visited: Optional[set[Any]] = None,
 ) -> tuple[Optional[str], bytes, Any]:
     """
     Users need to have the pillow package installed.
@@ -454,11 +466,16 @@ def _xobj_to_image(
         x_object:
         pillow_parameters: parameters provided to Pillow Image.save() method,
             cf. <https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.save>
+        _visited: XObjects already being converted higher up the /SMask chain.
+            Internal, used to stop a cyclic soft mask from recursing forever.
 
     Returns:
         Tuple[file extension, bytes, PIL.Image.Image]
 
     """
+    visited = set() if _visited is None else _visited
+    visited.add(_xobject_identity(x_object))
+
     def _apply_alpha(
         img: Image.Image,
         x_object: dict[str, Any],
@@ -467,7 +484,19 @@ def _xobj_to_image(
         extension: str,
     ) -> tuple[Image.Image, str, str]:
         if ImageAttributes.S_MASK in x_object:  # add alpha channel
-            alpha = _xobj_to_image(x_object[ImageAttributes.S_MASK])[2]
+            s_mask = x_object[ImageAttributes.S_MASK]
+            if _xobject_identity(s_mask) in visited:
+                # A soft mask that refers back to an image already being
+                # converted would recurse until the interpreter runs out of
+                # stack. Such a chain cannot describe a real alpha channel, so
+                # drop the mask and keep the image we have.
+                logger_warning(
+                    "Ignoring cyclic /SMask reference in %(obj_as_text)s",
+                    source=__name__,
+                    obj_as_text=obj_as_text,
+                )
+                return img, extension, image_format
+            alpha = _xobj_to_image(s_mask, _visited=visited)[2]
             if img.size != alpha.size:
                 logger_warning(
                     "image and mask size not matching: %(obj_as_text)s",

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -417,3 +417,55 @@ def test_image_from_bytes__limit(mode: str, expected: str) -> None:
             match=rf"^Requested image buffer size {expected} exceeds limit 75000000\.$"
     ):
         _ = _image_from_bytes(mode=mode, size=(100_000, 80_000), data=b"")
+
+
+def _minimal_image_xobject() -> StreamObject:
+    """Build the smallest image XObject _xobj_to_image will decode."""
+    stream = StreamObject()
+    stream[NameObject("/Subtype")] = NameObject("/Image")
+    stream[NameObject("/Width")] = NumberObject(1)
+    stream[NameObject("/Height")] = NumberObject(1)
+    stream[NameObject("/ColorSpace")] = NameObject("/DeviceGray")
+    stream[NameObject("/BitsPerComponent")] = NumberObject(8)
+    stream.set_data(b"\x00")
+    return stream
+
+
+def test_xobj_to_image__self_referential_smask(
+    caplog: pytest.LogCaptureFixture
+) -> None:
+    """A soft mask pointing at its own image must not recurse."""
+    image = _minimal_image_xobject()
+    image[NameObject("/SMask")] = image
+
+    extension, _, img = _xobj_to_image(image)
+
+    assert extension == ".png"
+    assert img.mode == "L"
+    assert "Ignoring cyclic /SMask reference" in caplog.text
+
+
+def test_xobj_to_image__two_node_smask_cycle(
+    caplog: pytest.LogCaptureFixture
+) -> None:
+    """A -> B -> A soft mask chains must not recurse either."""
+    first = _minimal_image_xobject()
+    second = _minimal_image_xobject()
+    first[NameObject("/SMask")] = second
+    second[NameObject("/SMask")] = first
+
+    extension, _, img = _xobj_to_image(first)
+
+    assert extension == ".png"
+    assert "Ignoring cyclic /SMask reference" in caplog.text
+
+
+def test_xobj_to_image__acyclic_smask_still_applied() -> None:
+    """The guard must not stop a legitimate soft mask being applied."""
+    image = _minimal_image_xobject()
+    image[NameObject("/SMask")] = _minimal_image_xobject()
+
+    extension, _, img = _xobj_to_image(image)
+
+    assert extension == ".png"
+    assert img.mode == "LA"

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -457,6 +457,9 @@ def test_xobj_to_image__two_node_smask_cycle(
     extension, _, img = _xobj_to_image(first)
 
     assert extension == ".png"
+    # The outer image still gets its mask: the cycle is only broken one level
+    # deeper, when the mask's own /SMask points back at an image being converted.
+    assert img.mode == "LA"
     assert "Ignoring cyclic /SMask reference" in caplog.text
 
 


### PR DESCRIPTION
Fixes the issue reported in GHSA-jg66-3v3w-cvmh. Opening it as a public PR per @stefan6419846's suggestion on that advisory, since the `RecursionError` is caught by the exception policy and so it is a robustness fix rather than a security one.

## Problem

`_xobj_to_image` recurses into `/SMask` without tracking which objects it has already visited:

```python
if ImageAttributes.S_MASK in x_object:  # add alpha channel
    alpha = _xobj_to_image(x_object[ImageAttributes.S_MASK])[2]
```

An image whose `/SMask` points back at itself, or any cycle in that chain, recurses until Python raises `RecursionError`. Reachable from the ordinary image extraction path via `page.images`.

## Fix

Thread a set of already-visited XObjects through the recursion and skip the mask when one repeats.

Indirect objects are keyed by their reference, so two resolutions of the same object compare equal; direct objects fall back to `id()`. A cyclic chain cannot describe a real alpha channel, so the mask is dropped with a `logger_warning` and the base image is still returned, rather than aborting extraction of an otherwise readable image.

## Tests

Three cases added to `tests/generic/test_image_xobject.py`, built from a minimal in-memory image XObject so they need no network or fixture file:

- self-referential `/SMask`
- a two-node `A -> B -> A` cycle
- an acyclic mask, asserting the guard does not stop a legitimate soft mask being applied (result mode is still `LA`)

The first two fail with `RecursionError` on `main` and pass with the fix; the third passes either way.

Offline suite before and after the change is identical here (81 passed, 14 pre-existing `FileNotFoundError` failures from fixture files missing in my checkout, unrelated to this change).