### PR TITLE
BUG: Apply character spacing (Tc) per glyph in layout-mode extraction

### DIFF
--- a/pypdf/_text_extraction/_layout_mode/_text_state_params.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_params.py
@@ -151,7 +151,7 @@ class TextStateParams:
 
         return (
             (self.font_size * ((width - td_offset) / 1000.0))
-            + self.Tc
+            + len(word) * self.Tc
             + word.count(self.font.space_char) * self.Tw
         ) * (self.Tz / 100.0)
 

--- a/resources/toy.layout.txt
+++ b/resources/toy.layout.txt
@@ -1,9 +1,9 @@
 AWAY again1
-   AWAY again2
+  AWAY again2
 
 
-    Something[cited]
+   Something[cited]
 
-              Single quote operator
-              Double quote operator
-              Last Txt
+          Single quote operator
+          Double quote operator
+          Last Txt

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -23,10 +23,12 @@ from pypdf._text_extraction._layout_mode._text_state_manager import TextStateMan
 from pypdf._text_extraction._layout_mode._text_state_params import TextStateParams
 from pypdf.errors import PdfReadError
 from pypdf.generic import (
+    ArrayObject,
     ContentStream,
     DecodedStreamObject,
     DictionaryObject,
     NameObject,
+    NumberObject,
 )
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
@@ -187,6 +189,51 @@ def test_layout_mode_uncommon_operators():
     reader = PdfReader(RESOURCE_ROOT / "toy.pdf")
     expected = (RESOURCE_ROOT / "toy.layout.txt").read_text(encoding="utf-8")
     assert expected == reader.pages[0].extract_text(extraction_mode="layout")
+
+
+def test_layout_mode_character_spacing_per_glyph():
+    """Tc advances the text matrix once per glyph, not once per shown string.
+
+    Regression test for #3948. Both content streams place the same glyphs at
+    the same positions per PDF 32000-1: with Courier 12pt and Tc=36 the
+    ten-glyph run advances 10 * (600/1000 * 12) + 10 * 36 = 432pt, so ``BB``
+    starts at x = 72 + 432 in both, abutting the run. Before the fix the TJ
+    form only added Tc once (advancing the run by 9 * Tc too little), so the
+    two forms disagreed.
+    """
+
+    def build(content: bytes) -> str:
+        writer = PdfWriter()
+        page = writer.add_blank_page(width=612, height=792)
+
+        font = DictionaryObject()
+        font[NameObject("/Type")] = NameObject("/Font")
+        font[NameObject("/Subtype")] = NameObject("/Type1")
+        font[NameObject("/BaseFont")] = NameObject("/Courier")
+        font[NameObject("/FirstChar")] = NumberObject(32)
+        font[NameObject("/LastChar")] = NumberObject(90)
+        font[NameObject("/Widths")] = ArrayObject([NumberObject(600)] * 59)
+        font_resources = DictionaryObject()
+        font_resources[NameObject("/F1")] = writer._add_object(font)
+        resources = DictionaryObject()
+        resources[NameObject("/Font")] = font_resources
+        page[NameObject("/Resources")] = resources
+
+        stream = DecodedStreamObject()
+        stream.set_data(content)
+        page[NameObject("/Contents")] = writer._add_object(stream)
+
+        buffer = BytesIO()
+        writer.write(buffer)
+        buffer.seek(0)
+        return PdfReader(buffer).pages[0].extract_text(extraction_mode="layout")
+
+    tj_form = build(b"BT /F1 12 Tf 36 Tc 72 720 Td [(AAAAAAAAAA) 0 (BB)] TJ ET")
+    td_form = build(b"BT /F1 12 Tf 36 Tc 72 720 Td (AAAAAAAAAA) Tj 432 0 Td (BB) Tj ET")
+
+    # The run ends exactly where BB begins, so BB abuts it in both streams.
+    assert "AAAAAAAAAABB" in tj_form.replace(" ", "")
+    assert tj_form == td_form
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
Closes #3948.

## Problem

In layout-mode extraction, `TextStateParams.word_tx` (`pypdf/_text_extraction/_layout_mode/_text_state_params.py`) added the character-spacing amount `Tc` **once per shown string**, regardless of glyph count:

```python
return (
    (self.font_size * ((width - td_offset) / 1000.0))
    + self.Tc
    + word.count(self.font.space_char) * self.Tw
) * (self.Tz / 100.0)
```

`width` is accumulated per glyph and `Tw` is multiplied by the number of space glyphs, but `Tc` was constant. PDF 32000-1 defines character spacing as a per-glyph quantity (§9.3.2, §9.4.4): showing an N-glyph string advances the text matrix by `N * Tc`, and a TJ numeric adjustment — which shows no glyph — contributes no `Tc` at all.

Consequences when `Tc` is nonzero:

- A TJ string element of N glyphs advanced by `1 * Tc` instead of `N * Tc`, so everything after it in the array was placed `(N - 1) * Tc` too far left.
- A leading numeric adjustment in a TJ array is advanced against the empty `TextStateParams` created in `_fixed_width_page.py` (`value == ""`), and `word_tx("")` still added a spurious `+Tc`.

## Fix

```diff
-            + self.Tc
+            + len(word) * self.Tc
```

`word` has already been decoded to one character per glyph at this point (the per-glyph width loop directly above indexes `self.font.width_map` per character), so `len(word)` is the glyph count and stays consistent with the width accumulation. `len("") == 0` naturally drops the spurious term for pure numeric adjustments, matching the spec (an advance produced purely by a TJ numeric adjustment carries no character spacing). The one-glyph `space_tx` path is unchanged.

## Verification

Reproducer from the issue — two content streams that place identical glyphs at identical positions per the spec (Courier 12pt, `Tc = 36`; the 10-glyph run advances `10 * (600/1000 * 12) + 10 * 36 = 432pt`, so `BB` starts at `x = 72 + 432` in both):

```
PDF A:  BT /F1 12 Tf 36 Tc 72 720 Td [(AAAAAAAAAA) 0 (BB)] TJ ET
PDF B:  BT /F1 12 Tf 36 Tc 72 720 Td (AAAAAAAAAA) Tj 432 0 Td (BB) Tj ET
```

Before, only the Td form kept the (spurious) gap; after the fix both extract identically. A new regression test `test_layout_mode_character_spacing_per_glyph` builds both streams in memory and asserts they converge.

`resources/toy.layout.txt` (the golden for `test_layout_mode_uncommon_operators`, which exercises `Tc` via the `"` operator that sets `Tc = 120`) is regenerated: the corrected per-glyph advance changes the layout-grid scale, shifting a few lines. `ruff check` passes on both changed files; the pre-existing `ruff format` drift in those files is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
