### PR TITLE
BUG: Collect the fonts declared in the AcroForm /DR dictionary

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2527,7 +2527,7 @@ def _get_fonts_walk(
     """
     fontkeys = ("/FontFile", "/FontFile2", "/FontFile3")
 
-    def process_font(f: DictionaryObject) -> None:
+    def process_font(f: PdfObject) -> None:
         nonlocal fnt, emb
         f = cast(DictionaryObject, f.get_object())  # to be sure
         if "/BaseFont" in f:
@@ -2568,7 +2568,9 @@ def _get_fonts_walk(
                 emb.add("(" + cast(str, f["/Subtype"]) + ")")
 
     if "/DR" in obj and "/Font" in cast(DictionaryObject, obj["/DR"]):
-        for f in cast(DictionaryObject, cast(DictionaryObject, obj["/DR"])["/Font"]):
+        for f in cast(
+            DictionaryObject, cast(DictionaryObject, obj["/DR"])["/Font"]
+        ).values():
             process_font(f)
     if "/Resources" in obj:
         if "/Font" in cast(DictionaryObject, obj["/Resources"]):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -16,7 +16,7 @@ from unittest import mock
 import pytest
 
 from pypdf import PdfReader, PdfWriter, Transformation
-from pypdf._page import PageObject
+from pypdf._page import PageObject, _get_fonts_walk
 from pypdf.annotations import Polygon
 from pypdf.constants import PageAttributes
 from pypdf.constants import PageAttributes as PG
@@ -664,6 +664,21 @@ def test_get_fonts2():
         },
         set(),
     )
+
+
+def test_get_fonts__acroform_default_resources():
+    """Fonts declared in the AcroForm /DR dictionary are collected too."""
+    font = DictionaryObject({
+        NameObject("/Type"): NameObject("/Font"),
+        NameObject("/Subtype"): NameObject("/Type1"),
+        NameObject("/BaseFont"): NameObject("/Helvetica"),
+    })
+    resources = DictionaryObject({
+        NameObject("/Font"): DictionaryObject({NameObject("/Helv"): font})
+    })
+    acro_form = DictionaryObject({NameObject("/DR"): resources})
+
+    assert _get_fonts_walk(acro_form, set(), set()) == ({"/Helvetica"}, set())
 
 
 def test_annotation_getter():


### PR DESCRIPTION
`_get_fonts_walk` iterates the /DR font dictionary directly:

    for f in cast(DictionaryObject, cast(DictionaryObject, obj["/DR"])["/Font"]):
        process_font(f)

Iterating a DictionaryObject yields its keys, so `process_font` receives the
font *names* rather than the font dictionaries. `/BaseFont` is never found on a
name, so every font that a form declares only in its default resources is
silently dropped from `_get_fonts()`. The /Resources branch a few lines below
already uses `.values()`, which is what made me look.

Also widened the `process_font` annotation from DictionaryObject to PdfObject.
The entries can be indirect references - that is why the function starts by
resolving its argument with `get_object()` - and a runtime protocol check
rejects them as declared. That accounts for 7 failures in test_page under
`make testtype`; they go to 0.

Added an offline test that builds an AcroForm carrying one /DR font. It fails
on main because the collected set comes back empty.

mypy reports the same 11 pre-existing errors before and after, none in this
file, and ruff check passes.
