### PR TITLE
BUG: Keep 8-bit DeviceRGB image mode from being overwritten

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -478,15 +478,21 @@ def _apply_decode(
 def _get_mode_and_invert_color(
     x_object: dict[str, Any], colors: int, color_space: Union[str, list[Any], Any]
 ) -> tuple[mode_str_type, bool]:
+    bits = x_object.get("/BitsPerComponent", 8)
+    # /DeviceRGB with a full-width sample is RGB. Keep that assignment:
+    # the generic path below used to overwrite it unconditionally (#3367).
+    # Sub-byte samples still go through the low-bit branch so
+    # _expand_low_bit_samples() can unpack them.
     if (
         ImageAttributes.COLOR_SPACE in x_object
         and x_object[ImageAttributes.COLOR_SPACE] == ColorSpaces.DEVICE_RGB
+        and bits >= 8
     ):
         # https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
-        mode: mode_str_type = "RGB"
-    if x_object.get("/BitsPerComponent", 8) < 8:
+        return "RGB", False
+    if bits < 8:
         mode, invert_color = _get_image_mode(
-            f"{x_object.get('/BitsPerComponent', 8)}bit", 0, ""
+            f"{bits}bit", 0, ""
         )
     else:
         mode, invert_color = _get_image_mode(

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -21,6 +21,7 @@ from pypdf.generic import (
 )
 from pypdf.generic._image_xobject import (
     _get_image_mode,
+    _get_mode_and_invert_color,
     _handle_flate,
     _image_from_bytes,
     _xobj_to_image,
@@ -228,6 +229,29 @@ def test_handle_flate__autodesk_indexed() -> None:
         for name, _image in page.images.items():  # noqa: PERF102
             assert isinstance(name, str)
             assert name.startswith("/")
+
+
+def test_device_rgb_mode_is_not_overwritten() -> None:
+    """8-bit /DeviceRGB must stay RGB; the generic path used to replace it (#3367)."""
+    x_object = {
+        NameObject("/ColorSpace"): NameObject("/DeviceRGB"),
+        NameObject("/BitsPerComponent"): NumberObject(8),
+    }
+    # ColorSpace on the XObject is /DeviceRGB. Pass a name _get_image_mode
+    # cannot map so a regression fails instead of accidentally succeeding.
+    mode, invert_color = _get_mode_and_invert_color(
+        x_object, colors=1, color_space=NameObject("/UnknownSpace")
+    )
+    assert mode == "RGB"
+    assert invert_color is False
+
+    # Sub-byte /DeviceRGB still reports 2/4bits so sample expansion can run.
+    x_object[NameObject("/BitsPerComponent")] = NumberObject(4)
+    mode, invert_color = _get_mode_and_invert_color(
+        x_object, colors=3, color_space=NameObject("/DeviceRGB")
+    )
+    assert mode == "4bits"
+    assert invert_color is False
 
 
 @pytest.mark.enable_socket


### PR DESCRIPTION
## Summary

`_get_mode_and_invert_color` set `mode = "RGB"` when `/ColorSpace` was `/DeviceRGB`, then immediately overwrote that assignment in the following `if`/`else`. That is the control-flow bug from #3367 (regression introduced in #1834).

8-bit `/DeviceRGB` now returns RGB and stops there. Images with `/BitsPerComponent` < 8 still go through the `"2bits"`/`"4bits"` path so `_expand_low_bit_samples()` can unpack them (the #3938 / #3929 behavior).

Closes #3367

## Test plan

- [x] `test_device_rgb_mode_is_not_overwritten` fails on current main (`UnknownSpace` used to become `"P"`) and passes with this change
- [x] `test_low_bit_devicergb_image_mode` and `test_low_bit_devicergb_image_without_filter` still pass
- [x] Offline `tests/generic/test_image_xobject.py` (23 tests) pass

Assisted by Grok (xAI) to locate the maintainer-confirmed issue and draft the patch; I verified the overwrite in source and ran the tests above.