### PR TITLE
STY: Accept any sequence as the annotation border

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -34,7 +34,7 @@ import re
 import struct
 import sys
 import uuid
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from io import BytesIO, FileIO, IOBase
 from itertools import compress
 from pathlib import Path
@@ -2285,7 +2285,7 @@ class PdfWriter(PdfDocCommon):
         page_number: int,
         uri: str,
         rect: RectangleObject,
-        border: Optional[ArrayObject] = None,
+        border: Optional[Sequence[Any]] = None,
     ) -> None:
         """
         Add an URI from a rectangular area to the specified page.

--- a/pypdf/annotations/_non_markup_annotations.py
+++ b/pypdf/annotations/_non_markup_annotations.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ..generic._base import (
@@ -17,7 +18,7 @@ class Link(AnnotationDictionary):
         self,
         *,
         rect: Union[RectangleObject, tuple[float, float, float, float]],
-        border: Optional[ArrayObject] = None,
+        border: Optional[Sequence[Any]] = None,
         url: Optional[str] = None,
         target_page_index: Optional[int] = None,
         fit: Fit = DEFAULT_FIT,


### PR DESCRIPTION
The `Link` annotation and `add_link` both declare `border` as an `ArrayObject`, but the argument is only sliced and indexed, and the documented usage is a plain list — the tests pass `[1, 0, 6, [3, 2]]` and `[50, 10, 4]`, and the docstring asks for "an array describing border-drawing properties" rather than a specific pypdf type.

Typed as the sequence both functions consume, which clears the two typeguard failures in the annotation tests.
