### PR TITLE
BUG: Reject a page range with a zero stride

### DIFF
--- a/pypdf/pagerange.py
+++ b/pypdf/pagerange.py
@@ -74,7 +74,13 @@ class PageRange:
             stop = start + 1 if start != -1 else None
             self._slice = slice(start, stop)
         else:
-            self._slice = slice(*[int(g) if g else None for g in m.group(4, 6, 8)])
+            bounds = [int(g) if g else None for g in m.group(4, 6, 8)]
+            step = bounds[2]
+            if step == 0:
+                # A zero stride cannot select anything; slice() accepts it here
+                # but raises as soon as the range is applied.
+                raise ParseError(arg)
+            self._slice = slice(*bounds)
 
     @staticmethod
     def valid(input: Any) -> bool:
@@ -88,9 +94,15 @@ class PageRange:
             True, if the ``input`` is a valid PageRange.
 
         """
-        return isinstance(input, (slice, PageRange)) or (
-            isinstance(input, str) and bool(re.match(PAGE_RANGE_RE, input))
-        )
+        if isinstance(input, (slice, PageRange)):
+            return True
+        if not isinstance(input, str):
+            return False
+        try:
+            PageRange(input)
+        except ParseError:
+            return False
+        return True
 
     def to_slice(self) -> slice:
         """Return the slice equivalent of this page range."""

--- a/tests/test_pagerange.py
+++ b/tests/test_pagerange.py
@@ -70,6 +70,15 @@ def test_str_init_error():
     assert exc.value.args[0] == "1-2"
 
 
+@pytest.mark.parametrize("init_str", ["::0", "1:5:0", "0:0:0"])
+def test_str_init_zero_step(init_str):
+    """A zero stride selects nothing and only raised once the range was applied."""
+    assert PageRange.valid(init_str) is False
+    with pytest.raises(ParseError) as exc:
+        PageRange(init_str)
+    assert exc.value.args[0] == init_str
+
+
 @pytest.mark.parametrize(
     ("params", "expected"),
     [

--- a/tests/test_pagerange.py
+++ b/tests/test_pagerange.py
@@ -80,6 +80,21 @@ def test_str_init_zero_step(init_str):
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (slice(1, 5), True),
+        (PageRange("1:5"), True),
+        ("1:5", True),
+        (5, False),
+        (None, False),
+        (["1:5"], False),
+    ],
+)
+def test_valid(value, expected):
+    assert PageRange.valid(value) is expected
+
+
+@pytest.mark.parametrize(
     ("params", "expected"),
     [
         (["foo.pdf", "1:5"], [("foo.pdf", PageRange("1:5"))]),


### PR DESCRIPTION
`PageRange("::0")` is accepted and `PageRange.valid("::0")` returns `True`, but the range cannot be applied:

```python
>>> PageRange.valid("::0")
True
>>> PageRange("::0").indices(10)
ValueError: slice step cannot be zero
```

`slice()` takes a zero step happily and only raises from `indices()`, away from the string that caused it. Through `PdfWriter.append(pages="::0") `the same input surfaces as a `TypeError` about the pages argument instead, which points the reader somewhere else entirely.

Every other malformed range is refused at construction with `ParseError`, so a zero stride now is too. `valid()` defers to the constructor rather than matching the pattern a second time, so the two cannot disagree again.

Reverting the change fails the three new tests