### PR TITLE
BUG: Type _id_translated to match what it holds

### DIFF
--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -73,7 +73,10 @@ class PdfReaderProtocol(PdfCommonDocProtocol, Protocol):
 
 class PdfWriterProtocol(PdfCommonDocProtocol, Protocol):
     _objects: list[Any]
-    _id_translated: dict[int, dict[int, int]]
+    # Maps id(source pdf) -> {source idnum: new idnum}. Each inner mapping also
+    # carries a "PreventGC" entry holding the source document itself, which keeps
+    # it alive while the translation table is in use -- hence the wider types.
+    _id_translated: dict[int, dict[Union[int, str], Any]]
 
     incremental: bool
     # Only populated in incremental mode, None otherwise.

--- a/pypdf/_protocols.py
+++ b/pypdf/_protocols.py
@@ -3,7 +3,7 @@
 from abc import abstractmethod
 from collections.abc import Sequence
 from pathlib import Path
-from typing import IO, Any, Optional, Protocol, Union
+from typing import IO, Any, Literal, Optional, Protocol, Union
 
 from ._utils import StrByteType, StreamType
 
@@ -73,10 +73,9 @@ class PdfReaderProtocol(PdfCommonDocProtocol, Protocol):
 
 class PdfWriterProtocol(PdfCommonDocProtocol, Protocol):
     _objects: list[Any]
-    # Maps id(source pdf) -> {source idnum: new idnum}. Each inner mapping also
-    # carries a "PreventGC" entry holding the source document itself, which keeps
-    # it alive while the translation table is in use -- hence the wider types.
-    _id_translated: dict[int, dict[Union[int, str], Any]]
+    # The "PreventGC" entry holds the source document, keeping it alive while
+    # the translation table is in use.
+    _id_translated: dict[int, dict[Union[int, Literal["PreventGC"]], Any]]
 
     incremental: bool
     # Only populated in incremental mode, None otherwise.

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -44,6 +44,7 @@ from typing import (
     IO,
     Any,
     Callable,
+    Literal,
     Optional,
     Union,
     cast,
@@ -215,7 +216,7 @@ class PdfWriter(PdfDocCommon):
         This is used for compression.
         """
 
-        self._id_translated: dict[int, dict[Union[int, str], Any]] = {}
+        self._id_translated: dict[int, dict[Union[int, Literal["PreventGC"]], Any]] = {}
         """List of already translated IDs.
            dict[id(pdf)][(idnum, generation)]
         """

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -215,7 +215,7 @@ class PdfWriter(PdfDocCommon):
         This is used for compression.
         """
 
-        self._id_translated: dict[int, dict[int, int]] = {}
+        self._id_translated: dict[int, dict[Union[int, str], Any]] = {}
         """List of already translated IDs.
            dict[id(pdf)][(idnum, generation)]
         """

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -178,7 +178,7 @@ class PdfObject(PdfObjectProtocol):
         if ind is not None:
             if id(ind.pdf) not in pdf_dest._id_translated:
                 pdf_dest._id_translated[id(ind.pdf)] = {}
-                pdf_dest._id_translated[id(ind.pdf)]["PreventGC"] = ind.pdf  # type: ignore[index]
+                pdf_dest._id_translated[id(ind.pdf)]["PreventGC"] = ind.pdf
             if (
                 not force_duplicate
                 and ind.idnum in pdf_dest._id_translated[id(ind.pdf)]
@@ -356,7 +356,7 @@ class IndirectObject(PdfObject):
             return self
         if id(self.pdf) not in pdf_dest._id_translated:
             pdf_dest._id_translated[id(self.pdf)] = {}
-            pdf_dest._id_translated[id(self.pdf)]["PreventGC"] = self.pdf  # type: ignore[index]
+            pdf_dest._id_translated[id(self.pdf)]["PreventGC"] = self.pdf
 
         if self.idnum in pdf_dest._id_translated[id(self.pdf)]:
             dup = pdf_dest.get_object(pdf_dest._id_translated[id(self.pdf)][self.idnum])

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3053,6 +3053,32 @@ def test_writer_reader_attribute_always_present():
     assert incremental._reader is not None
 
 
+def test_id_translated_holds_the_source_document():
+    """
+    Each `_id_translated` entry keeps the source document alive under a
+    "PreventGC" key alongside the integer idnum mappings, so the mapping is
+    keyed by `int | str` rather than by `int` alone.
+    """
+    source = PdfWriter()
+    source.add_blank_page(72, 72)
+    stream = BytesIO()
+    source.write(stream)
+    stream.seek(0)
+
+    writer = PdfWriter()
+    writer.append(PdfReader(stream))
+
+    assert writer._id_translated
+    for translated in writer._id_translated.values():
+        assert translated["PreventGC"] is not None
+        # The remaining entries are the idnum -> idnum mappings.
+        assert all(
+            isinstance(value, int)
+            for key, value in translated.items()
+            if key != "PreventGC"
+        )
+
+
 def test_incremental_read():
     """Test for #3116"""
     writer = PdfWriter()


### PR DESCRIPTION
`_id_translated` is declared `dict[int, dict[int, int]]`, but each inner
mapping also stores the source document under a "PreventGC" key so it is
not garbage collected while the translation table is live. The two writes
needed `# type: ignore[index]` to get past that, and a runtime protocol
check on PdfWriterProtocol fails on the string key.

Widened to `dict[int, dict[Union[int, str], Any]]`, which is what the
dictionary actually contains, and dropped the two ignores that became
unnecessary. Every reader looks entries up by idnum rather than iterating,
so behaviour is unchanged.

Under `make testtype` this accounts for 55 failures across test_generic and
test_writer; they go to 0. mypy reports the same 11 pre-existing errors
before and after, none in these files.
