### PR TITLE
STY: Type the XMP stream as StreamObject rather than ContentStream

### DIFF
--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -26,7 +26,7 @@ from xml.parsers.expat import ExpatError, XMLParserType
 from ._protocols import XmpInformationProtocol
 from ._utils import StreamType, deprecate_with_replacement, deprecation_no_replacement
 from .errors import LimitReachedError, PdfReadError, XmpDocumentError
-from .generic import ContentStream, PdfObject
+from .generic import ContentStream, PdfObject, StreamObject
 
 XMP_MAX_INPUT_LENGTH = 5_000_000
 XMP_MAX_ELEMENT_COUNT = 100_000
@@ -217,7 +217,7 @@ class XmpInformation(XmpInformationProtocol, PdfObject):
 
     """
 
-    def __init__(self, stream: ContentStream) -> None:
+    def __init__(self, stream: StreamObject) -> None:
         self.stream = stream
         try:
             data = self.stream.get_data()


### PR DESCRIPTION
`XmpInformation` is constructed from the `/Metadata` stream, which is a `DecodedStreamObject`. `ContentStream` is a sibling of that class rather than a parent, so the annotation could never hold — the same shape as #3972.

The class only calls `get_data`, `set_data` and `write_to_stream`, all of which `StreamObject` provides. 18 typeguard failures before, none after.
