### PR TITLE
BUG: Expand low-bit samples for images without a filter

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -170,6 +170,33 @@ def bits2byte(
     return bytes(byte_buffer)
 
 
+def _expand_low_bit_samples(
+    mode: mode_str_type,
+    size: tuple[int, int],
+    data: bytes,
+    color_space: Union[str, ArrayObject],
+) -> tuple[mode_str_type, bytes]:
+    """
+    Expand 2- or 4-bit-per-component samples to one byte per component.
+
+    Pillow has no mode for sub-byte samples, so the packed data has to be
+    unpacked before an image can be built from it. For a single-component
+    color space the samples are palette/grayscale indices ("P"). For a
+    multi-component space such as /DeviceRGB they are interleaved color
+    components, so they are also scaled to the full 0-255 range and become
+    an "RGB" image.
+
+    Returns the resulting mode and data, unchanged when the mode is not a
+    low-bit one.
+    """
+    if mode not in ("2bits", "4bits"):
+        return mode, data
+    bits = int(mode[0])
+    if color_space == "/DeviceRGB":
+        return "RGB", bits2byte(data, size, bits, colors=3, scale=True)
+    return "P", bits2byte(data, size, bits)
+
+
 def _image_from_bytes(
     mode: str, size: tuple[int, int], data: bytes
 ) -> Image.Image:
@@ -234,19 +261,7 @@ def _handle_flate(
     lookup: Any
     if isinstance(color_space, ArrayObject) and color_space[0] == "/Indexed":
         color_space, base, hival, lookup = __handle_flate__indexed(color_space)
-    if mode in ("2bits", "4bits"):
-        bits = int(mode[0])
-        # For a single-component color space these low-bit samples are a
-        # palette/grayscale image ("P"). For a multi-component space such as
-        # /DeviceRGB the samples are interleaved color components, so once
-        # expanded (and scaled) to bytes they form a full "RGB" image; forcing
-        # "P" here produced an unrecognized "4bits"/"2bits" Pillow mode (#3924).
-        if color_space == "/DeviceRGB":
-            data = bits2byte(data, size, bits, colors=3, scale=True)
-            mode = "RGB"
-        else:
-            data = bits2byte(data, size, bits)
-            mode = "P"
+    mode, data = _expand_low_bit_samples(mode, size, data, color_space)
     img = _image_from_bytes(mode, size, data)
     if color_space == "/Indexed":
         if isinstance(lookup, (EncodedStreamObject, DecodedStreamObject)):
@@ -602,7 +617,10 @@ def _xobj_to_image(
         try:
             img = Image.open(BytesIO(data), formats=("TIFF", "PNG"))
         except UnidentifiedImageError:
-            img = _image_from_bytes(mode, size, data)
+            fallback_mode, fallback_data = _expand_low_bit_samples(
+                mode, size, data, color_space
+            )
+            img = _image_from_bytes(fallback_mode, size, fallback_data)
     elif lfilters == FT.DCT_DECODE:
         img, image_format, extension = Image.open(BytesIO(data)), "JPEG", ".jpg"
         # invert_color kept unchanged
@@ -634,6 +652,9 @@ def _xobj_to_image(
     elif mode == "":
         raise PdfReadError(f"ColorSpace field not found in {x_object}")
     else:
+        # Images without a filter (for example inline images) reach Pillow
+        # directly, so low-bit samples have to be expanded here as well.
+        mode, data = _expand_low_bit_samples(mode, size, data, color_space)
         img, image_format, extension, invert_color = (
             _image_from_bytes(mode, size, data),
             "PNG",

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -18,7 +18,14 @@ from pypdf import PageObject, PdfReader, PdfWriter
 from pypdf._page import ImageFile
 from pypdf.errors import LimitReachedError
 from pypdf.filters import JBIG2Decode
-from pypdf.generic import ContentStream, NameObject, NullObject
+from pypdf.generic import (
+    ContentStream,
+    DecodedStreamObject,
+    DictionaryObject,
+    NameObject,
+    NullObject,
+    NumberObject,
+)
 from pypdf.generic._image_xobject import _handle_flate
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
@@ -597,6 +604,37 @@ def test_low_bit_devicergb_image_mode():
     # A single-component space must still map to a palette image ("P").
     gray = _handle_flate((2, 2), bytes([0xF0, 0x0F]), "4bits", "/DeviceGray", 1, "")[0]
     assert gray.mode == "P"
+
+
+def test_low_bit_devicergb_image_without_filter():
+    """Low-bit /DeviceRGB images decode even without a filter (#3367)."""
+    # Same 2x2 4-bit DeviceRGB samples as above, but stored uncompressed:
+    # images without a filter never reach the FlateDecode handler.
+    writer = PdfWriter()
+    image = DecodedStreamObject()
+    image.set_data(bytes([0xF0, 0x00, 0xF0, 0x00, 0xFF, 0xFF]))
+    image[NameObject("/Type")] = NameObject("/XObject")
+    image[NameObject("/Subtype")] = NameObject("/Image")
+    image[NameObject("/Width")] = NumberObject(2)
+    image[NameObject("/Height")] = NumberObject(2)
+    image[NameObject("/BitsPerComponent")] = NumberObject(4)
+    image[NameObject("/ColorSpace")] = NameObject("/DeviceRGB")
+    image[NameObject("/Colors")] = NumberObject(3)
+
+    page = writer.add_blank_page(20, 20)
+    page[NameObject("/Resources")] = DictionaryObject()
+    page["/Resources"][NameObject("/XObject")] = DictionaryObject()
+    page["/Resources"]["/XObject"][NameObject("/Im0")] = writer._add_object(image)
+
+    output = BytesIO()
+    writer.write(output)
+    output.seek(0)
+
+    img = PdfReader(output).pages[0].images[0].image
+    assert img.mode == "RGB"
+    assert img.tobytes() == bytes(
+        [255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]
+    )
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
Follow-up to #3929, which only fixed the FlateDecode path.

Fixes #3367.

The 2/4-bit expansion lived inside _handle_flate, so it only ran for
FlateDecode/RunLengthDecode images. Anything else — an image with no filter
at all, or the LZW/ASCII85 fallback — passed the raw "2bits"/"4bits" mode
straight to Pillow and raised "unrecognized image mode".

Pulled the expansion out into _expand_low_bit_samples() and called it from
the three places that build an image from raw bytes. The Flate path behaves
exactly as before, bits2byte is unchanged.

Added a test that builds an uncompressed 4-bit /DeviceRGB image and checks
it decodes to RGB — it fails on main with the same ValueError you were
seeing.
