### PR TITLE
BUG: Honor ActualText when extracting ligatures mapped to the PUA (#3975)

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -111,6 +111,58 @@ def _emit_tj(extractor: TextExtraction, actual_text: ActualTextStack, operands: 
         extractor.process_operation(b"Tj", operands)
 
 
+def _emit_tj_array(extractor: TextExtraction, operands: list[Any]) -> None:
+    """Expand a TJ array into Tj shows, inserting spaces for large gaps."""
+    confirm_space_width = extractor._space_width * 0.95
+    if not operands:
+        return
+    for op in operands[0]:
+        if isinstance(op, (str, bytes)):
+            extractor.process_operation(b"Tj", [op])
+        if isinstance(op, (int, float, NumberObject, FloatObject)) and (
+            abs(float(op)) >= confirm_space_width
+            and extractor.text
+            and extractor.text[-1] != " "
+        ):
+            extractor.process_operation(b"Tj", [" "])
+
+
+def _handle_marked_or_show(
+    extractor: TextExtraction,
+    actual_text: ActualTextStack,
+    operator: bytes,
+    operands: list[Any],
+) -> bool:
+    """Handle BDC/BMC/EMC and text-showing operators. Return True if consumed."""
+    if operator in (b"BDC", b"BMC"):
+        actual_text.begin(operands)
+        return True
+    if operator == b"EMC":
+        actual_text.end()
+        return True
+    if operator == b"'":
+        extractor.process_operation(b"T*", [])
+        _emit_tj(extractor, actual_text, operands)
+        return True
+    if operator == b'"' and len(operands) >= 3:
+        extractor.process_operation(b"Tw", [operands[0]])
+        extractor.process_operation(b"Tc", [operands[1]])
+        extractor.process_operation(b"T*", [])
+        _emit_tj(extractor, actual_text, operands[2:])
+        return True
+    if operator == b"TJ":
+        repl = actual_text.replacement()
+        if repl:
+            extractor.process_operation(b"Tj", [repl])
+        elif repl is None:
+            _emit_tj_array(extractor, operands)
+        return True
+    if operator == b"Tj":
+        _emit_tj(extractor, actual_text, operands)
+        return True
+    return False
+
+
 def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
     retval: Union[RectangleObject, ArrayObject, IndirectObject, None] = self.get(name)
     if isinstance(retval, RectangleObject):
@@ -1891,35 +1943,8 @@ class PageObject(DictionaryObject):
             if visitor_operand_before is not None:
                 visitor_operand_before(operator, operands, extractor.cm_matrix, extractor.tm_matrix)
             # Multiple operators are handled here
-            if operator in (b"BDC", b"BMC"):
-                actual_text.begin(operands)
-            elif operator == b"EMC":
-                actual_text.end()
-            elif operator == b"'":
-                extractor.process_operation(b"T*", [])
-                _emit_tj(extractor, actual_text, operands)
-            elif operator == b'"' and len(operands) >= 3:
-                extractor.process_operation(b"Tw", [operands[0]])
-                extractor.process_operation(b"Tc", [operands[1]])
-                extractor.process_operation(b"T*", [])
-                _emit_tj(extractor, actual_text, operands[2:])
-            elif operator == b"TJ":
-                repl = actual_text.replacement()
-                if repl:
-                    extractor.process_operation(b"Tj", [repl])
-                elif repl is None:
-                    # The space width may be smaller than the font width, so the width should be 95%.
-                    _confirm_space_width = extractor._space_width * 0.95
-                    if operands:
-                        for op in operands[0]:
-                            if isinstance(op, (str, bytes)):
-                                extractor.process_operation(b"Tj", [op])
-                            if isinstance(op, (int, float, NumberObject, FloatObject)) and (
-                                abs(float(op)) >= _confirm_space_width
-                                and extractor.text
-                                and extractor.text[-1] != " "
-                            ):
-                                extractor.process_operation(b"Tj", [" "])
+            if _handle_marked_or_show(extractor, actual_text, operator, operands):
+                pass
             elif operator == b"TD" and len(operands) >= 2:
                 extractor.process_operation(b"TL", [-operands[1]])
                 extractor.process_operation(b"Td", operands)
@@ -1980,8 +2005,6 @@ class PageObject(DictionaryObject):
                     extractor.text = ""
                     extractor.memo_cm = extractor.cm_matrix.copy()
                     extractor.memo_tm = extractor.tm_matrix.copy()
-            elif operator == b"Tj":
-                _emit_tj(extractor, actual_text, operands)
             else:
                 extractor.process_operation(operator, operands)
             if visitor_operand_after is not None:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -47,6 +47,7 @@ from typing import (
 from ._font import Font
 from ._protocols import PdfCommonDocProtocol
 from ._text_extraction import (
+    ActualTextStack,
     _layout_mode,
 )
 from ._text_extraction._text_extractor import TextExtraction
@@ -99,6 +100,15 @@ MERGE_CROP_BOX = "cropbox"  # pypdf <= 3.4.0 used "trimbox"
 
 # TODO: Make configurable.
 MAX_XFORM_INVOCATIONS_PER_EXTRACTION = 5_000
+
+
+def _emit_tj(extractor: TextExtraction, actual_text: ActualTextStack, operands: list[Any]) -> None:
+    """Emit a Tj, substituting /ActualText once per marked-content sequence."""
+    repl = actual_text.replacement()
+    if repl:
+        extractor.process_operation(b"Tj", [repl])
+    elif repl is None:
+        extractor.process_operation(b"Tj", operands)
 
 
 def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
@@ -1875,32 +1885,41 @@ class PageObject(DictionaryObject):
 
         # Initialize the extractor with the necessary parameters
         extractor.initialize_extraction(orientations, visitor_text, font_resources, fonts)
+        actual_text = ActualTextStack()
 
         for operands, operator in content.operations:
             if visitor_operand_before is not None:
                 visitor_operand_before(operator, operands, extractor.cm_matrix, extractor.tm_matrix)
             # Multiple operators are handled here
-            if operator == b"'":
+            if operator in (b"BDC", b"BMC"):
+                actual_text.begin(operands)
+            elif operator == b"EMC":
+                actual_text.end()
+            elif operator == b"'":
                 extractor.process_operation(b"T*", [])
-                extractor.process_operation(b"Tj", operands)
+                _emit_tj(extractor, actual_text, operands)
             elif operator == b'"' and len(operands) >= 3:
                 extractor.process_operation(b"Tw", [operands[0]])
                 extractor.process_operation(b"Tc", [operands[1]])
                 extractor.process_operation(b"T*", [])
-                extractor.process_operation(b"Tj", operands[2:])
+                _emit_tj(extractor, actual_text, operands[2:])
             elif operator == b"TJ":
-                # The space width may be smaller than the font width, so the width should be 95%.
-                _confirm_space_width = extractor._space_width * 0.95
-                if operands:
-                    for op in operands[0]:
-                        if isinstance(op, (str, bytes)):
-                            extractor.process_operation(b"Tj", [op])
-                        if isinstance(op, (int, float, NumberObject, FloatObject)) and (
-                            abs(float(op)) >= _confirm_space_width
-                            and extractor.text
-                            and extractor.text[-1] != " "
-                        ):
-                            extractor.process_operation(b"Tj", [" "])
+                repl = actual_text.replacement()
+                if repl:
+                    extractor.process_operation(b"Tj", [repl])
+                elif repl is None:
+                    # The space width may be smaller than the font width, so the width should be 95%.
+                    _confirm_space_width = extractor._space_width * 0.95
+                    if operands:
+                        for op in operands[0]:
+                            if isinstance(op, (str, bytes)):
+                                extractor.process_operation(b"Tj", [op])
+                            if isinstance(op, (int, float, NumberObject, FloatObject)) and (
+                                abs(float(op)) >= _confirm_space_width
+                                and extractor.text
+                                and extractor.text[-1] != " "
+                            ):
+                                extractor.process_operation(b"Tj", [" "])
             elif operator == b"TD" and len(operands) >= 2:
                 extractor.process_operation(b"TL", [-operands[1]])
                 extractor.process_operation(b"Td", operands)
@@ -1961,6 +1980,8 @@ class PageObject(DictionaryObject):
                     extractor.text = ""
                     extractor.memo_cm = extractor.cm_matrix.copy()
                     extractor.memo_tm = extractor.tm_matrix.copy()
+            elif operator == b"Tj":
+                _emit_tj(extractor, actual_text, operands)
             else:
                 extractor.process_operation(operator, operands)
             if visitor_operand_after is not None:

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -281,7 +281,10 @@ class ActualTextStack:
         if not self._stack or self._stack[-1] is None:
             return None
         entry = self._stack[-1]
+        assert entry is not None
         if entry[1]:
             return ""
         entry[1] = True
-        return entry[0]
+        text = entry[0]
+        assert isinstance(text, str)
+        return text

--- a/pypdf/_text_extraction/__init__.py
+++ b/pypdf/_text_extraction/__init__.py
@@ -243,3 +243,45 @@ def get_display_str(
             # Treat a sequence of bytes as a neutral character.
             text = x + text if rtl_dir else text + x
     return text, rtl_dir, widths
+
+
+class ActualTextStack:
+    """Track nested BDC/BMC...EMC /ActualText replacements during extraction."""
+
+    def __init__(self) -> None:
+        # None: unmarked or no ActualText. [text, consumed] otherwise.
+        self._stack: list[Optional[list[Any]]] = []
+
+    def begin(self, operands: list[Any]) -> None:
+        text: Optional[str] = None
+        if len(operands) >= 2:
+            props = operands[-1]
+            getter = getattr(props, "get", None)
+            raw = getter("/ActualText") if callable(getter) else None
+            if raw is not None:
+                if isinstance(raw, bytes):
+                    try:
+                        text = raw.decode("utf-8")
+                    except UnicodeDecodeError:
+                        text = raw.decode("latin-1")
+                else:
+                    text = str(raw)
+        self._stack.append([text, False] if text is not None else None)
+
+    def end(self) -> None:
+        if self._stack:
+            self._stack.pop()
+
+    def replacement(self) -> Optional[str]:
+        """Return ActualText once per marked sequence.
+
+        ``None`` means use the painted glyphs. ``""`` means skip later shows
+        in the same span. Any other string is the Unicode to emit instead.
+        """
+        if not self._stack or self._stack[-1] is None:
+            return None
+        entry = self._stack[-1]
+        if entry[1]:
+            return ""
+        entry[1] = True
+        return entry[0]

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, Optional, TypedDict
 
 from ..._font import Font
 from ..._utils import logger_warning
-from .. import LAYOUT_NEW_BT_GROUP_SPACE_WIDTHS
+from .. import LAYOUT_NEW_BT_GROUP_SPACE_WIDTHS, ActualTextStack
 from ._text_state_manager import TextStateManager
 from ._text_state_params import TextStateParams
 
@@ -88,12 +88,27 @@ def bt_group(tj_op: TextStateParams, rendered_text: str, displaced_tx: float) ->
     )
 
 
+
+def _append_layout_tj(
+    tj_ops: list[TextStateParams],
+    text_state_mgr: TextStateManager,
+    actual_text: ActualTextStack,
+    value: Any,
+) -> None:
+    repl = actual_text.replacement()
+    if repl:
+        tj_ops.append(text_state_mgr.text_state_params(repl))
+    elif repl is None:
+        tj_ops.append(text_state_mgr.text_state_params(value))
+
+
 def recurse_to_target_op(
     ops: Iterator[tuple[list[Any], bytes]],
     text_state_mgr: TextStateManager,
     end_target: Literal[b"Q", b"ET"],
     fonts: dict[str, Font],
     strip_rotated: bool = True,
+    actual_text: Optional[ActualTextStack] = None,
 ) -> tuple[list[BTGroup], list[TextStateParams]]:
     """
     Recurse operators between BT/ET and/or q/Q operators managing the transform
@@ -114,6 +129,8 @@ def recurse_to_target_op(
 
     # 1 entry per text show operator (Tj/TJ/'/")
     tj_ops: list[TextStateParams] = []
+    if actual_text is None:
+        actual_text = ActualTextStack()
 
     if end_target == b"Q":
         # add new q level. cm's added at this level will be popped at next b'Q'
@@ -186,7 +203,7 @@ def recurse_to_target_op(
             break
         if op == b"q":
             bts, tjs = recurse_to_target_op(
-                ops, text_state_mgr, b"Q", fonts, strip_rotated
+                ops, text_state_mgr, b"Q", fonts, strip_rotated, actual_text
             )
             bt_groups.extend(bts)
             tj_ops.extend(tjs)
@@ -194,30 +211,38 @@ def recurse_to_target_op(
             text_state_mgr.add_cm(*operands)
         elif op == b"BT":
             bts, tjs = recurse_to_target_op(
-                ops, text_state_mgr, b"ET", fonts, strip_rotated
+                ops, text_state_mgr, b"ET", fonts, strip_rotated, actual_text
             )
             bt_groups.extend(bts)
             tj_ops.extend(tjs)
+        elif op in (b"BDC", b"BMC"):
+            actual_text.begin(operands)
+        elif op == b"EMC":
+            actual_text.end()
         elif op == b"Tj":
-            tj_ops.append(text_state_mgr.text_state_params(operands[0]))
+            _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[0])
         elif op == b"TJ":
-            _tj = text_state_mgr.text_state_params()
-            for tj_op in operands[0]:
-                if isinstance(tj_op, bytes):
-                    _tj = text_state_mgr.text_state_params(tj_op)
-                    tj_ops.append(_tj)
-                else:
-                    text_state_mgr.add_trm(_tj.displacement_matrix(td_offset=tj_op))
+            repl = actual_text.replacement()
+            if repl:
+                tj_ops.append(text_state_mgr.text_state_params(repl))
+            elif repl is None:
+                _tj = text_state_mgr.text_state_params()
+                for tj_op in operands[0]:
+                    if isinstance(tj_op, bytes):
+                        _tj = text_state_mgr.text_state_params(tj_op)
+                        tj_ops.append(_tj)
+                    else:
+                        text_state_mgr.add_trm(_tj.displacement_matrix(td_offset=tj_op))
         elif op == b"'":
             text_state_mgr.reset_trm()
             text_state_mgr.add_tm([0, -text_state_mgr.TL])
-            tj_ops.append(text_state_mgr.text_state_params(operands[0]))
+            _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[0])
         elif op == b'"':
             text_state_mgr.reset_trm()
             text_state_mgr.set_state_param(b"Tw", operands[0])
             text_state_mgr.set_state_param(b"Tc", operands[1])
             text_state_mgr.add_tm([0, -text_state_mgr.TL])
-            tj_ops.append(text_state_mgr.text_state_params(operands[2]))
+            _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[2])
         elif op in (b"Td", b"Tm", b"TD", b"T*"):
             text_state_mgr.reset_trm()
             if op == b"Tm":
@@ -310,10 +335,15 @@ def text_show_operations(
     state_mgr = TextStateManager()  # transformation stack manager
     bt_groups: list[BTGroup] = []  # BT operator dict
     tj_ops: list[TextStateParams] = []  # Tj/TJ operator data
+    actual_text = ActualTextStack()
     for operands, op in ops:
-        if op in (b"BT", b"q"):
+        if op in (b"BDC", b"BMC"):
+            actual_text.begin(operands)
+        elif op == b"EMC":
+            actual_text.end()
+        elif op in (b"BT", b"q"):
             bts, tjs = recurse_to_target_op(
-                ops, state_mgr, b"ET" if op == b"BT" else b"Q", fonts, strip_rotated
+                ops, state_mgr, b"ET" if op == b"BT" else b"Q", fonts, strip_rotated, actual_text
             )
             bt_groups.extend(bts)
             tj_ops.extend(tjs)

--- a/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
+++ b/pypdf/_text_extraction/_layout_mode/_fixed_width_page.py
@@ -102,6 +102,51 @@ def _append_layout_tj(
         tj_ops.append(text_state_mgr.text_state_params(value))
 
 
+def _handle_layout_marked_or_show(
+    op: bytes,
+    operands: list[Any],
+    tj_ops: list[TextStateParams],
+    text_state_mgr: TextStateManager,
+    actual_text: ActualTextStack,
+) -> bool:
+    """Handle BDC/BMC/EMC and text-showing operators. Return True if consumed."""
+    if op in (b"BDC", b"BMC"):
+        actual_text.begin(operands)
+        return True
+    if op == b"EMC":
+        actual_text.end()
+        return True
+    if op == b"Tj":
+        _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[0])
+        return True
+    if op == b"TJ":
+        repl = actual_text.replacement()
+        if repl:
+            tj_ops.append(text_state_mgr.text_state_params(repl))
+        elif repl is None:
+            _tj = text_state_mgr.text_state_params()
+            for tj_op in operands[0]:
+                if isinstance(tj_op, bytes):
+                    _tj = text_state_mgr.text_state_params(tj_op)
+                    tj_ops.append(_tj)
+                else:
+                    text_state_mgr.add_trm(_tj.displacement_matrix(td_offset=tj_op))
+        return True
+    if op == b"'":
+        text_state_mgr.reset_trm()
+        text_state_mgr.add_tm([0, -text_state_mgr.TL])
+        _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[0])
+        return True
+    if op == b'"':
+        text_state_mgr.reset_trm()
+        text_state_mgr.set_state_param(b"Tw", operands[0])
+        text_state_mgr.set_state_param(b"Tc", operands[1])
+        text_state_mgr.add_tm([0, -text_state_mgr.TL])
+        _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[2])
+        return True
+    return False
+
+
 def recurse_to_target_op(
     ops: Iterator[tuple[list[Any], bytes]],
     text_state_mgr: TextStateManager,
@@ -215,34 +260,10 @@ def recurse_to_target_op(
             )
             bt_groups.extend(bts)
             tj_ops.extend(tjs)
-        elif op in (b"BDC", b"BMC"):
-            actual_text.begin(operands)
-        elif op == b"EMC":
-            actual_text.end()
-        elif op == b"Tj":
-            _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[0])
-        elif op == b"TJ":
-            repl = actual_text.replacement()
-            if repl:
-                tj_ops.append(text_state_mgr.text_state_params(repl))
-            elif repl is None:
-                _tj = text_state_mgr.text_state_params()
-                for tj_op in operands[0]:
-                    if isinstance(tj_op, bytes):
-                        _tj = text_state_mgr.text_state_params(tj_op)
-                        tj_ops.append(_tj)
-                    else:
-                        text_state_mgr.add_trm(_tj.displacement_matrix(td_offset=tj_op))
-        elif op == b"'":
-            text_state_mgr.reset_trm()
-            text_state_mgr.add_tm([0, -text_state_mgr.TL])
-            _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[0])
-        elif op == b'"':
-            text_state_mgr.reset_trm()
-            text_state_mgr.set_state_param(b"Tw", operands[0])
-            text_state_mgr.set_state_param(b"Tc", operands[1])
-            text_state_mgr.add_tm([0, -text_state_mgr.TL])
-            _append_layout_tj(tj_ops, text_state_mgr, actual_text, operands[2])
+        elif _handle_layout_marked_or_show(
+            op, operands, tj_ops, text_state_mgr, actual_text
+        ):
+            pass
         elif op in (b"Td", b"Tm", b"TD", b"T*"):
             text_state_mgr.reset_trm()
             if op == b"Tm":

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -988,3 +988,70 @@ def test_line_breaks_with_scaled_current_matrix() -> None:
     )
 
     assert PdfReader(buffer).pages[0].extract_text() == "Line one\nLine two"
+
+
+def _page_with_type1_ligature_font(
+    content_stream: bytes,
+    *,
+    differences: list[object],
+    tounicode: bytes,
+) -> BytesIO:
+    """Single page whose Type1 font maps a ligature glyph through /Differences and /ToUnicode."""
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=612, height=792)
+
+    to_unicode = DecodedStreamObject()
+    to_unicode.set_data(tounicode)
+
+    font = DictionaryObject()
+    font[NameObject("/Type")] = NameObject("/Font")
+    font[NameObject("/Subtype")] = NameObject("/Type1")
+    font[NameObject("/BaseFont")] = NameObject("/Helvetica")
+    font[NameObject("/Encoding")] = DictionaryObject({
+        NameObject("/Type"): NameObject("/Encoding"),
+        NameObject("/BaseEncoding"): NameObject("/WinAnsiEncoding"),
+        NameObject("/Differences"): ArrayObject(differences),
+    })
+    font[NameObject("/ToUnicode")] = to_unicode
+
+    font_resources = DictionaryObject()
+    font_resources[NameObject("/F1")] = writer._add_object(font)
+    resources = DictionaryObject()
+    resources[NameObject("/Font")] = font_resources
+    page[NameObject("/Resources")] = resources
+
+    content = DecodedStreamObject()
+    content.set_data(content_stream)
+    page[NameObject("/Contents")] = writer._add_object(content)
+
+    buffer = BytesIO()
+    writer.write(buffer)
+    buffer.seek(0)
+    return buffer
+
+
+def test_extract_text_ligature_actual_text_replaces_private_use() -> None:
+    """Marked-content ActualText is the Unicode for a ligature painted as U+E000.
+
+    Type0 subset fonts in issue #3975 map CID ligatures to U+E000 / U+E001 and
+    wrap the glyph in ``/Span << /ActualText (fi) >>``. Extraction must emit
+    ``fi``, not the private-use code point.
+    """
+    buffer = _page_with_type1_ligature_font(
+        b"BT /F1 12 Tf 72 720 Td (Of) Tj "
+        b"/Span << /ActualText (fi) >> BDC (\250) Tj EMC "
+        b"(ce) Tj ET",
+        differences=[NumberObject(0xA8), NameObject("/fi")],
+        tounicode=(
+            b"/CIDInit /ProcSet findresource begin\n"
+            b"12 dict begin\nbegincmap\n"
+            b"/CMapType 2 def\n"
+            b"1 begincodespacerange <00> <FF> endcodespacerange\n"
+            b"1 beginbfchar\n<A8> <E000>\nendbfchar\n"
+            b"endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n"
+        ),
+    )
+    page = PdfReader(buffer).pages[0]
+    assert "\ue000" not in page.extract_text()
+    assert "Office" in page.extract_text()
+    assert "Office" in page.extract_text(extraction_mode="layout").replace(" ", "")


### PR DESCRIPTION
Closes #3975

Some producers paint `fi`/`fl` ligatures as CIDs whose ToUnicode CMap lands in the Private Use Area, then wrap the show operator in `/Span << /ActualText (fi) >> BDC ... EMC`. `extract_text` ignored BDC/EMC, so `Federal Office` became `Federal Of\ue000ce`.

Honor `/ActualText` in the default extractor and in layout mode: emit the replacement once for the marked sequence and skip later shows in that span.

A regression test builds a page with the same ActualText + PUA pattern. Checked against the issue sample: page 3 now extracts `Federal Office for Information Security` with no U+E000.

Used Grok (xAI) while reproducing and implementing this.