### PR TITLE
BUG: Be more lenient about space width in layout mode text extraction

### DIFF
--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -168,7 +168,7 @@ def recurse_to_target_op(
                     # applied to the first tj of a BTGroup in fixed_width_page().
                     excess_tx = round(_tj.tx - last_displaced_tx, 3) * (_idx != bt_idx)
                     # space_tx could be 0 if either Tz or font_size was 0 for this _tj.
-                    spaces = int(excess_tx // _tj.space_tx) if _tj.space_tx else 0
+                    spaces = round(excess_tx / _tj.space_tx) if excess_tx > 0 else 0
                     if spaces > WHITESPACE_LIMIT:
                         logger_warning(
                             "Limiting excessive whitespace from %(actual)d to %(limit)d characters.",

--- a/resources/crazyones_layout_vertical_space.txt
+++ b/resources/crazyones_layout_vertical_space.txt
@@ -1,19 +1,19 @@
 The Crazy Ones
 October 14, 1998
 
-   Heres to the crazy ones. The misﬁts. The rebels. The troublemakers.
+   Heres to the crazy ones.  The misﬁts.  The rebels.  The troublemakers.
        The round pegs in the square holes.
-   The ones who see things diﬀerently. Theyre not fond of rules. And
-       they have no respect for the status quo. You can quote them,
+   The ones who see things diﬀerently.  Theyre not fond of rules.  And
+       they have no respect for the status quo.  You can quote them,
        disagree with them, glorify or vilify them.
-   About the only thing you cant do is ignore them. Because they change
-       things. They invent. They imagine. They heal. They explore. They
-       create. They inspire. They push the human race forward.
+   About the only thing you cant do is ignore them.  Because they change
+       things.  They invent.  They imagine.  They heal.  They explore.  They
+       create.  They inspire.  They push the human race forward.
    Maybe they have to be crazy.
-   How else can you stare at an empty canvas and see a work of art? Or
-       sit in silence and hear a song thats never been written? Or gaze at
+   How else can you stare at an empty canvas and see a work of art?  Or
+       sit in silence and hear a song thats never been written?  Or gaze at
        a red planet and see a laboratory on wheels?
    We make tools for these kinds of people.
-   While some see them as the crazy ones, we see genius. Because the
+   While some see them as the crazy ones, we see genius.  Because the
        people who are crazy enough to think they can change the world,
        are the ones who do.

--- a/resources/crazyones_layout_vertical_space_font_height_weight.txt
+++ b/resources/crazyones_layout_vertical_space_font_height_weight.txt
@@ -1,25 +1,25 @@
 The Crazy Ones
 October 14, 1998
 
-   Heres to the crazy ones. The misﬁts. The rebels. The troublemakers.
+   Heres to the crazy ones.  The misﬁts.  The rebels.  The troublemakers.
        The round pegs in the square holes.
 
-   The ones who see things diﬀerently. Theyre not fond of rules. And
-       they have no respect for the status quo. You can quote them,
+   The ones who see things diﬀerently.  Theyre not fond of rules.  And
+       they have no respect for the status quo.  You can quote them,
        disagree with them, glorify or vilify them.
 
-   About the only thing you cant do is ignore them. Because they change
-       things. They invent. They imagine. They heal. They explore. They
-       create. They inspire. They push the human race forward.
+   About the only thing you cant do is ignore them.  Because they change
+       things.  They invent.  They imagine.  They heal.  They explore.  They
+       create.  They inspire.  They push the human race forward.
 
    Maybe they have to be crazy.
 
-   How else can you stare at an empty canvas and see a work of art? Or
-       sit in silence and hear a song thats never been written? Or gaze at
+   How else can you stare at an empty canvas and see a work of art?  Or
+       sit in silence and hear a song thats never been written?  Or gaze at
        a red planet and see a laboratory on wheels?
 
    We make tools for these kinds of people.
 
-   While some see them as the crazy ones, we see genius. Because the
+   While some see them as the crazy ones, we see genius.  Because the
        people who are crazy enough to think they can change the world,
        are the ones who do.

--- a/resources/multicolumn-lorem-ipsum.txt
+++ b/resources/multicolumn-lorem-ipsum.txt
@@ -1,44 +1,44 @@
-                        Two-Column Document with Lorem Ipsum
+                         Two-Column Document with Lorem Ipsum
 
-                                                         Your Name
-                                                     January 3, 2024
+                                                            Your Name
+                                                        January 3, 2024
 
-Abstract                                                          pellentesque ante.  Phasellus adipiscing semper elit.
-                                                                  Proin fermentum massa ac quam.  Sed diam turpis,
-This is a sample document with two columns ﬁlled                  molestie vitae, placerat a, molestie nec, leo.  Maece-
-with Lorem Ipsum text.                                            nas lacinia. Nam ipsum ligula, eleifend at, accumsan
-  Lorem ipsum dolor sit amet,  consectetuer adip-                 nec, suscipit a, ipsum.  Morbi blandit ligula feugiat
-iscing elit.   Ut purus elit, vestibulum ut, placerat             magna.  Nunc eleifend consequat lorem.  Sed lacinia
-ac, adipiscing vitae, felis. Curabitur dictum gravida             nulla vitae enim.   Pellentesque tincidunt purus vel
-mauris.     Nam  arcu  libero,  nonummy  eget,  con-              magna.  Integer non enim.  Praesent euismod nunc
-sectetuer id, vulputate a, magna.   Donec vehicula                eu purus.  Donec bibendum quam in tellus.  Nullam
-augue eu neque.   Pellentesque habitant morbi tris-               cursus pulvinar lectus.  Donec et mi.  Nam vulpu-
-tique senectus et netus et malesuada fames ac turpis              tate metus eu enim. Vestibulum pellentesque felis eu
-egestas.   Mauris ut leo.   Cras viverra metus rhon-              massa.
-cus sem.   Nulla et lectus vestibulum urna fringilla                 Quisque ullamcorper placerat ipsum.  Cras nibh.
-ultrices.  Phasellus eu tellus sit amet tortor gravida            Morbi vel justo vitae lacus tincidunt ultrices. Lorem
-placerat. Integer sapien est, iaculis in, pretium quis,           ipsum dolor sit amet, consectetuer adipiscing elit. In
-viverra ac, nunc.   Praesent eget sem vel leo ultri-              hachabitasseplateadictumst. Integertempusconva-
-ces bibendum.  Aenean faucibus.  Morbi dolor nulla,               llis augue. Etiam facilisis. Nunc elementum fermen-
-malesuada eu, pulvinar at, mollis ac, nulla.   Cur-               tum wisi.  Aenean placerat.  Ut imperdiet, enim sed
-abitur auctor semper nulla.  Donec varius orci eget               gravida sollicitudin, felis odio placerat quam, ac pul-
-risus.  Duis nibh mi, congue eu, accumsan eleifend,               vinar elit purus eget enim. Nunc vitae tortor. Proin
-sagittis quis, diam. Duis eget orci sit amet orci dig-            tempus nibh sit amet nisl. Vivamus quis tortor vitae
-nissim rutrum.                                                    risus porta vehicula.
+Abstract                                                              pellentesque ante.  Phasellus adipiscing semper elit.
+                                                                      Proin fermentum massa ac quam.  Sed diam turpis,
+This  is  a  sample  document  with  two  columns  ﬁlled              molestie vitae, placerat a, molestie nec, leo.  Maece-
+with Lorem Ipsum text.                                                nas lacinia.  Nam ipsum ligula, eleifend at, accumsan
+  Lorem  ipsum  dolor  sit  amet,  consectetuer  adip-                nec,  suscipit a,  ipsum.  Morbi blandit ligula feugiat
+iscing  elit.   Ut  purus  elit,  vestibulum  ut,  placerat           magna.  Nunc eleifend consequat lorem.  Sed lacinia
+ac, adipiscing vitae, felis.  Curabitur dictum gravida                nulla  vitae  enim.   Pellentesque  tincidunt  purus  vel
+mauris.     Nam  arcu  libero,   nonummy  eget,   con-                magna.   Integer  non  enim.   Praesent  euismod  nunc
+sectetuer  id,  vulputate  a,  magna.   Donec  vehicula               eu purus.  Donec bibendum quam in tellus.  Nullam
+augue  eu  neque.   Pellentesque  habitant  morbi  tris-              cursus  pulvinar  lectus.   Donec  et  mi.   Nam  vulpu-
+tique senectus et netus et malesuada fames ac turpis                  tate metus eu enim.  Vestibulum pellentesque felis eu
+egestas.   Mauris  ut  leo.   Cras  viverra  metus  rhon-             massa.
+cus  sem.   Nulla  et  lectus  vestibulum  urna  fringilla               Quisque  ullamcorper  placerat  ipsum.   Cras  nibh.
+ultrices.  Phasellus eu tellus sit amet tortor gravida                Morbi vel justo vitae lacus tincidunt ultrices.  Lorem
+placerat.  Integer sapien est, iaculis in, pretium quis,              ipsum dolor sit amet, consectetuer adipiscing elit.  In
+viverra  ac,  nunc.   Praesent  eget  sem  vel  leo  ultri-           hac habitasse platea dictumst.  Integer tempus conva-
+ces bibendum.  Aenean faucibus.  Morbi dolor nulla,                   llis augue.  Etiam facilisis.  Nunc elementum fermen-
+malesuada  eu,  pulvinar  at,  mollis  ac,  nulla.   Cur-             tum wisi.  Aenean placerat.  Ut imperdiet, enim sed
+abitur  auctor  semper  nulla.   Donec  varius  orci  eget            gravida sollicitudin, felis odio placerat quam, ac pul-
+risus.   Duis  nibh  mi,  congue  eu,  accumsan  eleifend,            vinar elit purus eget enim.  Nunc vitae tortor.  Proin
+sagittis quis, diam.  Duis eget orci sit amet orci dig-               tempus nibh sit amet nisl.  Vivamus quis tortor vitae
+nissim rutrum.                                                        risus porta vehicula.
   Nam dui ligula, fringilla a, euismod sodales, sollic-
-itudin vel, wisi. Morbi auctor lorem non justo. Nam                  Fusce mauris.  Vestibulum luctus nibh at lectus.
-lacus libero, pretium at, lobortis vitae, ultricies et,           Sed bibendum, nulla a faucibus semper, leo velit ul-
-tellus.   Donec aliquet, tortor sed accumsan biben-               tricies tellus, ac venenatis arcu wisi vel nisl. Vestibu-
-dum,  erat ligula aliquet magna,  vitae ornare odio               lum diam. Aliquam pellentesque, augue quis sagittis
-metus a mi.  Morbi ac orci et nisl hendrerit mollis.              posuere, turpis lacus congue quam, in hendrerit risus
-Suspendisse ut massa.  Cras nec ante.  Pellentesque               eros eget felis.  Maecenas eget erat in sapien mattis
-a nulla. Cum sociis natoque penatibus et magnis dis               porttitor.  Vestibulum porttitor.  Nulla facilisi.  Sed
-parturient montes, nascetur ridiculus mus. Aliquam                a turpis eu lacus commodo facilisis.  Morbi fringilla,
-tincidunturna. Nullaullamcorpervestibulumturpis.                  wisi in dignissim interdum, justo lectus sagittis dui,
-Pellentesque cursus luctus mauris.                                et vehicula libero dui cursus dui.   Mauris tempor
-  Nulla malesuada porttitor diam. Donec felis erat,               ligula sed lacus.  Duis cursus enim ut augue.  Cras
-congue non, volutpat at, tincidunt tristique, libero.             ac magna.  Cras nulla.  Nulla egestas.  Curabitur a
-Vivamus viverra fermentum felis.  Donec nonummy                   leo.   Quisque egestas wisi eget nunc.   Nam feugiat
+itudin vel, wisi.  Morbi auctor lorem non justo.  Nam                    Fusce  mauris.   Vestibulum  luctus  nibh  at  lectus.
+lacus  libero,  pretium  at,  lobortis  vitae,  ultricies  et,        Sed bibendum, nulla a faucibus semper, leo velit ul-
+tellus.   Donec  aliquet,  tortor  sed  accumsan  biben-              tricies tellus, ac venenatis arcu wisi vel nisl.  Vestibu-
+dum,  erat  ligula  aliquet  magna,  vitae  ornare  odio              lum diam.  Aliquam pellentesque, augue quis sagittis
+metus  a  mi.   Morbi  ac  orci  et  nisl  hendrerit  mollis.         posuere, turpis lacus congue quam, in hendrerit risus
+Suspendisse ut massa.  Cras nec ante.  Pellentesque                   eros eget felis.  Maecenas eget erat in sapien mattis
+a nulla.  Cum sociis natoque penatibus et magnis dis                  porttitor.  Vestibulum porttitor.  Nulla facilisi.  Sed
+parturient montes, nascetur ridiculus mus.  Aliquam                   a turpis eu lacus commodo facilisis.  Morbi fringilla,
+tincidunt urna.  Nulla ullamcorper vestibulum turpis.                 wisi in dignissim interdum, justo lectus sagittis dui,
+Pellentesque cursus luctus mauris.                                    et  vehicula  libero  dui  cursus  dui.    Mauris  tempor
+  Nulla malesuada porttitor diam.  Donec felis erat,                  ligula  sed  lacus.   Duis  cursus  enim  ut  augue.   Cras
+congue  non,  volutpat  at,  tincidunt  tristique,  libero.           ac  magna.   Cras  nulla.   Nulla  egestas.   Curabitur  a
+Vivamus  viverra  fermentum  felis.   Donec  nonummy                  leo.   Quisque  egestas  wisi  eget  nunc.   Nam  feugiat
 
 
-                                                                1
+                                                                    1

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -668,7 +668,7 @@ def test_recurse_to_target_op__excessive_intra_group_spacing(caplog):
             "ty": 700.0
         }
     ]
-    assert caplog.messages == ["Limiting excessive whitespace from 299757 to 10000 characters."]
+    assert caplog.messages == ["Limiting excessive whitespace from 299758 to 10000 characters."]
 
 
 def test_fixed_width_page__excessive_blank_lines(caplog):


### PR DESCRIPTION
When extracting text from PDF documents that indicate spaces through Td operators, we currently use a floor division of unaccounted text width by space width. As a result, all cases where space width is larger then unaccounted text width are not counted as spaces. This patch takes a normal division instead and rounds it to an integer. As a result, an excess text width of around half a space or larger will be added as a space in the output. I'm assuming that the same works for documents that specify spaces using vertical displacement in TJ operators.

This problem often applies to documents produced by latex, which usually do not use space characters but TJ operators for showing a space.

This patch changes the output of the text extraction of two documents in our test suite. First, for The Crazy Ones, it adds one extra space bweteen each of the sentences on the first line. This appears to be in line with Latex PDF output, which adds more space between sentences than between regular words.

For the multicolumn Lorem Ipsum test document, it adds quite a number of spaces in the output. Most importantly, though, it includes the following changes:

```
- tincidunturna. Nullaullamcorpervestibulumturpis.
+ tincidunt urna.  Nulla ullamcorper vestibulum turpis.
```

and:

```
- hachabitasseplateadictumst. Integertempusconva-
+ hac habitasse platea dictumst.  Integer tempus conva-
```

Clearly, these spaces should have been there in the first place. With that, I assume that no further tests for this patch are needed.

This patch was generated by Google Gemini after an AI-assisted bug-hunting process.

Fixes most of https://github.com/py-pdf/pypdf/issues/3973