### PR TITLE
BUG: Resolve the font resource before building a Font from it

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2055,7 +2055,9 @@ class PageObject(DictionaryObject):
             resources_dict: Any = obj.get(PG.RESOURCES, {})
             if "/Font" in resources_dict and self.pdf is not None:
                 for font_name in resources_dict["/Font"]:
-                    fonts[font_name] = Font.from_font_resource(resources_dict["/Font"][font_name])
+                    fonts[font_name] = Font.from_font_resource(
+                        resources_dict["/Font"][font_name].get_object()
+                    )
 
             if "/Parent" not in obj:
                 break

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -534,7 +534,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         acro_form_font_resources = acro_form_resources.get("/Font", DictionaryObject())
         font_resource = acro_form_font_resources.get(font_name, None)
         if font_resource:
-            font = Font.from_font_resource(font_resource)
+            font = Font.from_font_resource(font_resource.get_object())
         else:
             # Normally, we should have found a font resource by now. However, when a user has provided a specific
             # font name, we may not have found the associated font resource among the AcroForm resources. Also, in


### PR DESCRIPTION
`Font.from_font_resource` takes a `DictionaryObject` and reads it with `.get()`, but two callers hand over the raw entry from the `/Font` resource dictionary, which is an `IndirectObject`.

It works today only because `IndirectObject` forwards unknown attributes to the object it points at, so the `.get()` calls land on the resolved dictionary by accident rather than by design.

The third caller in `_page.py` already calls `get_object()` first, so the other two now do the same. A typeguard run reports four failures for this before the change and none after