### PR TITLE
STY: Type the annotation list as holding PdfObject

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3014,7 +3014,7 @@ class PdfWriter(PdfDocCommon):
 
     def _insert_filtered_annotations(
         self,
-        annots: Union[IndirectObject, list[DictionaryObject], None],
+        annots: Union[IndirectObject, list[PdfObject], None],
         page: PageObject,
         pages: dict[int, PageObject],
         reader: PdfReader,


### PR DESCRIPTION
`_insert_filtered_annotations` declares its `annots` argument as holding
DictionaryObject entries, but a page's /Annots array holds indirect references.
The function resolves each one itself:

    for an in annots:
        ano = cast("DictionaryObject", an.get_object())

so an IndirectObject is exactly what it expects, and a runtime protocol check
rejects the array the reader hands it. I checked what actually arrives by
appending a PDF with annotations: the first element is an IndirectObject.

Typed the elements as PdfObject, the common base that both the resolved
dictionaries and the references share, and which provides the `get_object`
call above.

Under `make testtype` this is 4 failures in test_writer; they go to 0. mypy
reports the same 11 pre-existing errors before and after, and ruff check passes.
