### PR TITLE
ROB: Detect cyclic pages in _get_page_in_node

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -378,25 +378,30 @@ class PdfDocCommon(ABC):
         If page_number is greater than the number of pages, it returns the top node, -1.
         """
         top = cast(DictionaryObject, self.root_object["/Pages"])
+        visited: set[int] = set()
 
         def recursive_call(
-            node: DictionaryObject, mi: int
+            _node: DictionaryObject, mi: int
         ) -> tuple[Optional[PdfObject], int]:
-            ma = cast(int, node.get("/Count", 1))  # default 1 for /Page types
-            if node["/Type"] == "/Page":  # type: ignore[comparison-overlap]
+            _node_id = id(_node)
+            if _node_id in visited:
+                raise LimitReachedError("Detected cycle in /Pages hierarchy when retrieving page.")
+            visited.add(_node_id)
+            ma = cast(int, _node.get("/Count", 1))  # default 1 for /Page types
+            if _node.get("/Type") == "/Page":
                 if page_number == mi:
-                    return node, -1
+                    return _node, -1
                 return None, mi + 1
             if (page_number - mi) >= ma:  # not in nodes below
-                if node == top:
+                if _node == top:
                     return top, -1
                 return None, mi + ma
-            for idx, kid in enumerate(cast(ArrayObject, node["/Kids"])):
+            for _idx, kid in enumerate(cast(ArrayObject, _node["/Kids"])):
                 kid = cast(DictionaryObject, kid.get_object())
                 n, i = recursive_call(kid, mi)
                 if n is not None:  # page has just been found ...
                     if i < 0:  # ... just below!
-                        return node, idx
+                        return _node, _idx
                     # ... at lower levels
                     return n, i
                 mi = i

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -802,3 +802,23 @@ def test_build_outline_item__non_array_color(caplog):
     # during append, so that path must tolerate it too.
     target = PdfWriter()
     target.append(writer)
+
+
+def test_get_page_in_node__cycle():
+    writer = PdfWriter()
+    page1 = DictionaryObject({
+        NameObject("/Count"): NumberObject(100)
+    })
+    page2 = DictionaryObject({
+        NameObject("/Count"): NumberObject(100)
+    })
+    page3 = DictionaryObject({
+        NameObject("/Count"): NumberObject(100),
+        NameObject("/Kids"): ArrayObject([writer._add_object(page1)])
+    })
+    page1[NameObject("/Kids")] = ArrayObject([writer._add_object(page2)])
+    page2[NameObject("/Kids")] = ArrayObject([writer._add_object(page3)])
+    writer.root_object[NameObject("/Pages")] = writer._add_object(page1)
+
+    with pytest.raises(LimitReachedError, match=r"^Detected cycle in /Pages hierarchy when retrieving page\.$"):
+        writer._get_page_in_node(42)


### PR DESCRIPTION
Previously, this would raise a recursion error.