### PR TITLE
STY: Type pages as a Sequence rather than a list

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -30,7 +30,7 @@
 
 import struct
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable, Iterator, Mapping
+from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from datetime import datetime
 from typing import (
     Any,
@@ -1094,10 +1094,15 @@ class PdfDocCommon(ABC):
         return outline_item
 
     @property
-    def pages(self) -> list[PageObject]:
+    def pages(self) -> Sequence[PageObject]:
         """
         Property that emulates a list of :class:`PageObject<pypdf._page.PageObject>`.
         This property allows to get a page or a range of pages.
+
+        The returned object supports indexing, slicing, ``len()``, iteration and
+        (for PdfWriter) ``del``, but it is not a :class:`list` - pages are looked
+        up on demand rather than materialised up front, so list-only operations
+        such as ``append()`` or concatenation with ``+`` are not available.
 
         Note:
             For PdfWriter only: Provides the capability to remove a page/range of
@@ -1108,7 +1113,7 @@ class PdfDocCommon(ABC):
             PdfWriter.
 
         """
-        return _VirtualList(self.get_num_pages, self.get_page)  # type: ignore[return-value]
+        return _VirtualList(self.get_num_pages, self.get_page)
 
     @property
     def page_labels(self) -> list[str]:
@@ -1312,7 +1317,9 @@ class PdfDocCommon(ABC):
             return
 
         ind = self.pages[page].indirect_reference
-        del self.pages[page]
+        # `pages` is typed as a Sequence because it is not a list, but the
+        # concrete _VirtualList does implement deletion.
+        del cast(_VirtualList, self.pages)[page]
         if clean and ind is not None:
             self._replace_object(ind, NullObject())
 

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -1,6 +1,7 @@
 """Helpers for working with PDF types."""
 
 from abc import abstractmethod
+from collections.abc import Sequence
 from pathlib import Path
 from typing import IO, Any, Optional, Protocol, Union
 
@@ -43,7 +44,7 @@ class PdfCommonDocProtocol(Protocol):
         ...  # pragma: no cover
 
     @property
-    def pages(self) -> list[Any]:
+    def pages(self) -> Sequence[Any]:
         ...  # pragma: no cover
 
     @property


### PR DESCRIPTION
Was looking at #3689 and pulled on one of the typeguard failures. PdfDocCommon.pages
is annotated list[PageObject], but it returns a _VirtualList, which is a
Sequence that looks pages up on demand. The mismatch is currently hidden with a
type: ignore[return-value] on the return.

The practical effect is that a type checker will happily accept reader.pages + [page]
or reader.pages.append(page), and both blow up at runtime — TypeError for the
first, AttributeError for the second. Nothing warns you until it runs.

It also accounts for 16 of the "is not a list" failures in test_generic.py under
make testtype. Those go to 0 with this change.

Annotated the property and the matching PdfCommonDocProtocol member as Sequence
and dropped the ignore. One call site needed a cast — _replace_object's cleanup
does `del self.pages[page]`, and _VirtualList implements __delitem__ even though
Sequence doesn't declare it, so I cast there rather than widen the annotation to
MutableSequence, which would be wrong (no append/__setitem__/insert).

mypy on pypdf/ reports the same 22 pre-existing errors before and after, none in
these two files. Full suite is unchanged: the 3 failures I see locally
(test_build_link__go_to_action_without_destination, two flatten_form_field tests)
and test_appearance_stream_rtl all fail the same way on main — missing cached
fixtures on my machine.

I left the other testtype failures alone since #3689 is still open on what to do
with them overall — this one seemed worth separating out because it's a genuine
annotation bug rather than test-only noise.
