### PR TITLE
BUG: Default decode_parms to a DictionaryObject

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -832,8 +832,6 @@ def decode_stream_data(stream: StreamObject) -> bytes:
     if not isinstance(filters, ArrayObject):
         # We have a single filter instance
         filters = (filters,)
-    # The decoders are typed for a DictionaryObject, so the default has to be
-    # one too -- a plain {} is not an instance of it.
     decode_parms = stream.get(StreamAttributes.DECODE_PARMS, (DictionaryObject(),) * len(filters))
     if not isinstance(decode_parms, (list, tuple)):
         decode_parms = (decode_parms,)

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -832,7 +832,9 @@ def decode_stream_data(stream: StreamObject) -> bytes:
     if not isinstance(filters, ArrayObject):
         # We have a single filter instance
         filters = (filters,)
-    decode_parms = stream.get(StreamAttributes.DECODE_PARMS, ({},) * len(filters))
+    # The decoders are typed for a DictionaryObject, so the default has to be
+    # one too -- a plain {} is not an instance of it.
+    decode_parms = stream.get(StreamAttributes.DECODE_PARMS, (DictionaryObject(),) * len(filters))
     if not isinstance(decode_parms, (list, tuple)):
         decode_parms = (decode_parms,)
     data: bytes = stream._data
@@ -841,7 +843,9 @@ def decode_stream_data(stream: StreamObject) -> bytes:
         return data
     for filter_name, params in zip(filters, decode_parms):
         if isinstance(params, NullObject):
-            params = {}
+            # The decoders are typed for a DictionaryObject; a plain {} is not
+            # one, so a null /DecodeParms entry would hand them the wrong type.
+            params = DictionaryObject()
         if filter_name in (FT.ASCII_HEX_DECODE, FTA.AHx):
             _deprecate_inline_image_filters(filter_name=filter_name, old_name=FTA.AHx, new_name=FT.ASCII_HEX_DECODE)
             data = ASCIIHexDecode.decode(data)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1070,29 +1070,15 @@ def test_deprecate_inline_image_filters():
 
 
 def test_decode_stream_data__default_parms_are_dictionary_objects():
-    """
-    A stream without /DecodeParms still has to hand the decoders a
-    DictionaryObject; a plain {} is not an instance of one.
-    """
-    captured = []
-
-    class RecordingFlate(FlateDecode):
-        @staticmethod
-        def decode(data, decode_parms=None, **kwargs) -> bytes:  # noqa: ANN003
-            captured.append(decode_parms)
-            return FlateDecode.decode(data, decode_parms, **kwargs)
-
+    """A stream without /DecodeParms hands the decoders a DictionaryObject."""
     stream = DecodedStreamObject()
-    stream.set_data(b"hello")
     stream[NameObject("/Filter")] = NameObject("/FlateDecode")
-    encoded = zlib.compress(b"hello")
-    stream._data = encoded
+    stream._data = zlib.compress(b"hello")
 
-    with mock.patch("pypdf.filters.FlateDecode", RecordingFlate):
+    with mock.patch.object(FlateDecode, "decode", return_value=b"hello") as decode:
         assert decode_stream_data(stream) == b"hello"
 
-    assert captured, "the filter should have been invoked"
-    assert isinstance(captured[0], DictionaryObject)
+    assert isinstance(decode.call_args.args[1], DictionaryObject)
 
 
 def test_flatedecode__columns_is_zero():

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1069,6 +1069,32 @@ def test_deprecate_inline_image_filters():
     assert decode_stream_data(stream).startswith(b"II*")
 
 
+def test_decode_stream_data__default_parms_are_dictionary_objects():
+    """
+    A stream without /DecodeParms still has to hand the decoders a
+    DictionaryObject; a plain {} is not an instance of one.
+    """
+    captured = []
+
+    class RecordingFlate(FlateDecode):
+        @staticmethod
+        def decode(data, decode_parms=None, **kwargs) -> bytes:  # noqa: ANN003
+            captured.append(decode_parms)
+            return FlateDecode.decode(data, decode_parms, **kwargs)
+
+    stream = DecodedStreamObject()
+    stream.set_data(b"hello")
+    stream[NameObject("/Filter")] = NameObject("/FlateDecode")
+    encoded = zlib.compress(b"hello")
+    stream._data = encoded
+
+    with mock.patch("pypdf.filters.FlateDecode", RecordingFlate):
+        assert decode_stream_data(stream) == b"hello"
+
+    assert captured, "the filter should have been invoked"
+    assert isinstance(captured[0], DictionaryObject)
+
+
 def test_flatedecode__columns_is_zero():
     data = b"Hello World!"
     parameters = DictionaryObject({


### PR DESCRIPTION
`decode_stream_data` defaults the per-filter decode parameters to
`({},) * len(filters)`. The decoders take
`Optional[Union[DictionaryObject, IndirectObject]]`, and a plain `{}` is not
a DictionaryObject, so any stream without an explicit /DecodeParms hands
them the wrong type. A runtime protocol check rejects it; static checking
never noticed because the value flows through `stream.get`, which returns Any.

`DictionaryObject()` is an empty mapping and satisfies the annotation, so the
substitution is behaviour-neutral — the same pattern is already used a few
lines above in `decode`.

Accounts for 5 of the failures in test_generic under `make testtype`; they go
to 0. Added a test that fails on main.
