### PR TITLE
BUG: Do not scale the text leading by the font size

### DIFF
--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -119,9 +119,13 @@ def crlf_space_check(
     delta_x = m[4] - m_prev[4]
     delta_y = m[5] - m_prev[5]
     # Table 108 of the 1.7 reference ("Text positioning operators")
-    scale_prev_x = math.sqrt(tm_prev[0]**2 + tm_prev[1]**2)
-    scale_prev_y = math.sqrt(tm_prev[2]**2 + tm_prev[3]**2)
-    scale_y = math.sqrt(tm_matrix[2]**2 + tm_matrix[3]**2)
+    # delta_x/delta_y are expressed in the coordinate system produced by
+    # text matrix x current transformation matrix, so the scaling factors
+    # they get compared against have to be taken from the same combined
+    # matrices instead of the text matrices alone.
+    scale_prev_x = math.sqrt(m_prev[0]**2 + m_prev[1]**2)
+    scale_prev_y = math.sqrt(m_prev[2]**2 + m_prev[3]**2)
+    scale_y = math.sqrt(m[2]**2 + m[3]**2)
     cm_prev = m
 
     if orientation not in orientations:

--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -27,7 +27,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import math
 from typing import Any, Callable, Optional, Union
 
 from .._codecs import encoding_dict_from_named_encoding
@@ -274,8 +273,9 @@ class TextExtraction:
 
     def _handle_tl(self, operands: list[Any]) -> None:
         """Handle TL (Set Text Leading) operation - Table 5.2 page 398."""
-        scale_x = math.sqrt(self.tm_matrix[0] ** 2 + self.tm_matrix[2] ** 2)
-        self.TL = float(operands[0] if operands else 0.0) * self.font_size * scale_x
+        # The leading is measured in unscaled text space units (PDF 32000-1, 9.3.5)
+        # and T* applies the text matrix to it, so it must not be scaled here.
+        self.TL = float(operands[0] if operands else 0.0)
 
     def _handle_tf(self, operands: list[Any]) -> None:
         """Handle Tf (Set font size) operation - Table 5.2 page 398."""

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -930,3 +930,61 @@ def test_extract_text__form_xobject__limit(caplog) -> None:
     assert caplog.messages == [
         "Exceeded 100 form XObject invocations while extracting text; further form content is skipped."
     ]
+
+
+def _page_with_helvetica(content_stream: bytes) -> BytesIO:
+    """Build a single page using /F1 (Helvetica) and the given content stream."""
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+
+    helvetica = DictionaryObject()
+    helvetica[NameObject("/Type")] = NameObject("/Font")
+    helvetica[NameObject("/Subtype")] = NameObject("/Type1")
+    helvetica[NameObject("/BaseFont")] = NameObject("/Helvetica")
+    font_resources = DictionaryObject()
+    font_resources[NameObject("/F1")] = writer._add_object(helvetica)
+    resources = DictionaryObject()
+    resources[NameObject("/Font")] = font_resources
+    page[NameObject("/Resources")] = resources
+
+    content = DecodedStreamObject()
+    content.set_data(content_stream)
+    page[NameObject("/Contents")] = writer._add_object(content)
+
+    buffer = BytesIO()
+    writer.write(buffer)
+    buffer.seek(0)
+    return buffer
+
+
+def test_text_leading_is_not_scaled_by_font_size() -> None:
+    """Tests for #3982"""
+    buffer = _page_with_helvetica(
+        b"BT /F1 12 Tf 1 0 0 1 72 700 Tm 14 TL "
+        b"(Line one) Tj T* (Line two) Tj T* (Line three) Tj ET"
+    )
+
+    positions = []
+
+    def visitor_text(text, cm, tm, font_dict, font_size) -> None:
+        if text.strip():
+            positions.append(round(tm[5], 2))
+
+    text = PdfReader(buffer).pages[0].extract_text(visitor_text=visitor_text)
+
+    # T* moves down by the leading itself: 14 units, not 14 * 12 (the font size).
+    assert positions == [700.0, 686.0, 672.0]
+    assert text == "Line one\nLine two\nLine three"
+
+
+def test_line_breaks_with_scaled_current_matrix() -> None:
+    """Tests for #2262: the line height has to be compared in the same space."""
+    # The lines are 240 units apart in text space, which the CTM scales down to
+    # 12 units, matching a 200 pt font scaled down to 10 pt.
+    buffer = _page_with_helvetica(
+        b"q 0.05 0 0 0.05 0 0 cm "
+        b"BT /F1 200 Tf 1 0 0 1 200 14000 Tm (Line one) Tj "
+        b"1 0 0 1 200 13760 Tm (Line two) Tj ET Q"
+    )
+
+    assert PdfReader(buffer).pages[0].extract_text() == "Line one\nLine two"


### PR DESCRIPTION
Closes #3982.

## Problem

`TL` sets the text leading, which per PDF 32000-1 §9.3.5 is a distance in *unscaled text space units*, and `T*` is defined as `0 -Tl Td` — the text matrix is what scales it. `_handle_tl` multiplied the operand by the font size (and the text matrix scale) before storing it:

```python
scale_x = math.sqrt(self.tm_matrix[0] ** 2 + self.tm_matrix[2] ** 2)
self.TL = float(operands[0] if operands else 0.0) * self.font_size * scale_x
```

so every `T*` moved the text matrix by `TL * font size` per line. With `14 TL` and a 12 pt font, `visitor_text` reported lines 168 units apart instead of 14. Bisected to fcb103a7 (#2890), first released in 5.1.0.

## Fix

`_handle_tl` stores the operand unchanged. `T*` already applies the text matrix to it (`tm[4] -= TL * tm[2]`, `tm[5] -= TL * tm[3]`, i.e. `0 -Tl Td`), so no pre-scaling is correct.

#2890 introduced that scaling to fix #2262 (missing line breaks), so the second change addresses the actual cause of #2262. In `crlf_space_check`, `delta_x`/`delta_y` are computed from `m = tm x cm`, but the quantities they are compared against (`str_height`, `font_size`, `spacewidth`, `str_widths` — all unscaled text space values) were scaled by the text matrix alone:

```diff
-    scale_prev_x = math.sqrt(tm_prev[0]**2 + tm_prev[1]**2)
-    scale_prev_y = math.sqrt(tm_prev[2]**2 + tm_prev[3]**2)
-    scale_y = math.sqrt(tm_matrix[2]**2 + tm_matrix[3]**2)
+    scale_prev_x = math.sqrt(m_prev[0]**2 + m_prev[1]**2)
+    scale_prev_y = math.sqrt(m_prev[2]**2 + m_prev[3]**2)
+    scale_y = math.sqrt(m[2]**2 + m[3]**2)
```

Any page whose CTM scales the text down therefore lost its line breaks, and inflating `TL` only hid that for lines positioned by `T*`. Comparing in the same space fixes it generally, including lines positioned by `Tm` or `Td`, which the `TL` scaling never covered. Removing only the `TL` scaling makes the existing `test_text_leading_height_unit` fail, so the two changes belong together.

This also brings plain mode in line with layout mode, which already treats `TL` as an unscaled distance (`add_tm([0, -text_state_mgr.TL])`).

## Verification

Two regression tests, each pinning one half of the fix:

| | main | TL fix only | `crlf_space_check` fix only | both |
|---|---|---|---|---|
| `test_text_leading_is_not_scaled_by_font_size` (new, #3982) | fail | pass | fail | pass |
| `test_line_breaks_with_scaled_current_matrix` (new, #2262 class) | fail | fail | pass | pass |
| `test_text_leading_height_unit` (existing, #2262) | pass | fail | pass | pass |

Effect on extraction output, measured over 442 PDFs (`tests/pdf_cache`, `sample-files`, `resources`; first 8 pages, both extraction modes):

- layout mode: no change at all
- plain mode: 63 files change — 38 from the `TL` change, 26 from the `crlf_space_check` change, 1 from both
- in all 63, the extracted text is identical once spaces and newlines are stripped; only line and space segmentation moves

Samples (main → this PR):

- `sample-files/011-google-doc-document`: the Zen of Python lines were concatenated onto one line, now one per line
- `Giacalone.pdf`: `Davide Giacalone\na , *\n, Fabien Llobell\nb` → `Davide Giacalone a,*, Fabien Llobell b`
- `tika-934771.pdf`: `further investi\n-\ngations` → `further investi-\ngations`
- `iss2958.pdf`, `srcwatermark.pdf`, `tika-959184.pdf` (CTM-scaled title pages and drawings): line breaks appear where the text was previously run together

Full test suite passes locally (1454 passed, 16 skipped, 2 xfailed, 1 xpassed — the xpass is the pre-existing `test_issue_2336`, which behaves identically on unmodified main), as do `ruff check pypdf tests` and `mypy pypdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
