### PR TITLE
BUG: Preserve internal Link annotations when appending/merging (#3953)

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2980,21 +2980,22 @@ class PdfWriter(PdfDocCommon):
 
     def _get_cloned_page(
         self,
-        page: Union[IndirectObject, PageObject, NullObject, None],
+        page: Union[IndirectObject, PageObject, NullObject, int, None],
         pages: dict[int, PageObject],
         reader: PdfReader,
     ) -> Optional[IndirectObject]:
         if isinstance(page, NullObject):
             return None
-        if isinstance(page, int) and not isinstance(page, bool):
+        if isinstance(page, int):
             # An explicit destination may reference the target page by its
             # (zero-based) index in the source document rather than by an
-            # indirect reference; this is what ``Link(target_page_index=...)``
+            # indirect reference; this is what `Link(target_page_index=...)`
             # produces. Resolve the index through the reader's page list so it
-            # can be remapped like a regular page reference.
+            # can be remapped like a regular page reference. A destination that
+            # points past the end of the source document is dropped.
             try:
                 page = reader.pages[page].indirect_reference
-            except (IndexError, AttributeError):
+            except IndexError:
                 return None
         if isinstance(page, DictionaryObject) and page.get("/Type", "") == "/Page":
             _i = page.indirect_reference

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2986,6 +2986,16 @@ class PdfWriter(PdfDocCommon):
     ) -> Optional[IndirectObject]:
         if isinstance(page, NullObject):
             return None
+        if isinstance(page, int) and not isinstance(page, bool):
+            # An explicit destination may reference the target page by its
+            # (zero-based) index in the source document rather than by an
+            # indirect reference; this is what ``Link(target_page_index=...)``
+            # produces. Resolve the index through the reader's page list so it
+            # can be remapped like a regular page reference.
+            try:
+                page = reader.pages[page].indirect_reference
+            except (IndexError, AttributeError):
+                return None
         if isinstance(page, DictionaryObject) and page.get("/Type", "") == "/Page":
             _i = page.indirect_reference
         elif isinstance(page, IndirectObject):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -899,6 +899,54 @@ def test_link_annotation(pdf_file_path):
         writer.write(output_stream)
 
 
