### PR TITLE
BUG: Type the xref stream as StreamObject rather than ContentStream

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -73,8 +73,6 @@ from .errors import (
 )
 from .generic import (
     ArrayObject,
-    ContentStream,
-    DecodedStreamObject,
     Destination,
     DictionaryObject,
     EncodedStreamObject,
@@ -1160,7 +1158,7 @@ class PdfReader(PdfDocCommon):
         raise PdfReadError("Could not find xref table at specified location")
 
     def _sanitize_pdf15_xref_stream_index_pairs(
-            self, index_pairs: list[int], entry_sizes: list[int], xref_stream: ContentStream
+            self, index_pairs: list[int], entry_sizes: list[int], xref_stream: StreamObject
     ) -> list[int]:
         # `entry_sizes` holds the byte widths for the entries. Summing determines the total number of bytes per entry.
         # We expect up to 3 values. `min_entry_bytes` will be the smallest plausible size of one xref entry.
@@ -1204,13 +1202,11 @@ class PdfReader(PdfDocCommon):
 
         return result
 
-    def _read_pdf15_xref_stream(
-        self, stream: StreamType
-    ) -> Union[ContentStream, EncodedStreamObject, DecodedStreamObject]:
+    def _read_pdf15_xref_stream(self, stream: StreamType) -> StreamObject:
         """Read the cross-reference stream for PDF 1.5+."""
         stream.seek(-1, 1)
         stream_idnum, stream_generation = self.read_object_header(stream)
-        xref_stream = cast(ContentStream, read_object(stream, self))
+        xref_stream = cast(StreamObject, read_object(stream, self))
         if cast(str, xref_stream["/Type"]) != "/XRef":
             raise PdfReadError(f"Unexpected type {xref_stream['/Type']!r}")
         self.cache_indirect_object(stream_generation, stream_idnum, xref_stream)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -28,13 +28,11 @@ from pypdf.errors import (
 from pypdf.filters import FlateDecode
 from pypdf.generic import (
     ArrayObject,
-    ContentStream,
     Destination,
     DictionaryObject,
     IndirectObject,
     NameObject,
     NumberObject,
-    StreamObject,
     TextStringObject,
 )
 
@@ -2496,32 +2494,6 @@ def test_read_pdf15_xref_stream__w_0_0_0(caplog):
     assert caplog.messages == [
         "Cross-reference stream encodes no entry data.",
     ]
-
-
-def test_read_pdf15_xref_stream__returns_a_stream_object():
-    """
-    A compressed cross-reference stream is read as an EncodedStreamObject,
-    which is a sibling of ContentStream rather than a subclass of it.
-    """
-    pdf = b"%PDF-1.7\n"
-    pdf += b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
-    pdf += b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
-    startxref = len(pdf)
-    encoded = FlateDecode.encode(bytes(6))
-    pdf += (
-        f"3 0 obj\n<< /Type /XRef /Size 1 /W [1 2 3] /Root 1 0 R /Filter /FlateDecode "
-        f"/Length {len(encoded)} >>\nstream\n"
-    ).encode()
-    pdf += encoded + b"\nendstream\nendobj\n"
-    pdf += f"startxref\n{startxref}\n%%EOF\n".encode()
-
-    reader = PdfReader(BytesIO(pdf), strict=False)
-    stream = BytesIO(pdf)
-    stream.seek(startxref + 1)
-    xref_stream = reader._read_pdf15_xref_stream(stream)
-
-    assert isinstance(xref_stream, StreamObject)
-    assert not isinstance(xref_stream, ContentStream)
 
 
 @pytest.mark.timeout(10)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -28,11 +28,13 @@ from pypdf.errors import (
 from pypdf.filters import FlateDecode
 from pypdf.generic import (
     ArrayObject,
+    ContentStream,
     Destination,
     DictionaryObject,
     IndirectObject,
     NameObject,
     NumberObject,
+    StreamObject,
     TextStringObject,
 )
 
@@ -2494,6 +2496,32 @@ def test_read_pdf15_xref_stream__w_0_0_0(caplog):
     assert caplog.messages == [
         "Cross-reference stream encodes no entry data.",
     ]
+
+
+def test_read_pdf15_xref_stream__returns_a_stream_object():
+    """
+    A compressed cross-reference stream is read as an EncodedStreamObject,
+    which is a sibling of ContentStream rather than a subclass of it.
+    """
+    pdf = b"%PDF-1.7\n"
+    pdf += b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+    pdf += b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+    startxref = len(pdf)
+    encoded = FlateDecode.encode(bytes(6))
+    pdf += (
+        f"3 0 obj\n<< /Type /XRef /Size 1 /W [1 2 3] /Root 1 0 R /Filter /FlateDecode "
+        f"/Length {len(encoded)} >>\nstream\n"
+    ).encode()
+    pdf += encoded + b"\nendstream\nendobj\n"
+    pdf += f"startxref\n{startxref}\n%%EOF\n".encode()
+
+    reader = PdfReader(BytesIO(pdf), strict=False)
+    stream = BytesIO(pdf)
+    stream.seek(startxref + 1)
+    xref_stream = reader._read_pdf15_xref_stream(stream)
+
+    assert isinstance(xref_stream, StreamObject)
+    assert not isinstance(xref_stream, ContentStream)
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
`_read_pdf15_xref_stream` casts the result of `read_object` to
ContentStream:

    xref_stream = cast(ContentStream, read_object(stream, self))

A compressed cross-reference stream is read as an EncodedStreamObject,
which is a sibling of ContentStream rather than a subclass - they share
StreamObject as their base but neither is the other. The cast asserted
something untrue, and `_sanitize_pdf15_xref_stream_index_pairs` declared
the same wrong type for its `xref_stream` parameter, so a runtime protocol
check rejects the object that is actually passed.

Both now use StreamObject. That is the common base of the three stream
types this function can return, and it still provides `get_data`, which is
the only method either place calls on the value.

The return annotation listed the three siblings but not their base, so it
is collapsed to StreamObject as well. The single caller passes the result
to `_process_xref_stream`, which takes a DictionaryObject, and StreamObject
extends DictionaryObject. Removing the union left the ContentStream and
DecodedStreamObject imports unused, so those are dropped too.

Under `make testtype` this is 138 failures in test_writer alone; they go
to 0. mypy reports the same 11 pre-existing errors before and after.

Added an offline test that builds a minimal PDF with a FlateDecode xref
stream and asserts the result is a StreamObject but not a ContentStream.
It fails on main.
