### PR TITLE
SEC: Limit iterations for outline retrieval and XForm text extraction

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -44,6 +44,7 @@ from ._encryption import Encryption
 from ._page import PageObject, _VirtualList
 from ._page_labels import index2label as page_index2page_label
 from ._utils import (
+    _TraversalState,
     deprecation_with_replacement,
     logger_warning,
     parse_iso8824_date,
@@ -85,6 +86,10 @@ from .generic import (
 from .generic._files import EmbeddedFile
 from .types import OutlineType, PagemodeType
 from .xmp import XmpInformation
+
+# TODO: Make configurable.
+OUTLINE_MAX_ENTRIES = 100_000
+OUTLINE_MAX_DEPTH = 100
 
 
 def convert_to_int(d: bytes, size: int) -> Union[int, tuple[Any, ...]]:
@@ -234,7 +239,7 @@ class DocumentInformation(DictionaryObject):
         The "raw" version of modification date; can return a
         ``ByteStringObject``.
 
-        Typically in the format ``D:YYYYMMDDhhmmss[+Z-]hh'mm`` where the suffix
+        Typically, in the format ``D:YYYYMMDDhhmmss[+Z-]hh'mm`` where the suffix
         is the offset from UTC.
         """
         return self.get(DI.MOD_DATE)
@@ -871,10 +876,16 @@ class PdfDocCommon(ABC):
 
     def _get_outline(
         self,
+        *,
         node: Optional[DictionaryObject] = None,
         outline: Optional[Any] = None,
         visited: Optional[set[int]] = None,
+        depth: int = 0,
+        traversal_state: Optional[_TraversalState] = None
     ) -> OutlineType:
+        if traversal_state is None:
+            traversal_state = _TraversalState()
+
         if outline is None:
             outline = []
             catalog = self.root_object
@@ -894,6 +905,9 @@ class PdfDocCommon(ABC):
         if node is None:
             return outline
 
+        if depth > OUTLINE_MAX_DEPTH:
+            raise LimitReachedError(f"Maximum outline depth reached: {depth} > {OUTLINE_MAX_DEPTH}.")
+
         # see if there are any more outline items
         if visited is None:
             visited = set()
@@ -903,6 +917,11 @@ class PdfDocCommon(ABC):
                 logger_warning("Detected cycle in outline structure for %(node)s", source=__name__, node=node)
                 break
             visited.add(node_id)
+            traversal_state.entry_count += 1
+            if traversal_state.entry_count > OUTLINE_MAX_ENTRIES:
+                raise LimitReachedError(
+                    f"Maximum outline entry limit reached: {traversal_state.entry_count} > {OUTLINE_MAX_ENTRIES}."
+                )
 
             outline_obj = self._build_outline_item(node)
             if outline_obj:
@@ -917,6 +936,8 @@ class PdfDocCommon(ABC):
                     node=cast(DictionaryObject, node["/First"]),
                     outline=sub_outline,
                     visited=inner_visited,
+                    depth=depth + 1,
+                    traversal_state=traversal_state,
                 )
                 if sub_outline:
                     outline.append(sub_outline)

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -54,6 +54,7 @@ from ._utils import (
     CompressedTransformationMatrix,
     TransformationMatrixType,
     _human_readable_bytes,
+    _TraversalState,
     deprecate,
     deprecate_no_replacement,
     deprecate_with_replacement,
@@ -95,6 +96,9 @@ except ImportError:
     pil_not_imported = True  # error will be raised only when using images
 
 MERGE_CROP_BOX = "cropbox"  # pypdf <= 3.4.0 used "trimbox"
+
+# TODO: Make configurable.
+MAX_XFORM_INVOCATIONS_PER_EXTRACTION = 5_000
 
 
 def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
@@ -1805,6 +1809,7 @@ class PageObject(DictionaryObject):
         visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]] = None,
         *,
         known_ids: Optional[set[int]] = None,
+        traversal_state: Optional[_TraversalState] = None
     ) -> str:
         """
         See extract_text for most arguments.
@@ -1817,6 +1822,8 @@ class PageObject(DictionaryObject):
         """
         if known_ids is None:
             known_ids = set()
+        if traversal_state is None:
+            traversal_state = _TraversalState()
 
         extractor = TextExtraction()
         font_resources: dict[str, DictionaryObject] = {}
@@ -1913,31 +1920,19 @@ class PageObject(DictionaryObject):
                 except IndexError:
                     pass
                 try:
-                    xobj = cast(DictionaryObject, resources_dict["/XObject"])
-                    xform = cast(EncodedStreamObject, xobj[operands[0]])
-                    if xform["/Subtype"] != NameObject("/Image"):
-                        xform_id = id(xform)
-                        if xform_id in known_ids:
-                            logger_warning(
-                                "Detected cyclic form XObject reference, skipping %(operand)s.",
-                                source=__name__,
-                                operand=operands[0]
-                            )
-                            text = ""
-                        else:
-                            known_ids.add(xform_id)
-                            try:
-                                text = self.extract_xform_text(
-                                    xform,
-                                    orientations,
-                                    space_width,
-                                    visitor_operand_before,
-                                    visitor_operand_after,
-                                    visitor_text,
-                                    known_ids=known_ids,
-                                )
-                            finally:
-                                known_ids.discard(xform_id)
+                    xform_text = self._extract_text__xform(
+                        resources_dict=resources_dict,
+                        operands=operands,
+                        orientations=orientations,
+                        space_width=space_width,
+                        visitor_operand_before=visitor_operand_before,
+                        visitor_operand_after=visitor_operand_after,
+                        visitor_text=visitor_text,
+                        known_ids=known_ids,
+                        traversal_state=traversal_state
+                    )
+                    if xform_text is not None:
+                        text = xform_text
                         extractor.output += text
                         if visitor_text is not None:
                             visitor_text(
@@ -1972,6 +1967,63 @@ class PageObject(DictionaryObject):
                 extractor.font_size,
             )
         return extractor.output
+
+    def _extract_text__xform(
+        self,
+        *,
+        resources_dict: DictionaryObject,
+        operands: Any,
+        orientations: tuple[int, ...] = (0, 90, 180, 270),
+        space_width: float = 200.0,
+        visitor_operand_before: Optional[Callable[[Any, Any, Any, Any], None]] = None,
+        visitor_operand_after: Optional[Callable[[Any, Any, Any, Any], None]] = None,
+        visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]] = None,
+        known_ids: set[int],
+        traversal_state: _TraversalState
+    ) -> Optional[str]:
+        xobj = cast(DictionaryObject, resources_dict["/XObject"])
+        xform = cast(EncodedStreamObject, xobj[operands[0]])
+        if xform["/Subtype"] == NameObject("/Image"):
+            return None
+
+        xform_id = id(xform)
+        if xform_id in known_ids:
+            logger_warning(
+                "Detected cyclic form XObject reference, skipping %(operand)s.",
+                source=__name__,
+                operand=operands[0]
+            )
+            return ""
+
+        if traversal_state.entry_count >= MAX_XFORM_INVOCATIONS_PER_EXTRACTION:
+            if not traversal_state.has_logged:
+                traversal_state.has_logged = True
+                logger_warning(
+                    (
+                        "Exceeded %(limit)d form XObject invocations while extracting text; "
+                        "further form content is skipped."
+                    ),
+                    source=__name__,
+                    limit=MAX_XFORM_INVOCATIONS_PER_EXTRACTION
+                )
+            return ""
+
+        traversal_state.entry_count += 1
+        known_ids.add(xform_id)
+        try:
+            text = self.extract_xform_text(
+                xform,
+                orientations,
+                space_width,
+                visitor_operand_before,
+                visitor_operand_after,
+                visitor_text,
+                known_ids=known_ids,
+                traversal_state=traversal_state,
+            )
+        finally:
+            known_ids.discard(xform_id)
+        return text
 
     def _layout_mode_fonts(self) -> dict[str, Font]:
         """
@@ -2209,6 +2261,7 @@ class PageObject(DictionaryObject):
         visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]] = None,
         *,
         known_ids: Optional[set[int]] = None,
