### PR TITLE
BUG: Keep the Adobe CMYK inversion when an explicit /Decode is present

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -415,17 +415,21 @@ def _apply_decode(
     # requires reverting scale (cf p243,2§ last sentence)
     if ImageAttributes.DECODE in x_object:
         decode = x_object[ImageAttributes.DECODE]
-        if img.mode == "CMYK" and lfilters == FT.DCT_DECODE and len(decode) % 2 == 0:
+        if img.mode == "CMYK" and lfilters == FT.DCT_DECODE:
             # Adobe writes CMYK JPEGs with inverted component values, which is
-            # what the [1 0] remap below compensates for. An explicit /Decode
-            # array is expressed in terms of the true values, so it has to be
-            # combined with that inversion instead of replacing it — otherwise
-            # an identity /Decode leaves the image inverted (#2931).
-            # Substituting the inversion into the /Decode mapping is the same
-            # as swapping each [min max] pair.
+            # what the [min max] -> [1 0] remap in the branches below
+            # compensates for. An explicit /Decode array is expressed in terms
+            # of the true values, so it has to be combined with that inversion
+            # rather than replacing it - otherwise an identity /Decode leaves
+            # the image inverted (#2931).
+            #
+            # Substituting s -> 1-s into dmin + s*(dmax-dmin) gives
+            # dmax + s*(dmin-dmax), which is the same pair swapped. A malformed
+            # odd-length array is left untouched here and dropped with a
+            # warning further down.
             decode = [
                 value
-                for index in range(0, len(decode), 2)
+                for index in range(0, len(decode) - 1, 2)
                 for value in (decode[index + 1], decode[index])
             ]
     elif img.mode == "CMYK" and lfilters == FT.JPX_DECODE:

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -415,8 +415,19 @@ def _apply_decode(
     # requires reverting scale (cf p243,2§ last sentence)
     if ImageAttributes.DECODE in x_object:
         decode = x_object[ImageAttributes.DECODE]
-        # if invert_color and lfilters == FT.DCT_DECODE:
-        #     decode = list(reversed(decode))
+        if img.mode == "CMYK" and lfilters == FT.DCT_DECODE and len(decode) % 2 == 0:
+            # Adobe writes CMYK JPEGs with inverted component values, which is
+            # what the [1 0] remap below compensates for. An explicit /Decode
+            # array is expressed in terms of the true values, so it has to be
+            # combined with that inversion instead of replacing it — otherwise
+            # an identity /Decode leaves the image inverted (#2931).
+            # Substituting the inversion into the /Decode mapping is the same
+            # as swapping each [min max] pair.
+            decode = [
+                value
+                for index in range(0, len(decode), 2)
+                for value in (decode[index + 1], decode[index])
+            ]
     elif img.mode == "CMYK" and lfilters == FT.JPX_DECODE:
         decode = [1.0, 0.0] if not invert_color else [0.0, 1.0]
         decode = decode * len(img.getbands())

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -349,6 +349,23 @@ def test_cmyk_no_filter():
 
 
 @pytest.mark.enable_socket
+def test_cmyk_dct_with_identity_decode_is_not_inverted():
+    """Cf #2931"""
+    url = "https://github.com/user-attachments/files/17602693/example.pdf"
+    name = "iss2931.pdf"
+    reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
+    image = reader.pages[0].images[0].image
+
+    # Adobe CMYK JPEGs store inverted values. This one also carries an explicit
+    # identity /Decode array, which must not cancel out that inversion.
+    assert image.mode == "CMYK"
+    top_left = image.convert("RGB").getpixel((0, 0))
+    assert all(90 < channel < 150 for channel in top_left), (
+        f"expected a light grey background, got {top_left} (image inverted?)"
+    )
+
+
+@pytest.mark.enable_socket
 def test_separation_1byte_to_rgb_inverted():
     """Cf #2343"""
     url = "https://github.com/py-pdf/pypdf/files/13679585/test2_P038-038.pdf"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -359,16 +359,22 @@ def test_cmyk_dct_with_identity_decode_is_not_inverted():
     # Adobe CMYK JPEGs store inverted values. This one also carries an explicit
     # identity /Decode array, which must not cancel out that inversion.
     #
-    # The raw CMYK samples are asserted rather than an RGB conversion: they are
-    # produced by pypdf itself, so they do not move with Pillow's colour
-    # management. Without the fix each channel comes back as its 255-complement,
-    # which is what the second assertion pins.
+    # The exact samples come out of the JPEG decoder, so they are not asserted
+    # directly: they can shift by a step or two between libjpeg builds. What
+    # the fix changes is far larger than that - every channel comes back as its
+    # 255-complement when the inversion is dropped - so the assertions below
+    # pin the sample against that complement with a tolerance.
     assert image.mode == "CMYK"
-    assert image.getpixel((0, 0)) == (121, 102, 114, 42)        # light grey wall
-    assert image.getpixel((449, 629)) == (153, 137, 74, 82)     # dark suit
-    # Sanity check that these are the non-inverted samples: without the fix the
-    # same pixel decodes to roughly the 255-complement, (134, 151, 142, 214).
-    assert image.getpixel((0, 0))[3] < 128
+    for xy, expected in (
+        ((0, 0), (121, 102, 114, 42)),        # light grey wall
+        ((449, 629), (153, 137, 74, 82)),     # dark suit
+    ):
+        actual = image.getpixel(xy)
+        assert all(abs(a - e) <= 8 for a, e in zip(actual, expected)), (
+            f"pixel {xy}: got {actual}, expected close to {expected}. "
+            f"Without the fix this decodes to roughly "
+            f"{tuple(255 - value for value in expected)}."
+        )
 
 
 @pytest.mark.enable_socket

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -358,11 +358,17 @@ def test_cmyk_dct_with_identity_decode_is_not_inverted():
 
     # Adobe CMYK JPEGs store inverted values. This one also carries an explicit
     # identity /Decode array, which must not cancel out that inversion.
+    #
+    # The raw CMYK samples are asserted rather than an RGB conversion: they are
+    # produced by pypdf itself, so they do not move with Pillow's colour
+    # management. Without the fix each channel comes back as its 255-complement,
+    # which is what the second assertion pins.
     assert image.mode == "CMYK"
-    top_left = image.convert("RGB").getpixel((0, 0))
-    assert all(90 < channel < 150 for channel in top_left), (
-        f"expected a light grey background, got {top_left} (image inverted?)"
-    )
+    assert image.getpixel((0, 0)) == (121, 102, 114, 42)        # light grey wall
+    assert image.getpixel((449, 629)) == (153, 137, 74, 82)     # dark suit
+    # Sanity check that these are the non-inverted samples: without the fix the
+    # same pixel decodes to roughly the 255-complement, (134, 151, 142, 214).
+    assert image.getpixel((0, 0))[3] < 128
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
Fixes #2931.

Adobe writes CMYK JPEGs with inverted component values, and _apply_decode
compensates with a [1 0] remap. That branch is only reached when the image has
no /Decode array, so an image that carries an explicit /Decode skips the
inversion and comes out inverted.

The example PDF on the issue has /Decode [0 1 0 1 0 1 0 1] — the identity — so
nothing is remapped at all and the extracted image is inverted:

    >>> reader.pages[0].images[0].image.convert("RGB").getpixel((0, 0))
    (19, 17, 18)        # near-black; the background is light grey

/Decode is expressed in terms of the true component values, not the stored
inverted ones, so it has to be composed with the inversion rather than replace
it. Substituting s -> 1-s into dmin + s*(dmax-dmin) gives dmax + s*(dmin-dmax),
which is just the pair swapped, so the fix is to swap each [min max] pair for
CMYK + DCTDecode.

With that, the same pixel reads (112, 128, 118) and the image matches the
original.

Added a regression test using the PDF from the issue; it fails on main with the
inverted pixel value.
