### PR TITLE
MAINT: Deduplicate CatalogAttributes and CatalogDictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -49,7 +49,6 @@ from ._utils import (
     parse_iso8824_date,
 )
 from .constants import CatalogAttributes as CA
-from .constants import CatalogDictionary as CD
 from .constants import (
     CheckboxRadioButtonAttributes,
     Core,
@@ -319,7 +318,7 @@ class PdfDocCommon(ABC):
     @property
     def viewer_preferences(self) -> Optional[ViewerPreferences]:
         """Returns the existing ViewerPreferences as an overloaded dictionary."""
-        o = self.root_object.get(CD.VIEWER_PREFERENCES, None)
+        o = self.root_object.get(CA.VIEWER_PREFERENCES, None)
         if o is None:
             return None
         o = o.get_object()
@@ -328,7 +327,7 @@ class PdfDocCommon(ABC):
             if hasattr(o, "indirect_reference") and o.indirect_reference is not None:
                 self._replace_object(o.indirect_reference, o)
             else:
-                self.root_object[NameObject(CD.VIEWER_PREFERENCES)] = o
+                self.root_object[NameObject(CA.VIEWER_PREFERENCES)] = o
         return o
 
     def get_num_pages(self) -> int:
@@ -566,8 +565,8 @@ class PdfDocCommon(ABC):
             catalog = self.root_object
             stack = []
             # get the AcroForm tree
-            if CD.ACRO_FORM in catalog:
-                tree = cast(Optional[TreeObject], catalog[CD.ACRO_FORM])
+            if CA.ACRO_FORM in catalog:
+                tree = cast(Optional[TreeObject], catalog[CA.ACRO_FORM])
             else:
                 return None
         if tree is None:
@@ -1144,7 +1143,7 @@ class PdfDocCommon(ABC):
              - Show two pages at a time, odd-numbered pages on the right
         """
         try:
-            return cast(NameObject, self.root_object[CD.PAGE_LAYOUT])
+            return cast(NameObject, self.root_object[CA.PAGE_LAYOUT])
         except KeyError:
             return None
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -68,9 +68,8 @@ from ._utils import (
     logger_warning,
 )
 from .constants import AnnotationDictionaryAttributes as AA
-from .constants import CatalogAttributes as CA
 from .constants import (
-    CatalogDictionary,
+    CatalogAttributes,
     Core,
     GoToActionArguments,
     ImageType,
@@ -584,13 +583,13 @@ class PdfWriter(PdfDocCommon):
         # https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf
         try:
             # get the AcroForm tree
-            if CatalogDictionary.ACRO_FORM not in self._root_object:
+            if CatalogAttributes.ACRO_FORM not in self._root_object:
                 self._root_object[
-                    NameObject(CatalogDictionary.ACRO_FORM)
+                    NameObject(CatalogAttributes.ACRO_FORM)
                 ] = self._add_object(DictionaryObject())
 
             need_appearances = NameObject(InteractiveFormDictEntries.NeedAppearances)
-            cast(DictionaryObject, self._root_object[CatalogDictionary.ACRO_FORM])[
+            cast(DictionaryObject, self._root_object[CatalogAttributes.ACRO_FORM])[
                 need_appearances
             ] = BooleanObject(state)
         except Exception as exc:  # pragma: no cover
@@ -604,7 +603,7 @@ class PdfWriter(PdfDocCommon):
     def create_viewer_preferences(self) -> ViewerPreferences:
         o = ViewerPreferences()
         self._root_object[
-            NameObject(CatalogDictionary.VIEWER_PREFERENCES)
+            NameObject(CatalogAttributes.VIEWER_PREFERENCES)
         ] = self._add_object(o)
         return o
 
@@ -793,8 +792,8 @@ class PdfWriter(PdfDocCommon):
         """
         # Names / JavaScript preferred to be able to add multiple scripts
         if "/Names" not in self._root_object:
-            self._root_object[NameObject(CA.NAMES)] = DictionaryObject()
-        names = cast(DictionaryObject, self._root_object[CA.NAMES])
+            self._root_object[NameObject(CatalogAttributes.NAMES)] = DictionaryObject()
+        names = cast(DictionaryObject, self._root_object[CatalogAttributes.NAMES])
         if "/JavaScript" not in names:
             names[NameObject("/JavaScript")] = DictionaryObject(
                 {NameObject("/Names"): ArrayObject()}
@@ -983,9 +982,9 @@ class PdfWriter(PdfDocCommon):
                 annotation itself.
 
         """
-        if CatalogDictionary.ACRO_FORM not in self._root_object:
+        if CatalogAttributes.ACRO_FORM not in self._root_object:
             raise PyPdfError("No /AcroForm dictionary in PDF of PdfWriter Object")
-        acro_form = cast(DictionaryObject, self._root_object[CatalogDictionary.ACRO_FORM])
+        acro_form = cast(DictionaryObject, self._root_object[CatalogAttributes.ACRO_FORM])
         if InteractiveFormDictEntries.Fields not in acro_form:
             raise PyPdfError("No /Fields dictionary in PDF of PdfWriter Object")
         if isinstance(auto_regenerate, bool):
@@ -1109,10 +1108,10 @@ class PdfWriter(PdfDocCommon):
             return lst
 
         try:
-            af = cast(DictionaryObject, self._root_object[CatalogDictionary.ACRO_FORM])
+            af = cast(DictionaryObject, self._root_object[CatalogAttributes.ACRO_FORM])
         except KeyError:
             af = DictionaryObject()
-            self._root_object[NameObject(CatalogDictionary.ACRO_FORM)] = af
+            self._root_object[NameObject(CatalogAttributes.ACRO_FORM)] = af
         try:
             fields = cast(ArrayObject, af[InteractiveFormDictEntries.Fields])
         except KeyError:
@@ -3317,15 +3316,15 @@ class PdfWriter(PdfDocCommon):
         if start != 0:
             new_page_label[NameObject("/St")] = NumberObject(start)
 
-        if NameObject(CatalogDictionary.PAGE_LABELS) not in self._root_object:
+        if NameObject(CatalogAttributes.PAGE_LABELS) not in self._root_object:
             nums = ArrayObject()
             nums_insert(NumberObject(0), default_page_label, nums)
             page_labels = TreeObject()
             page_labels[NameObject("/Nums")] = nums
-            self._root_object[NameObject(CatalogDictionary.PAGE_LABELS)] = page_labels
+            self._root_object[NameObject(CatalogAttributes.PAGE_LABELS)] = page_labels
 
         page_labels = cast(
-            TreeObject, self._root_object[NameObject(CatalogDictionary.PAGE_LABELS)]
+            TreeObject, self._root_object[NameObject(CatalogAttributes.PAGE_LABELS)]
         )
         nums = cast(ArrayObject, page_labels[NameObject("/Nums")])
 
@@ -3336,7 +3335,7 @@ class PdfWriter(PdfDocCommon):
             nums_insert(NumberObject(page_index_to + 1), default_page_label, nums)
 
         page_labels[NameObject("/Nums")] = nums
-        self._root_object[NameObject(CatalogDictionary.PAGE_LABELS)] = page_labels
+        self._root_object[NameObject(CatalogAttributes.PAGE_LABELS)] = page_labels
 
     def _repr_mimebundle_(
         self,

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -2,6 +2,9 @@
 
 import sys
 from enum import Enum, IntFlag, auto, unique
+from typing import Optional, TypeVar
+
+from ._utils import deprecate_with_replacement
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -31,8 +34,39 @@ class TrailerKeys:
 
 
 class CatalogAttributes:
-    NAMES = "/Names"
-    DESTS = "/Dests"
+    """§7.7.2 of the 1.7 and 2.0 references."""
+    TYPE = "/Type"  # name, required; must be /Catalog
+    VERSION = "/Version"  # name
+    EXTENSIONS = "/Extensions"  # dictionary, optional; ISO 32000-1
+    PAGES = "/Pages"  # dictionary, required
+    PAGE_LABELS = "/PageLabels"  # number tree, optional
+    NAMES = "/Names"  # dictionary, optional
+    DESTS = "/Dests"  # dictionary, optional
+    VIEWER_PREFERENCES = "/ViewerPreferences"  # dictionary, optional
+    PAGE_LAYOUT = "/PageLayout"  # name, optional
+    PAGE_MODE = "/PageMode"  # name, optional
+    OUTLINES = "/Outlines"  # dictionary, optional
+    THREADS = "/Threads"  # array, optional
+    OPEN_ACTION = "/OpenAction"  # array or dictionary or name, optional
+    AA = "/AA"  # dictionary, optional
+    URI = "/URI"  # dictionary, optional
+    ACRO_FORM = "/AcroForm"  # dictionary, optional
+    METADATA = "/Metadata"  # stream, optional
+    STRUCT_TREE_ROOT = "/StructTreeRoot"  # dictionary, optional
+    MARK_INFO = "/MarkInfo"  # dictionary, optional
+    LANG = "/Lang"  # text string, optional
+    SPIDER_INFO = "/SpiderInfo"  # dictionary, optional
+    OUTPUT_INTENTS = "/OutputIntents"  # array, optional
+    PIECE_INFO = "/PieceInfo"  # dictionary, optional
+    OC_PROPERTIES = "/OCProperties"  # dictionary, optional
+    PERMS = "/Perms"  # dictionary, optional
+    LEGAL = "/Legal"  # dictionary, optional
+    REQUIREMENTS = "/Requirements"  # array, optional
+    COLLECTION = "/Collection"  # dictionary, optional
+    NEEDS_RENDERING = "/NeedsRendering"  # boolean, optional
+    DSS = "/DSS"  # dictionary, optional
+    AF = "/AF"  # array of dictionaries, optional
+    D_PART_ROOT = "/DPartRoot"  # dictionary, optional
 
 
 class EncryptionDictAttributes:
@@ -607,41 +641,53 @@ class GraphicsStateParameters:
     TK = "/TK"
 
 
+T = TypeVar("T")
+
+class Descriptor:
+    def __get__(self, instance: Optional[T], owner: type[T]) -> None:
+        deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
+
+
 class CatalogDictionary:
     """§7.7.2 of the 1.7 and 2.0 references."""
+    def __init__(self) -> None:
+        deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
-    TYPE = "/Type"  # name, required; must be /Catalog
-    VERSION = "/Version"  # name
-    EXTENSIONS = "/Extensions"  # dictionary, optional; ISO 32000-1
-    PAGES = "/Pages"  # dictionary, required
-    PAGE_LABELS = "/PageLabels"  # number tree, optional
-    NAMES = "/Names"  # dictionary, optional
-    DESTS = "/Dests"  # dictionary, optional
-    VIEWER_PREFERENCES = "/ViewerPreferences"  # dictionary, optional
-    PAGE_LAYOUT = "/PageLayout"  # name, optional
-    PAGE_MODE = "/PageMode"  # name, optional
-    OUTLINES = "/Outlines"  # dictionary, optional
-    THREADS = "/Threads"  # array, optional
-    OPEN_ACTION = "/OpenAction"  # array or dictionary or name, optional
-    AA = "/AA"  # dictionary, optional
-    URI = "/URI"  # dictionary, optional
-    ACRO_FORM = "/AcroForm"  # dictionary, optional
-    METADATA = "/Metadata"  # stream, optional
-    STRUCT_TREE_ROOT = "/StructTreeRoot"  # dictionary, optional
-    MARK_INFO = "/MarkInfo"  # dictionary, optional
-    LANG = "/Lang"  # text string, optional
-    SPIDER_INFO = "/SpiderInfo"  # dictionary, optional
-    OUTPUT_INTENTS = "/OutputIntents"  # array, optional
-    PIECE_INFO = "/PieceInfo"  # dictionary, optional
-    OC_PROPERTIES = "/OCProperties"  # dictionary, optional
-    PERMS = "/Perms"  # dictionary, optional
-    LEGAL = "/Legal"  # dictionary, optional
-    REQUIREMENTS = "/Requirements"  # array, optional
-    COLLECTION = "/Collection"  # dictionary, optional
-    NEEDS_RENDERING = "/NeedsRendering"  # boolean, optional
-    DSS = "/DSS"  # dictionary, optional
-    AF = "/AF"  # array of dictionaries, optional
-    D_PART_ROOT = "/DPartRoot"  # dictionary, optional
+    TYPE = Descriptor()  # name, required; must be /Catalog
+    VERSION = Descriptor()  # name
+    EXTENSIONS = Descriptor()  # dictionary, optional; ISO 32000-1
+    PAGES = Descriptor()  # dictionary, required
+    PAGE_LABELS = Descriptor()  # number tree, optional
+    NAMES = Descriptor()  # dictionary, optional
+    DESTS = Descriptor()  # dictionary, optional
+    VIEWER_PREFERENCES = Descriptor()  # dictionary, optional
+    PAGE_LAYOUT = Descriptor()  # name, optional
+    PAGE_MODE = Descriptor()  # name, optional
+    OUTLINES = Descriptor()  # dictionary, optional
+    THREADS = Descriptor()  # array, optional
+    OPEN_ACTION = Descriptor()  # array or dictionary or name, optional
+    AA = Descriptor()  # dictionary, optional
+    URI = Descriptor()  # dictionary, optional
+    ACRO_FORM = Descriptor()  # dictionary, optional
+    METADATA = Descriptor()  # stream, optional
+    STRUCT_TREE_ROOT = Descriptor()  # dictionary, optional
+    MARK_INFO = Descriptor()  # dictionary, optional
+    LANG = Descriptor()  # text string, optional
+    SPIDER_INFO = Descriptor()  # dictionary, optional
+    OUTPUT_INTENTS = Descriptor()  # array, optional
+    PIECE_INFO = Descriptor()  # dictionary, optional
+    OC_PROPERTIES = Descriptor()  # dictionary, optional
+    PERMS = Descriptor()  # dictionary, optional
+    LEGAL = Descriptor()  # dictionary, optional
+    REQUIREMENTS = Descriptor()  # array, optional
+    COLLECTION = Descriptor()  # dictionary, optional
+    NEEDS_RENDERING = Descriptor()  # boolean, optional
+    DSS = Descriptor()  # dictionary, optional
+    AF = Descriptor()  # array of dictionaries, optional
+    D_PART_ROOT = Descriptor()  # dictionary, optional
+
+def __create_old_class_instance() -> None:
+    deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
 
 class OutlineFontFlag(IntFlag):

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -2,6 +2,7 @@
 
 import sys
 from enum import Enum, IntFlag, auto, unique
+from typing import Any
 
 from ._utils import deprecate_with_replacement
 
@@ -641,7 +642,7 @@ class GraphicsStateParameters:
 
 
 class _CatalogDictionaryMeta(type):
-    def __getattribute__(cls, name: str) -> str:
+    def __getattribute__(cls, name: Any) -> str:
         value = super().__getattribute__(name)
 
         if not name.startswith("__"):

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -651,7 +651,7 @@ class _CatalogDictionaryMeta(type):
 
 
 class CatalogDictionary(CatalogAttributes, metaclass=_CatalogDictionaryMeta):
-    def __init__():
+    def __init__() -> None:
         deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -647,8 +647,6 @@ class _CatalogDictionaryMeta(type):
 
         if not name.startswith("__"):
             deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
-        else:
-            pass  # For coverage
         return value
 
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -2,7 +2,6 @@
 
 import sys
 from enum import Enum, IntFlag, auto, unique
-from typing import Optional, TypeVar
 
 from ._utils import deprecate_with_replacement
 
@@ -641,50 +640,18 @@ class GraphicsStateParameters:
     TK = "/TK"
 
 
+class _CatalogDictionaryMeta(type):
+    def __getattribute__(cls, name):
+        value = super().__getattribute__(name)
 
-class CatalogDictionary:
-    """§7.7.2 of the 1.7 and 2.0 references."""
-    def __init__(self) -> None:
-        deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
-
-    T = TypeVar("T")
-
-    class Descriptor:
-        def __get__(self, instance: Optional[T], owner: type[T]) -> None:
+        if not name.startswith("__"):
             deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
+        return value
 
-    TYPE = Descriptor()  # name, required; must be /Catalog
-    VERSION = Descriptor()  # name
-    EXTENSIONS = Descriptor()  # dictionary, optional; ISO 32000-1
-    PAGES = Descriptor()  # dictionary, required
-    PAGE_LABELS = Descriptor()  # number tree, optional
-    NAMES = Descriptor()  # dictionary, optional
-    DESTS = Descriptor()  # dictionary, optional
-    VIEWER_PREFERENCES = Descriptor()  # dictionary, optional
-    PAGE_LAYOUT = Descriptor()  # name, optional
-    PAGE_MODE = Descriptor()  # name, optional
-    OUTLINES = Descriptor()  # dictionary, optional
-    THREADS = Descriptor()  # array, optional
-    OPEN_ACTION = Descriptor()  # array or dictionary or name, optional
-    AA = Descriptor()  # dictionary, optional
-    URI = Descriptor()  # dictionary, optional
-    ACRO_FORM = Descriptor()  # dictionary, optional
-    METADATA = Descriptor()  # stream, optional
-    STRUCT_TREE_ROOT = Descriptor()  # dictionary, optional
-    MARK_INFO = Descriptor()  # dictionary, optional
-    LANG = Descriptor()  # text string, optional
-    SPIDER_INFO = Descriptor()  # dictionary, optional
-    OUTPUT_INTENTS = Descriptor()  # array, optional
-    PIECE_INFO = Descriptor()  # dictionary, optional
-    OC_PROPERTIES = Descriptor()  # dictionary, optional
-    PERMS = Descriptor()  # dictionary, optional
-    LEGAL = Descriptor()  # dictionary, optional
-    REQUIREMENTS = Descriptor()  # array, optional
-    COLLECTION = Descriptor()  # dictionary, optional
-    NEEDS_RENDERING = Descriptor()  # boolean, optional
-    DSS = Descriptor()  # dictionary, optional
-    AF = Descriptor()  # array of dictionaries, optional
-    D_PART_ROOT = Descriptor()  # dictionary, optional
+
+class CatalogDictionary(CatalogAttributes, metaclass=_CatalogDictionaryMeta):
+    pass
+
 
 def __create_old_class_instance() -> None:
     deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -641,7 +641,7 @@ class GraphicsStateParameters:
 
 
 class _CatalogDictionaryMeta(type):
-    def __getattribute__(cls, name):
+    def __getattribute__(cls, name: str) -> str:
         value = super().__getattribute__(name)
 
         if not name.startswith("__"):

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -655,10 +655,6 @@ class CatalogDictionary(CatalogAttributes, metaclass=_CatalogDictionaryMeta):
         deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
 
-def __create_old_class_instance() -> None:
-    deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
-
-
 class OutlineFontFlag(IntFlag):
     """A class used as an enumerable flag for formatting an outline font."""
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -650,7 +650,8 @@ class _CatalogDictionaryMeta(type):
 
 
 class CatalogDictionary(CatalogAttributes, metaclass=_CatalogDictionaryMeta):
-    pass
+    def __init__():
+        deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
 
 def __create_old_class_instance() -> None:

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -2,7 +2,6 @@
 
 import sys
 from enum import Enum, IntFlag, auto, unique
-from typing import Any
 
 from ._utils import deprecate_with_replacement
 
@@ -642,7 +641,7 @@ class GraphicsStateParameters:
 
 
 class _CatalogDictionaryMeta(type):
-    def __getattribute__(cls, name: Any) -> str:
+    def __getattribute__(cls, name: str) -> str:
         value = super().__getattribute__(name)
 
         if not name.startswith("__"):
@@ -651,7 +650,7 @@ class _CatalogDictionaryMeta(type):
 
 
 class CatalogDictionary(CatalogAttributes, metaclass=_CatalogDictionaryMeta):
-    def __init__() -> None:
+    def __init__(self) -> None:
         deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
 

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -2,6 +2,7 @@
 
 import sys
 from enum import Enum, IntFlag, auto, unique
+from typing import Any
 
 from ._utils import deprecate_with_replacement
 
@@ -641,7 +642,7 @@ class GraphicsStateParameters:
 
 
 class _CatalogDictionaryMeta(type):
-    def __getattribute__(cls, name: str) -> str:
+    def __getattribute__(cls, name: str) -> Any:
         value = super().__getattribute__(name)
 
         if not name.startswith("__"):

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -641,17 +641,17 @@ class GraphicsStateParameters:
     TK = "/TK"
 
 
-T = TypeVar("T")
-
-class Descriptor:
-    def __get__(self, instance: Optional[T], owner: type[T]) -> None:
-        deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
-
 
 class CatalogDictionary:
     """§7.7.2 of the 1.7 and 2.0 references."""
     def __init__(self) -> None:
         deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
+
+    T = TypeVar("T")
+
+    class Descriptor:
+        def __get__(self, instance: Optional[T], owner: type[T]) -> None:
+            deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
 
     TYPE = Descriptor()  # name, required; must be /Catalog
     VERSION = Descriptor()  # name

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -647,6 +647,8 @@ class _CatalogDictionaryMeta(type):
 
         if not name.startswith("__"):
             deprecate_with_replacement("CatalogDictionary", "CatalogAttributes", "7.0.0")
+        else:
+            pass  # For coverage
         return value
 
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -600,7 +600,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         writer: PdfWriter,
         page: PageObject,
         flatten: bool,
-        acro_form: DictionaryObject,  # _root_object[CatalogDictionary.ACRO_FORM])
+        acro_form: DictionaryObject,  # _root_object[CatalogAttributes.ACRO_FORM])
         field: DictionaryObject,
         annotation: DictionaryObject,
         user_font_name: str = "",

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -158,4 +158,4 @@ def test_catalog_dictionary():
         AttributeError,
         match="type object 'CatalogDictionary' has no attribute '__Type__'"
     ):
-        assert CatalogDictionary.__Type__ != "/__Type__"
+        assert CatalogDictionary.INVALID != "/INVALID"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -144,15 +144,10 @@ def test_catalog_dictionary():
     ):
         assert CatalogDictionary.TYPE == "/Type"
 
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        warnings.simplefilter("always")
+    with pytest.warns(
+        DeprecationWarning,
+    ):
         assert CatalogDictionary.__name__ == "CatalogDictionary"
-
-    assert not [
-        warning
-        for warning in caught_warnings
-        if issubclass(warning.category, DeprecationWarning)
-    ]
 
     with pytest.raises(
         AttributeError,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -132,11 +132,11 @@ def test_catalog_dictionary():
             r"Use CatalogAttributes instead\.$"
         ),
     ):
-        CatalogDictionary()
+        CatalogDictionary.TYPE == '/Type'
 
     with pytest.warns(
         DeprecationWarning,
         match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
               r"Use CatalogAttributes instead\.$",
     ):
-        CatalogDictionary.TYPE
+        CatalogDictionary.TYPE == '/Type'

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,6 @@
 """Test the pypdf.constants module."""
 import re
-import warnings
+from typing import Callable
 
 import pytest
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,5 +1,6 @@
 """Test the pypdf.constants module."""
 import re
+import warnings
 from typing import Callable
 
 import pytest
@@ -142,6 +143,16 @@ def test_catalog_dictionary():
         )
     ):
         assert CatalogDictionary.TYPE == "/Type"
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        assert CatalogDictionary.__name__ == "CatalogDictionary"
+
+    assert not [
+        warning
+        for warning in caught_warnings
+        if issubclass(warning.category, DeprecationWarning)
+    ]
 
     with pytest.raises(
         AttributeError,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -156,6 +156,6 @@ def test_catalog_dictionary():
 
     with pytest.raises(
         AttributeError,
-        match="type object 'CatalogDictionary' has no attribute '__Type__'"
+        match="type object 'CatalogDictionary' has no attribute 'INVALID'"
     ):
         assert CatalogDictionary.INVALID != "/INVALID"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -138,7 +138,7 @@ def test_catalog_dictionary():
         DeprecationWarning,
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-            r"Use CatalogAttributes instead\.$",
+            r"Use CatalogAttributes instead\.$"
         ),
     ):
         assert CatalogDictionary.TYPE == "/Type"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,7 +4,12 @@ from typing import Callable
 
 import pytest
 
-from pypdf.constants import PDF_KEYS, GraphicsStateParameters, UserAccessPermissions
+from pypdf.constants import (
+    PDF_KEYS,
+    CatalogDictionary,
+    GraphicsStateParameters,
+    UserAccessPermissions,
+)
 
 
 def test_slash_prefix():
@@ -19,6 +24,8 @@ def test_slash_prefix():
     """
     pattern = re.compile(r"^/[A-Z]+[a-zA-Z0-9]*$")
     for cls in PDF_KEYS:
+        if cls == CatalogDictionary:  # Deprecated
+            continue
         for attr in dir(cls):
             # Skip magic methods
             if attr.startswith("__") and attr.endswith("__"):
@@ -115,3 +122,19 @@ def test_user_access_permissions__all():
     assert all_int & UserAccessPermissions.PRINT == UserAccessPermissions.PRINT
     assert all_int & UserAccessPermissions.R7 == UserAccessPermissions.R7
     assert all_int & UserAccessPermissions.R31 == UserAccessPermissions.R31
+
+
+def test_catalog_dictionary():
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
+              r"Use CatalogAttributes instead\.$",
+    ):
+        CatalogDictionary()
+
+    with pytest.warns(
+    DeprecationWarning,
+    match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
+        r"Use CatalogAttributes instead\.$",
+    ):
+        CatalogDictionary.TYPE

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -129,7 +129,7 @@ def test_catalog_dictionary():
         DeprecationWarning,
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-            r"Use CatalogAttributes instead\.$",
+            r"Use CatalogAttributes instead\.$"
         )
     ):
         assert isinstance(CatalogDictionary(), CatalogDictionary)
