### PR TITLE
BUG: Reject a non-positive number when building a Roman numeral

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -73,6 +73,8 @@ from .generic import (
 
 
 def number2uppercase_roman_numeral(num: int) -> str:
+    if num <= 0:
+        raise ValueError("Expecting a positive number")
     roman = [
         (1000, "M"),
         (900, "CM"),

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -70,6 +70,15 @@ def test_number2uppercase_letter():
         number2uppercase_letter(-1)
 
 
+@pytest.mark.parametrize("number", [0, -1, -5])
+def test_number2roman_numeral_non_positive(number):
+    """A non-positive number produced a numeral rather than being refused."""
+    with pytest.raises(ValueError, match="Expecting a positive number"):
+        number2uppercase_roman_numeral(number)
+    with pytest.raises(ValueError, match="Expecting a positive number"):
+        number2lowercase_roman_numeral(number)
+
+
 @pytest.mark.enable_socket
 def test_index2label(caplog):
     name = "waarom-meisjes-het-beter-doen-op-HAVO-en-VWO-ROA.pdf"


### PR DESCRIPTION
`number2uppercase_roman_numeral(-1)` returns `'CMXCIX'` and `0` returns an empty string:

```python
>>> number2uppercase_roman_numeral(-1)
'CMXCIX'
>>> number2uppercase_roman_numeral(0)
''
```

The loop subtracts each value it emits and stops once the remainder reaches zero, which a negative input satisfies after a single pass over the table.

`number2uppercase_letter` and `number2lowercase_letter` beside it already refuse a non-positive number with the same message, so this brings the four numbering styles in line.

`index2label` already catches `ValueError` from the mapping function and falls back to the page position, so a file carrying `/St 0` now logs "Ignoring malformed page label entry" rather than labelling a page `CMXCIX`.

Reverting the change fails the three new tests