### PR TITLE
ROB: Reject too few values when setting a page box

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -134,6 +134,13 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
 
 
 def _set_rectangle(self: Any, name: str, value: Union[RectangleObject, float]) -> None:
+    if isinstance(value, (list, tuple)) and len(value) < 4:
+        # The getter tolerates more than four values for backwards compatibility
+        # but cannot do anything with fewer, so writing them would produce a page
+        # whose box cannot be read back.
+        raise ValueError(
+            f"Expected four values for {name}, got {len(value)}: {value}"
+        )
     self[NameObject(name)] = value
 
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1595,3 +1595,38 @@ def test_get_rectangle__size_handling(caplog):
         ValueError, match=r"Expected four values for /MediaBox, got 3: \[0, 0, 13\]"
     ):
         _ = page.mediabox
+
+
+@pytest.mark.parametrize(
+    ("box", "pdf_name"),
+    [
+        ("mediabox", "/MediaBox"),
+        ("cropbox", "/CropBox"),
+        ("trimbox", "/TrimBox"),
+        ("artbox", "/ArtBox"),
+        ("bleedbox", "/BleedBox"),
+    ],
+)
+@pytest.mark.parametrize("values", [[0, 0], [0, 0, 13]])
+def test_box_setter_rejects_too_few_values(box, pdf_name, values):
+    """
+    The getter cannot build a rectangle from fewer than four values, so writing
+    them through the property would produce a box that cannot be read back.
+    """
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    page = writer.pages[0]
+    with pytest.raises(
+        ValueError, match=f"Expected four values for {pdf_name}, got {len(values)}"
+    ):
+        setattr(page, box, ArrayObject(values))
+
+
+@pytest.mark.parametrize("box", ["mediabox", "cropbox"])
+def test_box_setter_allows_extra_values(box):
+    """More than four entries stays accepted, matching what the getter tolerates."""
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    page = writer.pages[0]
+    setattr(page, box, ArrayObject([0, 0, 13, 37, 0, 0]))
+    assert getattr(page, box) == RectangleObject((0, 0, 13, 37))


### PR DESCRIPTION
`page.mediabox = ArrayObject([0, 0])` is accepted, but reading the box back raises:

```python
>>> page.mediabox = ArrayObject([0, 0])
>>> page.mediabox
ValueError: Expected four values for /MediaBox, got 2: [0, 0]
```

So a page can be written with a box that cannot be read back.

The getter warns and truncates when there are more than four values, for backwards compatibility with files pypdf itself once wrote, so the setter keeps accepting those and only refuses the case the getter cannot handle. Writing through `page[NameObject("/MediaBox")]` directly is untouched.

Applies to all five boxes. Reverting the change fails the ten new tests