### PR TITLE
STY: Return None from remove_objects_from_page

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2071,7 +2071,7 @@ class PdfWriter(PdfDocCommon):
                 text_filters=text_filters
             )
             page.replace_contents(content)
-        return [], []  # type: ignore[return-value]
+        return None
 
     def _remove_objects_from_page__clean(
             self,


### PR DESCRIPTION
`remove_objects_from_page` is declared `-> None` and documented as returning
nothing, but its last line is:

    return [], []  # type: ignore[return-value]

The tuple is never used. All four internal callers discard it, so do the tests,
and every other exit from the function either returns None or delegates to
`_remove_annots_from_page`, which is itself `-> None`. A runtime protocol check
rejects it because the value does not match the signature.

Returns None instead, and the ignore goes with it. `return None` rather than a
bare `return` to satisfy RET502, matching the early return higher up in the
same function.

Under `make testtype` this is 6 failures in test_writer; they go to 0. mypy
reports the same 11 pre-existing errors before and after, and ruff check passes.
