### PR TITLE
ROB: Do not crash on a non-array destination

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -75,7 +75,6 @@ from .generic import (
     IndirectObject,
     NameObject,
     NullObject,
-    NumberObject,
     PdfObject,
     TextStringObject,
     TreeObject,
@@ -1007,18 +1006,13 @@ class PdfDocCommon(ABC):
     def _build_destination(
         self,
         title: Union[str, bytes],
-        array: Optional[
-            list[
-                Union[NumberObject, IndirectObject, NullObject, DictionaryObject, None]
-            ]
-        ],
+        array: Optional[ArrayObject],
     ) -> Destination:
         page, typ = None, None
-        # Handle outline items with missing or invalid destination: a valid
-        # destination is an array of at least two elements (page and fit type).
-        # Anything else (a NullObject, a name, a bare number, None, ...) cannot
-        # be unpacked below and is treated as a missing destination.
-        if not isinstance(array, list) or len(array) < 2:
+        # A valid destination is an array of at least a page and a fit type.
+        # Anything else (a name, a bare number, a NullObject, None, ...) cannot
+        # be unpacked below, so treat it as a missing destination.
+        if not isinstance(array, ArrayObject) or len(array) < 2:
             page = NullObject()
             return Destination(title, page, Fit.fit())
         page, typ, *array = array  # type: ignore[assignment]

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1014,12 +1014,11 @@ class PdfDocCommon(ABC):
         ],
     ) -> Destination:
         page, typ = None, None
-        # handle outline items with missing or invalid destination
-        if (
-            isinstance(array, (NullObject, str))
-            or (isinstance(array, ArrayObject) and len(array) < 2)
-            or array is None
-        ):
+        # handle outline items with missing or invalid destination: a valid
+        # destination is an array of at least two elements (page and fit type).
+        # Anything else (a NullObject, a name, a bare number, None, ...) cannot
+        # be unpacked below and is treated as a missing destination.
+        if not isinstance(array, list) or len(array) < 2:
             page = NullObject()
             return Destination(title, page, Fit.fit())
         page, typ, *array = array  # type: ignore[assignment]

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1017,7 +1017,7 @@ class PdfDocCommon(ABC):
             return Destination(title, page, Fit.fit())
         page, typ, *array = array  # type: ignore[assignment]
         try:
-            return Destination(title, page, Fit(fit_type=typ, fit_args=array))  # type: ignore[arg-type]
+            return Destination(title, page, Fit(fit_type=typ, fit_args=array))
         except PdfReadError:
             logger_warning("Unknown destination: %(title)r %(array)s", source=__name__, title=title, array=array)
             if self.strict:

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1014,7 +1014,7 @@ class PdfDocCommon(ABC):
         ],
     ) -> Destination:
         page, typ = None, None
-        # handle outline items with missing or invalid destination: a valid
+        # Handle outline items with missing or invalid destination: a valid
         # destination is an array of at least two elements (page and fit type).
         # Anything else (a NullObject, a name, a bare number, None, ...) cannot
         # be unpacked below and is treated as a missing destination.

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -211,7 +211,8 @@ def test_build_destination__short_array():
 
 def test_build_destination__non_array():
     """A non-array destination degrades to a null destination rather than
-    raising TypeError while unpacking."""
+    raising TypeError while unpacking.
+    """
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)
 
@@ -221,7 +222,8 @@ def test_build_destination__non_array():
 
 def test_named_destinations__non_array_value():
     """A bare number where a destination array is expected is skipped instead
-    of crashing named_destinations with a TypeError."""
+    of crashing named_destinations with a TypeError.
+    """
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)
     names = DictionaryObject()

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -209,6 +209,39 @@ def test_build_destination__short_array():
     assert dest["/Type"] == "/FitR"
 
 
+def test_build_destination__non_array():
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+
+    # A destination that is not an array at all, such as the bare number that
+    # can appear as a value in a malformed name tree, degrades to a null
+    # destination instead of raising a TypeError on the unpacking.
+    dest = writer._build_destination("title", NumberObject(5))
+    assert isinstance(dest["/Page"], NullObject)
+
+
+def test_named_destinations__non_array_value():
+    # A name tree whose /Names array holds a bare number where a destination
+    # array is expected used to crash reader.named_destinations with a raw
+    # TypeError instead of skipping the malformed entry.
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    names = DictionaryObject()
+    names[NameObject("/Names")] = ArrayObject(
+        [TextStringObject("foo"), NumberObject(5)]
+    )
+    dests = DictionaryObject()
+    dests[NameObject("/Dests")] = names
+    writer.root_object[NameObject("/Names")] = dests
+
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+    reader = PdfReader(stream)
+
+    assert "foo" in reader.named_destinations
+
+
 def _reader_with_button_field(field: DictionaryObject) -> PdfReader:
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -194,15 +194,15 @@ def test_viewer_preferences__indirect_reference():
 
 
 def test_build_destination__short_array():
+    """A one-element array degrades to a null destination instead of raising on
+    the unpacking; a valid array with extra fit args still builds.
+    """
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)
 
-    # An array too short to hold a page reference and a fit type degrades to a
-    # null destination instead of raising on the unpacking.
     dest = writer._build_destination("title", ArrayObject([NumberObject(0)]))
     assert isinstance(dest["/Page"], NullObject)
 
-    # A trailing fit type with the wrong number of arguments still builds.
     dest = writer._build_destination(
         "title", ArrayObject([NumberObject(0), NameObject("/FitR"), NumberObject(1), NumberObject(2)])
     )

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -210,20 +210,18 @@ def test_build_destination__short_array():
 
 
 def test_build_destination__non_array():
+    """A non-array destination degrades to a null destination rather than
+    raising TypeError while unpacking."""
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)
 
-    # A destination that is not an array at all, such as the bare number that
-    # can appear as a value in a malformed name tree, degrades to a null
-    # destination instead of raising a TypeError on the unpacking.
     dest = writer._build_destination("title", NumberObject(5))
     assert isinstance(dest["/Page"], NullObject)
 
 
 def test_named_destinations__non_array_value():
-    # A name tree whose /Names array holds a bare number where a destination
-    # array is expected used to crash reader.named_destinations with a raw
-    # TypeError instead of skipping the malformed entry.
+    """A bare number where a destination array is expected is skipped instead
+    of crashing named_destinations with a TypeError."""
     writer = PdfWriter()
     writer.add_blank_page(width=72, height=72)
     names = DictionaryObject()


### PR DESCRIPTION
`_build_destination` already degrades a null, string, short-array or missing destination to a null destination, but a destination that is some other single object slips past that check and hits `page, typ, *array = array`, raising `TypeError: cannot unpack non-iterable ... object`. I hit this reading a PDF whose `/Names` destination tree had a bare number where a destination array was expected, which crashes `reader.named_destinations`. Tightened the guard to require an array of at least two elements so anything else falls back the same way the other invalid cases already do.