@@ -138,7 +138,7 @@ def test_catalog_dictionary():
         DeprecationWarning,
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-            r"Use CatalogAttributes instead\.$",
+            r"Use CatalogAttributes instead\.$"
         )
     ):
         assert CatalogDictionary.TYPE == "/Type"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -140,3 +140,9 @@ def test_catalog_dictionary():
               r"Use CatalogAttributes instead\.$",
     ):
         assert CatalogDictionary.TYPE == "/Type"
+
+    with pytest.raises(
+        AttributeError,
+        match="type object \'CatalogDictionary\' has no attribute \'__test\'"
+    ):
+        CatalogDictionary.__test

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -129,7 +129,7 @@ def test_catalog_dictionary():
         DeprecationWarning,
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-            r"Use CatalogAttributes instead\.$"
+            r"Use CatalogAttributes instead\.$",
         ),
     ):
         assert isinstance(CatalogDictionary(), CatalogDictionary)
@@ -138,7 +138,7 @@ def test_catalog_dictionary():
         DeprecationWarning,
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-            r"Use CatalogAttributes instead\.$"
+            r"Use CatalogAttributes instead\.$",
         ),
     ):
         assert CatalogDictionary.TYPE == "/Type"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,7 +1,6 @@
 """Test the pypdf.constants module."""
 import re
 import warnings
