### PR TITLE
STY: Type the second argument of mult as the mapping it also accepts

### DIFF
--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -5,6 +5,7 @@ Some parts are still in _page.py. In doubt, they will stay there.
 """
 
 import math
+from collections.abc import Mapping
 from typing import Any, Callable, Optional, Union
 
 from .._font import Font
@@ -71,7 +72,9 @@ def set_custom_rtl(
     return CUSTOM_RTL_MIN, CUSTOM_RTL_MAX, CUSTOM_RTL_SPECIAL_CHARS
 
 
-def mult(m: list[float], n: list[float]) -> list[float]:
+def mult(
+    m: list[float], n: Union[list[float], Mapping[Union[int, str], Union[float, bool]]]
+) -> list[float]:
     return [
         m[0] * n[0] + m[1] * n[2],
         m[0] * n[1] + m[1] * n[3],

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -6,7 +6,7 @@ Some parts are still in _page.py. In doubt, they will stay there.
 
 import math
 from collections.abc import Mapping
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union
 
 from .._font import Font
 from .._utils import is_char_neutral, is_char_rtl
@@ -73,7 +73,11 @@ def set_custom_rtl(
 
 
 def mult(
-    m: list[float], n: Union[list[float], Mapping[Union[int, str], Union[float, bool]]]
+    m: list[float],
+    n: Union[
+        list[float],
+        Mapping[Union[int, Literal["is_text", "is_render"]], Union[float, bool]],
+    ],
 ) -> list[float]:
     return [
         m[0] * n[0] + m[1] * n[2],

--- a/pypdf/_text_extraction/_layout_mode/_text_state_manager.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_manager.py
@@ -199,5 +199,5 @@ class TextStateManager:
         """Current effective transform accounting for cm, tm, and trm transforms"""
         eff_transform = [*self.transform_stack.maps[0].values()]
         for transform in self.transform_stack.maps[1:]:
-            eff_transform = mult(eff_transform, transform)  # type: ignore[arg-type]  # dict has int keys 0-5
+            eff_transform = mult(eff_transform, transform)
         return eff_transform

--- a/pypdf/_text_extraction/_layout_mode/_text_state_manager.py
+++ b/pypdf/_text_extraction/_layout_mode/_text_state_manager.py
@@ -4,15 +4,16 @@ from collections import ChainMap, Counter
 from collections import ChainMap as ChainMapType
 from collections import Counter as CounterType
 from collections.abc import MutableMapping
-from typing import Any, Union
+from typing import Any, Literal, Union
 
 from ..._font import Font
 from ...errors import PdfReadError
 from .. import mult
 from ._text_state_params import TextStateParams
 
-TextStateManagerChainMapType = ChainMapType[Union[int, str], Union[float, bool]]
-TextStateManagerDictType = MutableMapping[Union[int, str], Union[float, bool]]
+TextStateManagerKeyType = Union[int, Literal["is_text", "is_render"]]
+TextStateManagerChainMapType = ChainMapType[TextStateManagerKeyType, Union[float, bool]]
+TextStateManagerDictType = MutableMapping[TextStateManagerKeyType, Union[float, bool]]
 
 
 class TextStateManager:


### PR DESCRIPTION
`effective_transform` passes the entries of a `ChainMap` into `mult`, which was annotated to take two lists. The call carried a `# type: ignore[arg-type]` with a comment noting that the dict has integer keys 0-5.

`mult` only reads keys 0 through 5. The ChainMap holds those alongside the `is_text` and `is_render` flags, so it satisfies the function as it stands. Annotating that removes eight typeguard failures in the text extraction and page tests, and the suppression along with them.

Reverting brings the eight back.