### PR TITLE
BUG: Always define PdfWriter._reader

### DIFF
--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -76,8 +76,7 @@ class PdfWriterProtocol(PdfCommonDocProtocol, Protocol):
     _id_translated: dict[int, dict[int, int]]
 
     incremental: bool
-    # Only populated in incremental mode; ``None`` otherwise. Every read of it
-    # in the writer is already guarded by ``if self.incremental``.
+    # Only populated in incremental mode, None otherwise.
     _reader: Optional[Any]  # PdfReader
 
     @abstractmethod

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -76,7 +76,9 @@ class PdfWriterProtocol(PdfCommonDocProtocol, Protocol):
     _id_translated: dict[int, dict[int, int]]
 
     incremental: bool
-    _reader: Any  # PdfReader
+    # Only populated in incremental mode; ``None`` otherwise. Every read of it
+    # in the writer is already guarded by ``if self.incremental``.
+    _reader: Optional[Any]  # PdfReader
 
     @abstractmethod
     def write(self, stream: Union[Path, StrByteType]) -> tuple[bool, IO[Any]]:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -226,8 +226,7 @@ class PdfWriter(PdfDocCommon):
         defined by Info in the PDF file's trailer dictionary."""
 
         self._reader: Optional[PdfReader] = None
-        """The document being appended to, in incremental mode only.
-        ``None`` for a writer that starts from scratch."""
+        """The document being appended to, in incremental mode only."""
 
         self._ID: Union[ArrayObject, None] = None
         """The PDF file identifier,

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -225,6 +225,10 @@ class PdfWriter(PdfDocCommon):
         """The PDF files's document information dictionary,
         defined by Info in the PDF file's trailer dictionary."""
 
+        self._reader: Optional[PdfReader] = None
+        """The document being appended to, in incremental mode only.
+        ``None`` for a writer that starts from scratch."""
+
         self._ID: Union[ArrayObject, None] = None
         """The PDF file identifier,
         defined by the ID in the PDF file's trailer dictionary."""
@@ -1376,6 +1380,7 @@ class PdfWriter(PdfDocCommon):
         self._resolve_links()
 
         if self.incremental:
+            assert self._reader is not None, "mypy"
             self._reader.stream.seek(0)
             stream.write(self._reader.stream.read(-1))
             if len(self.list_objects_in_increment()) > 0:
@@ -1444,6 +1449,8 @@ class PdfWriter(PdfDocCommon):
         ]
 
     def _write_increment(self, stream: StreamType) -> None:
+        # Only reached from `write()` inside `if self.incremental`.
+        assert self._reader is not None, "mypy"
         object_positions = {}
         object_blocks = []
         current_start = -1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2967,6 +2967,24 @@ def test_insert_filtered_annotations__annotations_are_none():
     ) == []
 
 
+def test_writer_reader_attribute_always_present():
+    """
+    `PdfWriterProtocol` declares `_reader`, but it used to be assigned only in
+    the incremental branch, so a plain `PdfWriter()` did not satisfy the
+    protocol it is passed as. It is `None` outside incremental mode.
+    """
+    writer = PdfWriter()
+    assert writer._reader is None
+
+    writer.add_blank_page(72, 72)
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    incremental = PdfWriter(stream, incremental=True)
+    assert incremental._reader is not None
+
+
 def test_incremental_read():
     """Test for #3116"""
     writer = PdfWriter()


### PR DESCRIPTION
Pulled on another one of the typeguard failures from #3689 and this one
turned out to be a real defect rather than test noise.

PdfWriterProtocol declares `_reader`, but PdfWriter only assigns it in the
incremental branch of __init__. So a writer built the normal way doesn't
actually satisfy the protocol it gets passed as — isinstance(writer,
PdfWriterProtocol) is False, and anything doing a runtime protocol check
rejects it. Under `make testtype` it's 62 of the failures, all on that one
missing attribute.

Declared it Optional[PdfReader] defaulting to None, next to the other
attribute docstrings in __init__. The three places that read it
(write(), _write_increment() twice) are all already inside
`if self.incremental`, so nothing changes at runtime — they just needed an
assert to narrow the Optional, which is the same `assert ..., "mypy"` style
already used elsewhere in this file.

Added a test that fails on main with AttributeError. mypy on pypdf/ reports
the same 22 pre-existing errors before and after, none in these files; the
offline suite goes 1007 → 1008 passed with the only failure being
test_appearance_stream_rtl, which fails the same way on a clean checkout here.