-from typing import Callable
 
 import pytest
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -130,7 +130,7 @@ def test_catalog_dictionary():
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
             r"Use CatalogAttributes instead\.$",
-        ),
+        )
     ):
         assert isinstance(CatalogDictionary(), CatalogDictionary)
 
@@ -139,7 +139,7 @@ def test_catalog_dictionary():
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
             r"Use CatalogAttributes instead\.$",
-        ),
+        )
     ):
         assert CatalogDictionary.TYPE == "/Type"
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -144,10 +144,15 @@ def test_catalog_dictionary():
     ):
         assert CatalogDictionary.TYPE == "/Type"
 
-    with pytest.warns(
-        DeprecationWarning,
-    ):
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
         assert CatalogDictionary.__name__ == "CatalogDictionary"
+
+    assert not [
+        warning
+        for warning in caught_warnings
+        if issubclass(warning.category, DeprecationWarning)
+    ]
 
     with pytest.raises(
         AttributeError,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -127,8 +127,10 @@ def test_user_access_permissions__all():
 def test_catalog_dictionary():
     with pytest.warns(
         DeprecationWarning,
-        match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-              r"Use CatalogAttributes instead\.$",
+        match=(
+            r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
+                  r"Use CatalogAttributes instead\.$"
+              ),
     ):
         CatalogDictionary()
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -136,8 +136,10 @@ def test_catalog_dictionary():
 
     with pytest.warns(
         DeprecationWarning,
-        match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-              r"Use CatalogAttributes instead\.$",
+        match=(
+            r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
+            r"Use CatalogAttributes instead\.$",
+        ),
     ):
         assert CatalogDictionary.TYPE == "/Type"
 
@@ -145,4 +147,4 @@ def test_catalog_dictionary():
         AttributeError,
         match="type object 'CatalogDictionary' has no attribute '__test'"
     ):
