### PR TITLE
STY: Accept any sequence of fit arguments in Fit

### DIFF
--- a/pypdf/generic/_fit.py
+++ b/pypdf/generic/_fit.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Any, Optional, Union
 
 from ._base import is_null_or_none
@@ -5,7 +6,7 @@ from ._base import is_null_or_none
 
 class Fit:
     def __init__(
-        self, fit_type: str, fit_args: tuple[Union[float, Any, None], ...] = ()
+        self, fit_type: str, fit_args: Sequence[Union[float, Any, None]] = ()
     ) -> None:
         from ._base import FloatObject, NameObject, NullObject, NumberObject  # noqa: PLC0415
 


### PR DESCRIPTION
`Fit` was annotated to take a tuple, but `_build_destination` unpacks the destination array and hands the remainder over as a list, and `_writer` passes the list stored under `/fit_args`. The constructor only iterates over the argument, so a list satisfies it as well as a tuple.

Typed as the sequence it consumes, which clears four typeguard failures in the annotation and outline tests.

I left the `# type: ignore[arg-type]` in `_build_destination` in place — removing it surfaces a separate complaint about `fit_type` that is outside what this change is about.
