### PR TITLE
BUG: Accept an ArrayObject when constructing a RectangleObject

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -619,7 +619,7 @@ class PageObject(DictionaryObject):
             else:
                 raise PageSizeNotDefinedError
         page.__setitem__(
-            NameObject(PG.MEDIABOX), RectangleObject((0, 0, width, height))  # type: ignore[arg-type]
+            NameObject(PG.MEDIABOX), RectangleObject((0, 0, width, height))
         )
 
         return page

--- a/pypdf/generic/_rectangle.py
+++ b/pypdf/generic/_rectangle.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Union
 
 from ._base import FloatObject, NumberObject
@@ -17,9 +18,7 @@ class RectangleObject(ArrayObject):
     * :attr:`trimbox <pypdf._page.PageObject.trimbox>`
     """
 
-    def __init__(
-        self, arr: Union["RectangleObject", tuple[float, float, float, float]]
-    ) -> None:
+    def __init__(self, arr: Sequence[Any]) -> None:
         # must have four points
         assert len(arr) == 4
         # automatically convert arr[x] into NumberObject(arr[x]) if necessary

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -543,6 +543,15 @@ def test_rectangleobject():
     assert ro.upper_right == (14, 18)
 
 
+def test_rectangleobject__accepts_an_array_object():
+    """A /MediaBox read from a PDF arrives as an ArrayObject, not a tuple."""
+    ro = RectangleObject(ArrayObject([
+        NumberObject(0), NumberObject(0), NumberObject(612), NumberObject(792)
+    ]))
+
+    assert list(ro) == [0, 0, 612, 792]
+
+
 def test_textstringobject_exc():
     tso = TextStringObject("foo")
     assert tso.get_original_bytes() == b"foo"


### PR DESCRIPTION
`RectangleObject.__init__` declares its argument as a RectangleObject or a
four-tuple, but the boxes read out of a PDF are ArrayObjects, which are
neither. Three call sites in _page.py needed `# type: ignore[arg-type]` to get
past that, and a runtime protocol check rejects the values the library itself
produces.

The implementation only needs something of length four that can be iterated -
it asserts the length and then maps `_ensure_is_number` over the elements - so
the argument is now typed `Sequence[Any]`. The elements stay `Any` because
`_ensure_is_number` accepts whatever it is handed and converts it.

One of the three ignores is dead with the wider type and is removed. The other
two stay: those callers pass `IndirectObject | None` and `PdfObject`, which
really are not sequences, so silencing them there is still correct.

Under `make testtype` this is 13 failures in test_page; they go to 0. mypy
reports the same 11 pre-existing errors before and after, and ruff check passes.

Added a test constructing a RectangleObject from an ArrayObject, which is the
shape a /MediaBox actually arrives in. It fails on main under typeguard.