+        traversal_state: Optional[_TraversalState] = None
     ) -> str:
         """
         Extract text from an XObject.
@@ -2235,6 +2288,7 @@ class PageObject(DictionaryObject):
             visitor_operand_after,
             visitor_text,
             known_ids=known_ids,
+            traversal_state=traversal_state,
         )
 
     def _get_fonts(self) -> tuple[set[str], set[str]]:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2261,7 +2261,7 @@ class PageObject(DictionaryObject):
         visitor_text: Optional[Callable[[Any, Any, Any, Any, Any], None]] = None,
         *,
         known_ids: Optional[set[int]] = None,
-        traversal_state: Optional[_TraversalState] = None
+        traversal_state: Optional[Any] = None
     ) -> str:
         """
         Extract text from an XObject.
@@ -2273,11 +2273,15 @@ class PageObject(DictionaryObject):
             visitor_operand_before:
             visitor_operand_after:
             visitor_text:
+            known_ids:
+            traversal_state:
 
         Returns:
             The extracted text
 
         """
+        # The type hint would have to use an internal type otherwise, which is not desired.
+        assert traversal_state is None or isinstance(traversal_state, _TraversalState)
         return self._extract_text(
             xform,
             self.pdf,

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -671,3 +671,10 @@ class Version:
                 return False
 
         return len(self.components) < len(other.components)
+
+
+@dataclass
+class _TraversalState:
+    """Sometimes we need mutable objects which just count something."""
+    entry_count: int = 0
+    has_logged: bool = False

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -822,3 +822,58 @@ def test_get_page_in_node__cycle():
 
     with pytest.raises(LimitReachedError, match=r"^Detected cycle in /Pages hierarchy when retrieving page\.$"):
         writer._get_page_in_node(42)
+
+
+def test_get_outline__depth():
+    writer = PdfWriter()
+    outlines = [
+        DictionaryObject({NameObject("/Title"): TextStringObject(f"Title{i}")})
+        for i in range(3)
+    ]
+    writer.root_object[NameObject("/Outlines")] = DictionaryObject({
+        NameObject("/First"): writer._add_object(outlines[0])
+    })
+    for index, outline in enumerate(outlines[:-1]):
+        outline[NameObject("/First")] = writer._add_object(outlines[index + 1])
+        outline[NameObject("/Next")] = writer._add_object(outlines[index + 1])
+        writer._add_object(outline)
+
+    assert writer._get_outline() == [
+        {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title0", "/Type": "/Fit"},
+        [
+            {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title1", "/Type": "/Fit"},
+            [
+                {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title2", "/Type": "/Fit"}
+            ],
+            {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title2", "/Type": "/Fit"}
+        ],
+        {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title1", "/Type": "/Fit"},
+        [
+            {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title2", "/Type": "/Fit"}
+        ],
+        {"/%is_open%": True, "/Page": NullObject(), "/Title": "Title2", "/Type": "/Fit"}
+    ]
+
+    with pytest.raises(expected_exception=LimitReachedError, match=r"^Maximum outline depth reached: 101 > 100\.$"):
+        writer._get_outline(depth=99)
+
+
+def test_get_outline__entry_count():
+    writer = PdfWriter()
+    outlines = [
+        DictionaryObject({NameObject("/Title"): TextStringObject(f"Title{i}")})
+        for i in range(10)
+    ]
+    writer.root_object[NameObject("/Outlines")] = DictionaryObject({
+        NameObject("/First"): writer._add_object(outlines[0])
+    })
+    for index, outline in enumerate(outlines[:-1]):
+        outline[NameObject("/First")] = writer._add_object(outlines[index + 1])
+        outline[NameObject("/Next")] = writer._add_object(outlines[index + 1])
+        writer._add_object(outline)
+
+    with mock.patch("pypdf._doc_common.OUTLINE_MAX_ENTRIES", 1000), \
+            pytest.raises(
+                expected_exception=LimitReachedError, match=r"^Maximum outline entry limit reached: 1001 > 1000\.$"
+            ):
+        writer._get_outline()

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -7,6 +7,7 @@ The tested code might be in _page.py.
 import re
 from dataclasses import asdict
 from io import BytesIO
+from unittest import mock
 
 import pytest
 
@@ -29,6 +30,8 @@ from pypdf.generic import (
     DictionaryObject,
     NameObject,
     NumberObject,
+    RectangleObject,
+    StreamObject,
 )
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
@@ -807,3 +810,123 @@ def test_page_object__layout_mode_fonts__cyclic(caplog) -> None:
 
     assert page._layout_mode_fonts() == fonts
     assert caplog.messages == ["Detected cycle in /Parent hierarchy when retrieving fonts."]
+
+
+def _generate_dag_with_forms(depth: int) -> bytes:
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+
+    font = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Subtype"): NameObject("/Type1"),
+            NameObject("/BaseFont"): NameObject("/Helvetica"),
+        }
+    )
+    font_ref = writer._add_object(font)
+
+    # There are only depth + 1 actual Form objects:
+    #
+    #   F0 -> F1 -> F2 -> ... -> Fdepth
+    #
+    # But each form invokes its child twice:
+    #
+    #   F0
+    #   ├── F1
+    #   │   ├── F2
+    #   │   │   └── ...
+    #   │   └── F2
+    #   └── F1
+    #       ├── F2
+    #       └── F2
+    #
+    # This gives a DAG with exponentially many traversal paths while
+    # keeping the PDF itself linear in size.
+    num_forms = depth + 1
+    forms: list[StreamObject] = []
+
+    for _ in range(num_forms):
+        form = StreamObject()
+        forms.append(form)
+
+    # Register all forms first so that their indirect references are
+    # available when constructing their resource dictionaries.
+    form_refs = [writer._add_object(form) for form in forms]
+
+    for k, form in enumerate(forms):
+        if k < depth:
+            next_name = NameObject(f"/F{k + 1}")
+            form_content = (
+                f"q\n"
+                f"{next_name} Do\n"
+                f"{next_name} Do\n"
+                f"Q\n"
+            ).encode("ascii")
+            xobjects = DictionaryObject({
+                next_name: form_refs[k + 1],
+            })
+        else:
+            # Leaf form: emit a single character.
+            form_content = (
+                b"BT\n"
+                b"/F1 12 Tf\n"
+                b"100 700 Td\n"
+                b"(.) Tj\n"
+                b"ET\n"
+            )
+            xobjects = DictionaryObject()
+
+        resources = DictionaryObject({
+            NameObject("/Font"): DictionaryObject({
+                NameObject("/F1"): font_ref,
+            }),
+        })
+        if xobjects:
+            resources[NameObject("/XObject")] = xobjects
+
+        form.update({
+            NameObject("/Type"): NameObject("/XObject"),
+            NameObject("/Subtype"): NameObject("/Form"),
+            NameObject("/FormType"): NumberObject(1),
+            NameObject("/BBox"): RectangleObject([0, 0, 612, 792]),
+            NameObject("/Resources"): resources,
+        })
+        form.set_data(form_content)
+
+    # Invoke the root form twice.
+    page_content = StreamObject()
+    page_content.set_data(
+        b"q\n"
+        b"/F0 Do\n"
+        b"/F0 Do\n"
+        b"Q\n"
+    )
+    page_content_ref = writer._add_object(page_content)
+
+    page_resources = DictionaryObject({
+        NameObject("/XObject"): DictionaryObject({
+            NameObject("/F0"): form_refs[0],
+        }),
+    })
+
+    page[NameObject("/Resources")] = page_resources
+    page[NameObject("/Contents")] = page_content_ref
+    page[NameObject("/MediaBox")] = ArrayObject(list(map(NumberObject, [0, 0, 612, 792])))
+
+    data = BytesIO()
+    writer.write(data)
+    return data.getvalue()
+
+
+@pytest.mark.timeout(5)
+def test_extract_text__form_xobject__limit(caplog) -> None:
+    # Takes about 15 seconds without fix.
+    reader = PdfReader(BytesIO(_generate_dag_with_forms(12)))
+    page = reader.pages[0]
+    with mock.patch("pypdf._page.MAX_XFORM_INVOCATIONS_PER_EXTRACTION", 100):
+        text = page.extract_text()
+    assert len(text) == 92
+    assert text == ".\n" * 46
+    assert caplog.messages == [
+        "Exceeded 100 form XObject invocations while extracting text; further form content is skipped."
+    ]


### PR DESCRIPTION
Please note that for now, there is no official way to change the limits, as the goal is to have a better way to configure such limits first.

Generating the `_generate_dag_with_forms` function has been assisted by ChatGPT.