### PR TITLE
ROB: Handle annotations without subtype during merge

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -3035,7 +3035,7 @@ class PdfWriter(PdfDocCommon):
         for an in annots:
             ano = cast("DictionaryObject", an.get_object())
             if (
-                ano["/Subtype"] != "/Link"  # type: ignore[comparison-overlap]
+                ano.get("/Subtype") != "/Link"
                 or "/A" not in ano
                 or cast("DictionaryObject", ano["/A"])["/S"] != "/GoTo"  # type: ignore[comparison-overlap]
                 or "/Dest" in ano

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -12,29 +12,6 @@ from . import RESOURCE_ROOT, get_data_from_url
 from .test_encryption import HAS_AES
 
 
-def test_merge_annotation_without_subtype():
-    """Regression test for #3356."""
-    src = PdfWriter()
-    src.add_blank_page(width=612, height=792)
-    annot = DictionaryObject()
-    src.pages[0][NameObject("/Annots")] = ArrayObject([src._add_object(annot)])
-
-    source = BytesIO()
-    src.write(source)
-    source.seek(0)
-
-    writer = PdfWriter()
-    writer.append(PdfReader(source), import_outline=False)
-
-    merged = BytesIO()
-    writer.write(merged)
-    merged.seek(0)
-
-    reread = PdfReader(merged)
-    merged_annot = reread.pages[0]["/Annots"][0].get_object()
-    assert "/Subtype" not in merged_annot
-
-
 def merger_operate(merger):
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     outline = RESOURCE_ROOT / "pdflatex-outline.pdf"
@@ -557,3 +534,26 @@ def test_merge__null_destination():
 
     writer.merge(position=1, fileobj=data)
     assert writer.pages[0].annotations is None
+
+
+def test_merge_annotation_without_subtype():
+    """Regression test for #3356."""
+    src = PdfWriter()
+    src.add_blank_page(width=612, height=792)
+    annot = DictionaryObject()
+    src.pages[0][NameObject("/Annots")] = ArrayObject([src._add_object(annot)])
+
+    source = BytesIO()
+    src.write(source)
+    source.seek(0)
+
+    writer = PdfWriter()
+    writer.append(PdfReader(source), import_outline=False)
+
+    merged = BytesIO()
+    writer.write(merged)
+    merged.seek(0)
+
+    reread = PdfReader(merged)
+    merged_annot = reread.pages[0]["/Annots"][0].get_object()
+    assert "/Subtype" not in merged_annot

--- a/tests/test_merger.py
+++ b/tests/test_merger.py
@@ -12,6 +12,29 @@ from . import RESOURCE_ROOT, get_data_from_url
 from .test_encryption import HAS_AES
 
 
+def test_merge_annotation_without_subtype():
+    """Regression test for #3356."""
+    src = PdfWriter()
+    src.add_blank_page(width=612, height=792)
+    annot = DictionaryObject()
+    src.pages[0][NameObject("/Annots")] = ArrayObject([src._add_object(annot)])
+
+    source = BytesIO()
+    src.write(source)
+    source.seek(0)
+
+    writer = PdfWriter()
+    writer.append(PdfReader(source), import_outline=False)
+
+    merged = BytesIO()
+    writer.write(merged)
+    merged.seek(0)
+
+    reread = PdfReader(merged)
+    merged_annot = reread.pages[0]["/Annots"][0].get_object()
+    assert "/Subtype" not in merged_annot
+
+
 def merger_operate(merger):
     pdf_path = RESOURCE_ROOT / "crazyones.pdf"
     outline = RESOURCE_ROOT / "pdflatex-outline.pdf"


### PR DESCRIPTION
Fixes #3356

Test: test_merge_annotation_without_subtype

ChatGPT / GPT-5.6 Sol

The program was crashing when something was missing. We changed it so it checks first and carries on safely.

