### PR TITLE
STY: Type the entity declaration flag as the int expat passes

### DIFF
--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -185,7 +185,7 @@ class _XmpBuilder(ExpatBuilderNS):
     def custom_entity_declaration_handler(
             self,
             entity_name: str,
-            is_parameter_entity: bool,
+            is_parameter_entity: int,
             value: Optional[str],
             base: Optional[str],
             system_id: str,


### PR DESCRIPTION
`EntityDeclHandler` is called by expat, which passes `is_parameter_entity` as an `int` rather than a `bool` — confirmed against CPython's `xml.parsers.expat`. Typed to match the callback contract.

Six typeguard failures in the XMP tests before, none after.
