### PR TITLE
DOC: Note why the entity declaration flag is typed as a bool

### DIFF
--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -185,6 +185,8 @@ class _XmpBuilder(ExpatBuilderNS):
     def custom_entity_declaration_handler(
             self,
             entity_name: str,
+            # expat passes an int here rather than a bool, but typeshed declares
+            # the handler with a bool, so the annotation follows typeshed.
             is_parameter_entity: bool,
             value: Optional[str],
             base: Optional[str],


### PR DESCRIPTION
Follow-up to #3994, which you offered to merge.

expat passes an int for `is_parameter_entity`, as documented in `expat.h` and unchanged since 2003, but typeshed declares the handler with a bool. Running the tests under typeguard reports the mismatch, so a one-line comment recording why the annotation stays as it is should save the next person the same detour.

No behaviour change