+def test_append_preserves_internal_link_annotation():
+    """
+    ``append()``/``merge()`` must keep internal ``Link`` annotations whose
+    destination references the target page by index (as produced by
+    ``Link(target_page_index=...)``) and remap that index to the cloned page.
+
+    Tests https://github.com/py-pdf/pypdf/issues/3953
+    """
+    source = PdfWriter()
+    for _ in range(3):
+        source.add_blank_page(width=595, height=842)
+    source.add_annotation(
+        page_number=1,
+        annotation=Link(
+            rect=(57, 700, 500, 720),
+            target_page_index=2,
+            fit=Fit(fit_type="/Fit"),
+        ),
+    )
+    source_buffer = BytesIO()
+    source.write(source_buffer)
+    source_buffer.seek(0)
+    reader = PdfReader(source_buffer)
+
+    # Two pre-existing pages so the appended pages (and the destination page
+    # index) are shifted, exercising the remapping.
+    writer = PdfWriter()
+    writer.add_blank_page(width=100, height=100)
+    writer.add_blank_page(width=100, height=100)
+    writer.append(reader)
+
+    result_buffer = BytesIO()
+    writer.write(result_buffer)
+    result_buffer.seek(0)
+    result = PdfReader(result_buffer)
+
+    link_page = result.pages[3]
+    assert "/Annots" in link_page
+    annotation = link_page["/Annots"][0].get_object()
+    assert annotation["/Subtype"] == "/Link"
+    destination = annotation["/Dest"]
+    # The bare page index must have been resolved to an indirect page reference
+    # pointing at the correctly offset cloned page (index 4).
+    target = destination[0].get_object()
+    assert result.pages[4].indirect_reference.idnum == destination[0].idnum
+    assert target["/Type"] == "/Page"
+
+
 @pytest.mark.parametrize(
     "annotation",
     [

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -901,9 +901,9 @@ def test_link_annotation(pdf_file_path):
 
 def test_append_preserves_internal_link_annotation():
     """
-    ``append()``/``merge()`` must keep internal ``Link`` annotations whose
+    `append()`/`merge()` must keep internal `Link` annotations whose
     destination references the target page by index (as produced by
-    ``Link(target_page_index=...)``) and remap that index to the cloned page.
+    `Link(target_page_index=...)`) and remap that index to the cloned page.
 
     Tests #3953
     """
@@ -950,7 +950,7 @@ def test_append_preserves_internal_link_annotation():
 def test_get_cloned_page_out_of_range_index_is_dropped():
     """
     A destination index that points past the end of the source document
-    resolves to ``None`` instead of raising ``IndexError``.
+    resolves to `None` instead of raising `IndexError`.
 
     Tests #3953
     """

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -905,7 +905,7 @@ def test_append_preserves_internal_link_annotation():
     destination references the target page by index (as produced by
     ``Link(target_page_index=...)``) and remap that index to the cloned page.
 
-    Tests https://github.com/py-pdf/pypdf/issues/3953
+    Tests #3953
     """
     source = PdfWriter()
     for _ in range(3):
@@ -945,6 +945,26 @@ def test_append_preserves_internal_link_annotation():
     target = destination[0].get_object()
     assert result.pages[4].indirect_reference.idnum == destination[0].idnum
     assert target["/Type"] == "/Page"
+
+
+def test_get_cloned_page_out_of_range_index_is_dropped():
+    """
+    A destination index that points past the end of the source document
+    resolves to ``None`` instead of raising ``IndexError``.
+
+    Tests #3953
+    """
+    source = PdfWriter()
+    source.add_blank_page(width=100, height=100)
+    source_buffer = BytesIO()
+    source.write(source_buffer)
+    source_buffer.seek(0)
+    reader = PdfReader(source_buffer)
+
+    writer = PdfWriter()
+    writer.append(reader)
+    # The source document has a single page, so index 5 is out of range.
+    assert writer._get_cloned_page(5, {}, reader) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`PdfWriter.append()` (and `merge()`) silently dropped internal `Link` annotations whose destination references the target page **by index** — the exact form produced by pypdf's own `Link(target_page_index=...)` helper, which serialises `/Dest` as `[<int>, /Fit]`.

## Root cause

`merge()` excludes `/Annots` from `add_page()` and re-adds annotations via `_insert_filtered_annotations()`, which remaps each destination page through `_get_cloned_page()`. That helper only handled `NullObject`, page dictionaries and `IndirectObject`:

```python
if isinstance(page, DictionaryObject) and page.get("/Type", "") == "/Page":
    _i = page.indirect_reference
elif isinstance(page, IndirectObject):
    _i = page
try:
    return pages[_i.idnum].indirect_reference
except Exception:
    return None
```

For a bare integer page index none of the branches match, so `_i` is never bound. The resulting `UnboundLocalError` is swallowed by the `except`, `_get_cloned_page()` returns `None`, and the caller drops the annotation.

## Fix

Resolve an integer destination through the reader's page list so it is remapped to the (correctly offset) cloned page, exactly like a regular page reference. The rewritten `/Dest` becomes a proper indirect page reference pointing at the cloned target page.

## Reproduction (from #3953)

```python
from pypdf import PdfReader, PdfWriter
from pypdf.annotations import Link
from pypdf.generic import Fit

w = PdfWriter()
for _ in range(3):
    w.add_blank_page(width=595, height=842)
w.add_annotation(page_number=1, annotation=Link(
    rect=(57, 700, 500, 720), target_page_index=2, fit=Fit(fit_type="/Fit")))
# ... write, read back, append into a fresh writer ...
```

Before: `/Annots` on the appended page disappears (`Annotation sizes differ: 1 vs. 0`).
After: the `Link` survives and its destination points at the correct cloned page.

## Tests

Added `test_append_preserves_internal_link_annotation`, which appends after two pre-existing pages (so the destination index must be remapped) and asserts the `Link` survives with an indirect `/Dest` pointing at the offset cloned page. It fails on `main` and passes with this fix. `ruff` (0.16.0) and `mypy` are clean.

Closes #3953

🤖 Generated with [Claude Code](https://claude.com/claude-code)