-        CatalogDictionary.__test
+        assert CatalogDictionary.__Type__ != "/__Type__"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -145,6 +145,6 @@ def test_catalog_dictionary():
 
     with pytest.raises(
         AttributeError,
-        match="type object 'CatalogDictionary' has no attribute '__test'"
+        match="type object 'CatalogDictionary' has no attribute '__Type__'"
     ):
         assert CatalogDictionary.__Type__ != "/__Type__"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -132,11 +132,12 @@ def test_catalog_dictionary():
             r"Use CatalogAttributes instead\.$"
         ),
     ):
-        CatalogDictionary.TYPE == '/Type'
+        cd = CatalogDictionary()
+        assert isinstance(cd, CatalogDictionary)
 
     with pytest.warns(
         DeprecationWarning,
         match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
               r"Use CatalogAttributes instead\.$",
     ):
-        CatalogDictionary.TYPE == '/Type'
+        assert CatalogDictionary.TYPE == "/Type"

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -129,14 +129,14 @@ def test_catalog_dictionary():
         DeprecationWarning,
         match=(
             r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-                  r"Use CatalogAttributes instead\.$"
-              ),
+            r"Use CatalogAttributes instead\.$"
+        ),
     ):
         CatalogDictionary()
 
     with pytest.warns(
-    DeprecationWarning,
-    match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
-        r"Use CatalogAttributes instead\.$",
+        DeprecationWarning,
+        match=r"^CatalogDictionary is deprecated and will be removed in pypdf 7\.0\.0\. "
+              r"Use CatalogAttributes instead\.$",
     ):
         CatalogDictionary.TYPE

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -132,8 +132,7 @@ def test_catalog_dictionary():
             r"Use CatalogAttributes instead\.$"
         ),
     ):
-        cd = CatalogDictionary()
-        assert isinstance(cd, CatalogDictionary)
+        assert isinstance(CatalogDictionary(), CatalogDictionary)
 
     with pytest.warns(
         DeprecationWarning,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -143,6 +143,6 @@ def test_catalog_dictionary():
 
     with pytest.raises(
         AttributeError,
-        match="type object \'CatalogDictionary\' has no attribute \'__test\'"
+        match="type object 'CatalogDictionary' has no attribute '__test'"
     ):
         CatalogDictionary.__test

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -144,15 +144,7 @@ def test_catalog_dictionary():
     ):
         assert CatalogDictionary.TYPE == "/Type"
 
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        warnings.simplefilter("always")
-        assert CatalogDictionary.__name__ == "CatalogDictionary"
-
-    assert not [
-        warning
-        for warning in caught_warnings
-        if issubclass(warning.category, DeprecationWarning)
-    ]
+    assert CatalogDictionary.__name__ == "CatalogDictionary"
 
     with pytest.raises(
         AttributeError,


### PR DESCRIPTION
Currently these classes represent the same thing.
To simplify, CatalogDictionary is deprecated with replacement CatalogAttributes.