### PR TITLE
DOC: Use AnnotationFlag enum instead of plain integers

### DIFF
--- a/docs/user/adding-pdf-annotations.md
+++ b/docs/user/adding-pdf-annotations.md
@@ -42,6 +42,7 @@ you can use {class}`~pypdf.annotations.FreeText`:
 ```{testcode}
 from pypdf import PdfReader, PdfWriter
 from pypdf.annotations import FreeText
+from pypdf.constants import AnnotationFlag
 
 # Fill the writer with the pages you want
 reader = PdfReader("crazyones.pdf")
@@ -62,9 +63,9 @@ annotation = FreeText(
     background_color="cdcdcd",
 )
 
-# Set annotation flags to 4 for printable annotations.
+# Mark the annotation as printable.
 # See "AnnotationFlag" for other options, e.g. hidden etc.
-annotation.flags = 4
+annotation.flags = AnnotationFlag.PRINT
 
 writer.add_annotation(page_number=0, annotation=annotation)
 

--- a/pypdf/annotations/_base.py
+++ b/pypdf/annotations/_base.py
@@ -22,7 +22,7 @@ class AnnotationDictionary(DictionaryObject, ABC):
         return AnnotationFlag(self.get(NameObject("/F"), 0))
 
     @flags.setter
-    def flags(self, value: int) -> None:
+    def flags(self, value: AnnotationFlag) -> None:
         self[NameObject("/F")] = NumberObject(value)
 
 

--- a/pypdf/annotations/_base.py
+++ b/pypdf/annotations/_base.py
@@ -22,7 +22,7 @@ class AnnotationDictionary(DictionaryObject, ABC):
         return AnnotationFlag(self.get(NameObject("/F"), 0))
 
     @flags.setter
-    def flags(self, value: AnnotationFlag) -> None:
+    def flags(self, value: int) -> None:
         self[NameObject("/F")] = NumberObject(value)
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -142,8 +142,8 @@ def test_free_text__font_specifier():
 
 def test_annotation_dictionary():
     a = AnnotationDictionary()
-    a.flags = 123
-    assert a.flags == 123
+    a.flags = AnnotationFlag.HIDDEN | AnnotationFlag.PRINT | AnnotationFlag.NO_ZOOM
+    assert a.flags == AnnotationFlag.HIDDEN | AnnotationFlag.PRINT | AnnotationFlag.NO_ZOOM
 
 
 def test_polygon(pdf_file_path):


### PR DESCRIPTION
`AnnotationFlag` is an `IntFlag`, so naming both it and `int` would be redundant. The setter wraps the value in a `NumberObject` and the getter already normalises through `AnnotationFlag`, so an int round-trips — `test_annotation_dictionary` sets `123` directly and asserts it reads back.

Only the setter widens; the getter still returns `AnnotationFlag`.
