### PR TITLE
STY: Type the destination and field trees as DictionaryObject

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -460,7 +460,7 @@ class PdfDocCommon(ABC):
     def _get_named_destinations(
         self,
         *,
-        tree: Union[TreeObject, DictionaryObject, None] = None,
+        tree: Optional[DictionaryObject] = None,
         retval: Optional[dict[str, Destination]] = None,
         visited: Optional[set[int]] = None,
     ) -> dict[str, Destination]:
@@ -546,7 +546,7 @@ class PdfDocCommon(ABC):
 
     def get_fields(
         self,
-        tree: Union[TreeObject, DictionaryObject, None] = None,
+        tree: Optional[DictionaryObject] = None,
         retval: Optional[dict[Any, Any]] = None,
         fileobj: Optional[Any] = None,
         stack: Optional[list[PdfObject]] = None,

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -460,7 +460,7 @@ class PdfDocCommon(ABC):
     def _get_named_destinations(
         self,
         *,
-        tree: Union[TreeObject, None] = None,
+        tree: Union[TreeObject, DictionaryObject, None] = None,
         retval: Optional[dict[str, Destination]] = None,
         visited: Optional[set[int]] = None,
     ) -> dict[str, Destination]:
@@ -484,11 +484,11 @@ class PdfDocCommon(ABC):
 
             # get the name tree
             if CA.DESTS in catalog:
-                tree = cast(TreeObject, catalog[CA.DESTS])
+                tree = cast(DictionaryObject, catalog[CA.DESTS])
             elif CA.NAMES in catalog:
                 names = cast(DictionaryObject, catalog[CA.NAMES])
                 if CA.DESTS in names:
-                    tree = cast(TreeObject, names[CA.DESTS])
+                    tree = cast(DictionaryObject, names[CA.DESTS])
 
         if is_null_or_none(tree):
             return retval
@@ -546,7 +546,7 @@ class PdfDocCommon(ABC):
 
     def get_fields(
         self,
-        tree: Optional[TreeObject] = None,
+        tree: Union[TreeObject, DictionaryObject, None] = None,
         retval: Optional[dict[Any, Any]] = None,
         fileobj: Optional[Any] = None,
         stack: Optional[list[PdfObject]] = None,
@@ -578,7 +578,7 @@ class PdfDocCommon(ABC):
             stack = []
             # get the AcroForm tree
             if CA.ACRO_FORM in catalog:
-                tree = cast(Optional[TreeObject], catalog[CA.ACRO_FORM])
+                tree = cast(Optional[DictionaryObject], catalog[CA.ACRO_FORM])
             else:
                 return None
         if tree is None:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -1608,7 +1608,7 @@ class PdfReader(PdfDocCommon):
     def _get_named_destinations(
         self,
         *,
-        tree: Union[TreeObject, None] = None,
+        tree: Union[TreeObject, DictionaryObject, None] = None,
         retval: Optional[dict[str, Destination]] = None,
         visited: Optional[set[int]] = None,
     ) -> dict[str, Destination]:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -85,7 +85,6 @@ from .generic import (
     PdfObject,
     StreamObject,
     TextStringObject,
-    TreeObject,
     is_null_or_none,
     read_object,
 )
@@ -1608,7 +1607,7 @@ class PdfReader(PdfDocCommon):
     def _get_named_destinations(
         self,
         *,
-        tree: Union[TreeObject, DictionaryObject, None] = None,
+        tree: Optional[DictionaryObject] = None,
         retval: Optional[dict[str, Destination]] = None,
         visited: Optional[set[int]] = None,
     ) -> dict[str, Destination]:


### PR DESCRIPTION
`_get_named_destinations` and `_get_fields` both walk trees that are plain dictionaries at runtime. A name tree node holds `/Kids` or `/Names`, and the AcroForm is a dictionary too — neither is a `TreeObject`, and neither function calls anything `TreeObject` adds on top of `DictionaryObject`. Both only do dictionary access.

The casts asserted `TreeObject` on objects that are `DictionaryObject`, so a typeguard run reports 16 failures across the reader, writer and form tests. `_check_kids` in the same file already takes `Union[TreeObject, DictionaryObject]`, so I followed that.

Reverting the change brings the 16 failures back.