### PR TITLE
ROB: AppearanceStream: Only escape parentheses for 8-bit fonts

### DIFF
--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -431,7 +431,14 @@ class TextStreamAppearance(BaseStreamAppearance):
             if any(len(c) >= 2 for c in encoded_line):
                 ap_stream += b"<" + (b"".join(encoded_line)).hex().encode() + b"> Tj\n"
             else:
-                ap_stream += b"(" + b"".join(encoded_line) + b") Tj\n"
+                # Escape parentheses (PDF 1.7 reference, table 3.2, Literal Strings)
+                line_as_bytes = (
+                    b"".join(encoded_line)
+                    .replace(b"\\", b"\\\\")
+                    .replace(b"(", br"\(")
+                    .replace(b")", br"\)")
+                )
+                ap_stream += b"(" + line_as_bytes + b") Tj\n"
             if is_rtl:
                 ap_stream += b"EMC\n"
         ap_stream += b"ET\nQ\nEMC\nQ\n"
@@ -696,9 +703,6 @@ class TextStreamAppearance(BaseStreamAppearance):
         else:  # /Tx
             text = field.get("/V", "")
             selection = []
-
-        # Escape parentheses (PDF 1.7 reference, table 3.2, Literal Strings)
-        text = text.replace("\\", "\\\\").replace("(", r"\(").replace(")", r"\)")
 
         # Derive font name, size and color from the default appearance. Also set
         # user-provided font name and font size in the default appearance, if given.

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -428,9 +428,9 @@ class TextStreamAppearance(BaseStreamAppearance):
                 bom_text = b"\xfe\xff" + original_text.encode("utf-16-be")
                 hex_original_text = bom_text.hex().upper()
                 ap_stream += f"/Span << /ActualText <{hex_original_text}> >> BDC\n".encode()
-            if any(len(c) >= 2 for c in encoded_line):
+            if font.sub_type == "Type0":  # 16-bit font
                 ap_stream += b"<" + (b"".join(encoded_line)).hex().encode() + b"> Tj\n"
-            else:
+            else:  # Simple font, 8-bit encoded.
                 # Escape parentheses (PDF 1.7 reference, table 3.2, Literal Strings)
                 line_as_bytes = (
                     b"".join(encoded_line)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1739,7 +1739,7 @@ def test_update_form_fields(caplog, tmp_path):
     del writer.pages[0]["/Resources"]["/Font"]
     writer.update_page_form_field_values(
         writer.pages[0],
-        {"Text1": "my Text1", "Text2": "ligne1\nligne2\nligne3"},
+        {"Text1": "my \\ your (Text1)", "Text2": "ligne1\nligne2\nligne3"},
         auto_regenerate=False,
     )
     writer.update_page_form_field_values(
@@ -1755,7 +1755,7 @@ def test_update_form_fields(caplog, tmp_path):
     assert flds["CheckBox1"]["/V"] == "/Yes"
     assert flds["CheckBox1"].indirect_reference.get_object()["/AS"] == "/Yes"
     assert (
-        b"(my Text1)"
+        rb"(my \\ your \(Text1\))"
         in flds["Text1"].indirect_reference.get_object()["/AP"]["/N"].get_data()
     )
     assert flds["Text2"]["/V"] == "ligne1\nligne2\nligne3"


### PR DESCRIPTION
The current implementation of escaping parentheses has two problems. First, it operates on any text, regardless of whether it will be 8-bit encoded or not. However, when we hex-encode text, for instance with Type0 / composite fonts, we erroneously will actually add the escape characters to the encoded text. Second, the parentheses-escaping code operates on un-encoded text. However, an 8-bit font with differences encoding might actually change a parenthesis to a different character, and it might also re-encode the backslash itself.

Postpone escaping parentheses until the last moment, where we operate on encoded text,and only with 8-bit encoding.

There is no existing bug report for this problem, but it has been reported at StackOverflow:
https://stackoverflow.com/questions/79853586/weasyprint-pypdf-visible-non-editable-escape-characters-on-parentheses


 