### PR TITLE
STY: Use the FfBits enum instead of a plain integer for form field flags

### DIFF
--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -21,6 +21,7 @@ from pypdf import (
 )
 from pypdf._font import Font
 from pypdf.annotations import Link
+from pypdf.constants import FieldDictionaryAttributes as FA
 from pypdf.errors import DeprecationError, LimitReachedError, PageSizeNotDefinedError, PdfReadError, PyPdfError
 from pypdf.generic import (
     ArrayObject,
@@ -598,12 +599,12 @@ def test_fill_form(pdf_file_path):
     writer.append(RESOURCE_ROOT / "crazyones.pdf", [0])
 
     writer.update_page_form_field_values(
-        writer.pages[0], {"foo": "some filled in text"}, flags=1, flatten=True
+        writer.pages[0], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly, flatten=True
     )
 
     # check if no fields to fill in the page
     writer.update_page_form_field_values(
-        writer.pages[1], {"foo": "some filled in text"}, flags=1, flatten=True
+        writer.pages[1], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly, flatten=True
     )
 
     writer.update_page_form_field_values(
@@ -623,7 +624,7 @@ def test_fill_form_with_qualified():
     writer.clone_document_from_reader(reader)
     writer.add_page(reader.pages[0])
     writer.update_page_form_field_values(
-        writer.pages[0], {"top.foo": "filling"}, flags=1
+        writer.pages[0], {"top.foo": "filling"}, flags=FA.FfBits.ReadOnly
     )
     b = BytesIO()
     writer.write(b)
@@ -2163,7 +2164,7 @@ def test_missing_fields(pdf_file_path):
 
     with pytest.raises(PyPdfError) as exc:
         writer.update_page_form_field_values(
-            writer.pages[0], {"foo": "some filled in text"}, flags=1
+            writer.pages[0], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly
         )
     assert exc.value.args[0] == "No /AcroForm dictionary in PDF of PdfWriter Object"
 
@@ -2172,7 +2173,7 @@ def test_missing_fields(pdf_file_path):
     del writer.root_object["/AcroForm"]["/Fields"]
     with pytest.raises(PyPdfError) as exc:
         writer.update_page_form_field_values(
-            writer.pages[0], {"foo": "some filled in text"}, flags=1
+            writer.pages[0], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly
         )
     assert exc.value.args[0] == "No /Fields dictionary in PDF of PdfWriter Object"
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -21,7 +21,7 @@ from pypdf import (
 )
 from pypdf._font import Font
 from pypdf.annotations import Link
-from pypdf.constants import FieldDictionaryAttributes as FA
+from pypdf.constants import FieldDictionaryAttributes
 from pypdf.errors import DeprecationError, LimitReachedError, PageSizeNotDefinedError, PdfReadError, PyPdfError
 from pypdf.generic import (
     ArrayObject,
@@ -599,12 +599,12 @@ def test_fill_form(pdf_file_path):
     writer.append(RESOURCE_ROOT / "crazyones.pdf", [0])
 
     writer.update_page_form_field_values(
-        writer.pages[0], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly, flatten=True
+        writer.pages[0], {"foo": "some filled in text"}, flags=FieldDictionaryAttributes.FfBits.ReadOnly, flatten=True
     )
 
     # check if no fields to fill in the page
     writer.update_page_form_field_values(
-        writer.pages[1], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly, flatten=True
+        writer.pages[1], {"foo": "some filled in text"}, flags=FieldDictionaryAttributes.FfBits.ReadOnly, flatten=True
     )
 
     writer.update_page_form_field_values(
@@ -624,7 +624,7 @@ def test_fill_form_with_qualified():
     writer.clone_document_from_reader(reader)
     writer.add_page(reader.pages[0])
     writer.update_page_form_field_values(
-        writer.pages[0], {"top.foo": "filling"}, flags=FA.FfBits.ReadOnly
+        writer.pages[0], {"top.foo": "filling"}, flags=FieldDictionaryAttributes.FfBits.ReadOnly
     )
     b = BytesIO()
     writer.write(b)
@@ -2164,7 +2164,7 @@ def test_missing_fields(pdf_file_path):
 
     with pytest.raises(PyPdfError) as exc:
         writer.update_page_form_field_values(
-            writer.pages[0], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly
+            writer.pages[0], {"foo": "some filled in text"}, flags=FieldDictionaryAttributes.FfBits.ReadOnly
         )
     assert exc.value.args[0] == "No /AcroForm dictionary in PDF of PdfWriter Object"
 
@@ -2173,7 +2173,7 @@ def test_missing_fields(pdf_file_path):
     del writer.root_object["/AcroForm"]["/Fields"]
     with pytest.raises(PyPdfError) as exc:
         writer.update_page_form_field_values(
-            writer.pages[0], {"foo": "some filled in text"}, flags=FA.FfBits.ReadOnly
+            writer.pages[0], {"foo": "some filled in text"}, flags=FieldDictionaryAttributes.FfBits.ReadOnly
         )
     assert exc.value.args[0] == "No /Fields dictionary in PDF of PdfWriter Object"
 


### PR DESCRIPTION
`update_page_form_field_values` takes its flags as `FieldDictionaryAttributes.FfBits` and the docstring points readers at that enum, but the tests passed a bare `1` in five places.

`FfBits(1)` is `ReadOnly`, so spelling it out says what the call is actually asking for rather than leaving the reader to look up the bit.

Same shape as #3997