### PR TITLE
MAINT: Skip `test_appearance_stream_rtl` when RTL support is unavailable

### DIFF
--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -18,7 +18,12 @@ from pypdf.generic import (
     NumberObject,
     RectangleObject,
 )
-from pypdf.generic._appearance_stream import BaseStreamAppearance, BaseStreamConfig, TextStreamAppearance
+from pypdf.generic._appearance_stream import (
+    HAS_RTL_SUPPORT,
+    BaseStreamAppearance,
+    BaseStreamConfig,
+    TextStreamAppearance,
+)
 
 from . import RESOURCE_ROOT
 
@@ -121,7 +126,7 @@ Option D
     )
     assert b"OneWord" in appearance_stream.get_data()
 
-
+@pytest.mark.skipif(not HAS_RTL_SUPPORT, reason="Requires arabic-reshaper and python-bidi")
 def test_appearance_stream_rtl():
     writer = PdfWriter(RESOURCE_ROOT / "fontsampler.pdf")
     layout = BaseStreamConfig(


### PR DESCRIPTION
The RTL support already degrades gracefully if `arabic-reshaper` and `python-bidi` optional dependencies are not installed. Use `HAS_RTL_SUPPORT` for `test_appearance_stream_rtl` as well.

I actually noticed this when upgrading the Fedora package to version 6.15.0. Neither dependency is currently packaged in Fedora so I had to deselect the test by hand in the SPEC file. But I would strongly prefer to avoid that because it gets tedious to hand-maintain deselection in the long run.

## Steps to test

1. Create a new virtual environment, go to pypdf's source directory and install all the runtime and development deps with:

```
pip install -e .[full,dev]
```

2. Run all appearance stream tests. They should all pass:

```
$ pytest -v tests/test_appearance_stream.py
==================================================== test session starts =====================================================
platform linux -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /home/tadej/.local/share/virtualenvs/pypdf-rtl-tests/bin/python
cachedir: .pytest_cache
rootdir: /home/tadej/Code/pypdf
configfile: pyproject.toml
plugins: xdist-3.8.0, socket-0.8.1, cov-7.1.0, timeout-2.4.0
collected 16 items                                                                                                           

tests/test_appearance_stream.py::test_comb PASSED                                                                      [  6%]
tests/test_appearance_stream.py::test_scale_text PASSED                                                                [ 12%]
tests/test_appearance_stream.py::test_appearance_stream_rtl PASSED                                                     [ 18%]
tests/test_appearance_stream.py::test_appearance_stream__no_rtl_support[arabic_reshaper] PASSED                        [ 25%]
tests/test_appearance_stream.py::test_appearance_stream__no_rtl_support[bidi] PASSED                                   [ 31%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[0-None] PASSED                                       [ 37%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[90-outcome1] PASSED                                  [ 43%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[180-outcome2] PASSED                                 [ 50%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[270-outcome3] PASSED                                 [ 56%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[360-None] PASSED                                     [ 62%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_ap_but_no_normal_state PASSED             [ 68%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_malformed_normal_state PASSED             [ 75%]
tests/test_appearance_stream.py::test_merge_transformed_page_updates_annotation_appearance_matrix PASSED               [ 81%]
tests/test_appearance_stream.py::test_merge_transformed_page_composes_existing_annotation_matrix PASSED                [ 87%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_without_appearance_stream PASSED               [ 93%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_multi_state_appearance PASSED             [100%]

===================================================== 16 passed in 1.41s =====================================================
```

3. Uninstall `arabic-reshaper` and `python-bidi`, re-run the tests. The `test_appearance_stream_rtl` should fail:

```
$ pip uninstall -y arabic-reshaper python-bidi
Found existing installation: arabic-reshaper 3.0.1
Uninstalling arabic-reshaper-3.0.1:
  Successfully uninstalled arabic-reshaper-3.0.1
Found existing installation: python-bidi 0.6.11
Uninstalling python-bidi-0.6.11:
  Successfully uninstalled python-bidi-0.6.11
$ pytest -v tests/test_appearance_stream.py
==================================================== test session starts =====================================================
platform linux -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /home/tadej/.local/share/virtualenvs/pypdf-rtl-tests/bin/python
cachedir: .pytest_cache
rootdir: /home/tadej/Code/pypdf
configfile: pyproject.toml
plugins: xdist-3.8.0, socket-0.8.1, cov-7.1.0, timeout-2.4.0
collected 16 items                                                                                                           

tests/test_appearance_stream.py::test_comb PASSED                                                                      [  6%]
tests/test_appearance_stream.py::test_scale_text PASSED                                                                [ 12%]
tests/test_appearance_stream.py::test_appearance_stream_rtl FAILED                                                     [ 18%]
tests/test_appearance_stream.py::test_appearance_stream__no_rtl_support[arabic_reshaper] PASSED                        [ 25%]
tests/test_appearance_stream.py::test_appearance_stream__no_rtl_support[bidi] PASSED                                   [ 31%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[0-None] PASSED                                       [ 37%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[90-outcome1] PASSED                                  [ 43%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[180-outcome2] PASSED                                 [ 50%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[270-outcome3] PASSED                                 [ 56%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[360-None] PASSED                                     [ 62%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_ap_but_no_normal_state PASSED             [ 68%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_malformed_normal_state PASSED             [ 75%]
tests/test_appearance_stream.py::test_merge_transformed_page_updates_annotation_appearance_matrix PASSED               [ 81%]
tests/test_appearance_stream.py::test_merge_transformed_page_composes_existing_annotation_matrix PASSED                [ 87%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_without_appearance_stream PASSED               [ 93%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_multi_state_appearance PASSED             [100%]

========================================================== FAILURES ==========================================================
_________________________________________________ test_appearance_stream_rtl _________________________________________________

    def test_appearance_stream_rtl():
        writer = PdfWriter(RESOURCE_ROOT / "fontsampler.pdf")
        layout = BaseStreamConfig(
            rectangle=RectangleObject([0, 0, 250, 30]),
            border_width=0
        )
        test_string = "!مرحبا بالعالم Hello World!"
        font_name = "/F7"
        font_resource = writer.pages[0]["/Resources"]["/Font"][font_name]
        font = Font.from_font_resource(font_resource)
        reverse_cmap, encoding_cmap = font._get_typographic_maps()
        unshaped_test_glyphs = [reverse_cmap[char] for char in test_string]
        hex_unshaped_test_glyphs = "".join(encoding_cmap[glyph_id].hex() for glyph_id in unshaped_test_glyphs)
        shaped_test_string = "!\ufee3\ufeae\ufea3\ufe92\ufe8e \ufe91\ufe8e\ufedf\ufecc\ufe8e\ufedf\ufee2 Hello World!"
        shaped_test_glyphs = [reverse_cmap[char] for char in shaped_test_string]
        # Reverse the arabic part of the test string to enable comparison with the RTL-supported case.
        hex_shaped_test_glyphs = "".join(
            encoding_cmap[glyph_id].hex()
            for glyph_id in shaped_test_glyphs[:1] + shaped_test_glyphs[1:14][::-1] + shaped_test_glyphs[14:]
        )
        appearance = TextStreamAppearance(
            layout=layout,
            text=test_string,
            font_resource=font_resource,
            font=font,
            font_name=font_name,
            font_size=12.0,
            font_color="0 g",
            is_multiline=False
        )
        # The regex returns two matches. The first matches the text in /Span << /ActualText <[group 0]> >> BDC
        # The second match concerns the encoded text data.
        [hex_actual_text, hex_glyphs_rtl_enabled] = re.findall("<([a-zA-Z0-9]+?)> ", appearance.get_data().decode())
        assert bytes.fromhex(hex_actual_text).decode("utf-16-be") == "\ufeff" + test_string
>       assert hex_shaped_test_glyphs == hex_glyphs_rtl_enabled
E       AssertionError: assert '00db004d0048...90648061200db' == '00db004a001e...90648061200db'
E         
E         - 00db004a001e0016025f00080003025f00080044002e00080044004a0003059c061c064806480658000305d8065806790648061200db
E         + 00db004d0048000900300048000904f6000300090516001b001f004f0003059c061c064806480658000305d8065806790648061200db

tests/test_appearance_stream.py:159: AssertionError
================================================== short test summary info ===================================================
FAILED tests/test_appearance_stream.py::test_appearance_stream_rtl - AssertionError: assert '00db004d0048...90648061200db' == '00db004a001e...90648061200db'
================================================ 1 failed, 15 passed in 1.45s ================================================
```

4. Apply the changes in this PR. The `test_appearance_stream_rtl` should now be automatically skipped:

```
$ pytest -v tests/test_appearance_stream.py
==================================================== test session starts =====================================================
platform linux -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- /home/tadej/.local/share/virtualenvs/pypdf-rtl-tests/bin/python
cachedir: .pytest_cache
rootdir: /home/tadej/Code/pypdf
configfile: pyproject.toml
plugins: xdist-3.8.0, socket-0.8.1, cov-7.1.0, timeout-2.4.0
collected 16 items                                                                                                           

tests/test_appearance_stream.py::test_comb PASSED                                                                      [  6%]
tests/test_appearance_stream.py::test_scale_text PASSED                                                                [ 12%]
tests/test_appearance_stream.py::test_appearance_stream_rtl SKIPPED (Requires arabic-reshaper and python-bidi)         [ 18%]
tests/test_appearance_stream.py::test_appearance_stream__no_rtl_support[arabic_reshaper] PASSED                        [ 25%]
tests/test_appearance_stream.py::test_appearance_stream__no_rtl_support[bidi] PASSED                                   [ 31%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[0-None] PASSED                                       [ 37%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[90-outcome1] PASSED                                  [ 43%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[180-outcome2] PASSED                                 [ 50%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[270-outcome3] PASSED                                 [ 56%]
tests/test_appearance_stream.py::test_base_stream_config_rotation[360-None] PASSED                                     [ 62%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_ap_but_no_normal_state PASSED             [ 68%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_malformed_normal_state PASSED             [ 75%]
tests/test_appearance_stream.py::test_merge_transformed_page_updates_annotation_appearance_matrix PASSED               [ 81%]
tests/test_appearance_stream.py::test_merge_transformed_page_composes_existing_annotation_matrix PASSED                [ 87%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_without_appearance_stream PASSED               [ 93%]
tests/test_appearance_stream.py::test_merge_transformed_page_annotation_with_multi_state_appearance PASSED             [100%]

=============================================== 15 passed, 1 skipped in 1.26s ================================================
```
