### PR TITLE
BUG: Make is_open=False collapse outline items

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1805,9 +1805,7 @@ class PdfWriter(PdfDocCommon):
             page_destination_ref,
             before,
             self,
-            page_destination.inc_parent_counter_outline
-            if is_open
-            else (lambda x, y: 0),  # noqa: ARG005
+            page_destination.inc_parent_counter_outline,
         )
         if "/Count" not in page_destination:
             page_destination[NameObject("/Count")] = NumberObject(0)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -736,12 +736,31 @@ def test_add_outline_item(pdf_file_path):
         writer.write(output_stream)
         output_stream.seek(0)
         reader = PdfReader(output_stream)
-        assert reader.trailer["/Root"]["/Outlines"]["/Count"] == 3
+        assert reader.trailer["/Root"]["/Outlines"]["/Count"] == 4
         assert reader.outline[0]["/Count"] == -2
         assert reader.outline[0]["/%is_open%"] == False  # noqa: E712
         assert reader.outline[2]["/Count"] == 2
         assert reader.outline[2]["/%is_open%"] == True  # noqa: E712
         assert reader.outline[1][0]["/Count"] == 0
+
+
+def test_add_outline_item_collapsed(pdf_file_path):
+    # Issue #2994: is_open=False must produce a collapsed outline item.
+    reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
+    writer = PdfWriter()
+
+    for page in reader.pages:
+        writer.add_page(page)
+
+    parent = writer.add_outline_item("Parent Item", 0, is_open=False)
+    writer.add_outline_item("Child Item", 0, parent=parent, is_open=False)
+
+    with open(pdf_file_path, "w+b") as output_stream:
+        writer.write(output_stream)
+        output_stream.seek(0)
+        reader = PdfReader(output_stream)
+        assert reader.outline[0]["/Count"] == -1
+        assert reader.outline[0]["/%is_open%"] == False  # noqa: E712
 
 
 def test_add_named_destination(pdf_file_path):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -744,8 +744,8 @@ def test_add_outline_item(pdf_file_path):
         assert reader.outline[1][0]["/Count"] == 0
 
 
-def test_add_outline_item_collapsed(pdf_file_path):
-    # Issue #2994: is_open=False must produce a collapsed outline item.
+def test_add_outline_item_collapsed():
+    """Issue #2994: is_open=False must produce a collapsed outline item."""
     reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
     writer = PdfWriter()
 
@@ -755,12 +755,40 @@ def test_add_outline_item_collapsed(pdf_file_path):
     parent = writer.add_outline_item("Parent Item", 0, is_open=False)
     writer.add_outline_item("Child Item", 0, parent=parent, is_open=False)
 
-    with open(pdf_file_path, "w+b") as output_stream:
+    with BytesIO() as output_stream:
         writer.write(output_stream)
         output_stream.seek(0)
         reader = PdfReader(output_stream)
         assert reader.outline[0]["/Count"] == -1
+        # "/%is_open%" is a BooleanObject, not a native bool, so `is False`
+        # would always fail; BooleanObject.__eq__ handles `== False` correctly.
         assert reader.outline[0]["/%is_open%"] == False  # noqa: E712
+
+
+@pytest.mark.parametrize(
+    ("is_open", "expected_count"),
+    [
+        (True, 2),
+        (False, -2),
+    ],
+)
+def test_add_outline_item_nested_count(is_open, expected_count):
+    """Issue #2994: /Count must propagate correctly across multiple children."""
+    reader = PdfReader(RESOURCE_ROOT / "pdflatex-outline.pdf")
+    writer = PdfWriter()
+
+    for page in reader.pages:
+        writer.add_page(page)
+
+    parent = writer.add_outline_item("Parent Item", 0, is_open=is_open)
+    writer.add_outline_item("Child 1", 0, parent=parent)
+    writer.add_outline_item("Child 2", 0, parent=parent)
+
+    with BytesIO() as output_stream:
+        writer.write(output_stream)
+        output_stream.seek(0)
+        reader = PdfReader(output_stream)
+        assert reader.outline[0]["/Count"] == expected_count
 
 
 def test_add_named_destination(pdf_file_path):


### PR DESCRIPTION
Outline items created with `is_open=False` were still expanded in PDF viewers, because the parent's `/Count` was never made negative (the PDF mechanism for a closed outline item). The writer passed a no-op counter callback when `is_open=False`, so collapsed items never propagated their count.

This change always passes `inc_parent_counter_outline`, which sets the parent `/Count` negative for closed items per the PDF spec and propagates only through open ancestors. It also adds a regression test for the issue's repro and updates the root `/Count` assertion in `test_add_outline_item` from 3 to 4, since a collapsed top-level item now correctly counts as one visible child of the outline root.

Fixes #2994

Session-settled decisions carried from planning: single creation-path fix over a two-part fix (verified sufficient); `/Count` sign as the open/closed source of truth over a private key (user-directed).

This PR was prepared with AI assistance and reviewed by the contributor.
