### PR TITLE
BUG: List the valid layouts in the page layout warning

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2392,7 +2392,7 @@ class PdfWriter(PdfDocCommon):
                 logger_warning(
                     "Layout should be one of: %(layouts)s",
                     source=__name__,
-                    layouts={"", "".join(self._valid_layouts)},
+                    layouts=", ".join(self._valid_layouts),
                 )
             layout = NameObject(layout)
         self._root_object.update({NameObject("/PageLayout"): layout})

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3557,3 +3557,22 @@ def test_add_articles_thread__cyclic() -> None:
             match=r"^Detected cyclic article structure\.$"
     ):
         writer._add_articles_thread(thread=thread, pages={}, reader=reader)
+
+
+def test_page_layout_warning_lists_the_valid_layouts(caplog):
+    """The warning built a set of an empty string and one concatenated blob."""
+    writer = PdfWriter()
+    writer.page_layout = "/Nonsense"
+    assert (
+        "Layout should be one of: /NoLayout, /SinglePage, /OneColumn, "
+        "/TwoColumnLeft, /TwoColumnRight, /TwoPageLeft, /TwoPageRight"
+    ) in caplog.text
+
+
+def test_page_mode_warning_lists_the_valid_modes(caplog):
+    writer = PdfWriter()
+    writer.page_mode = "/Nonsense"
+    assert (
+        "Mode should be one of: /UseNone, /UseOutlines, /UseThumbs, "
+        "/FullScreen, /UseOC, /UseAttachments"
+    ) in caplog.text


### PR DESCRIPTION
Setting an unknown page layout warns, but the message is not readable:

```
Layout should be one of: {'', '/NoLayout/SinglePage/OneColumn/TwoColumnLeft/TwoColumnRight/TwoPageLeft/TwoPageRight'}
```

It passes a set built from an empty string and the valid layouts joined without a separator, so the reader gets one run-on blob and a stray `''`.

`page_mode` next to it already joins its values with a comma, so this brings the two in line:

```
Layout should be one of: /NoLayout, /SinglePage, /OneColumn, /TwoColumnLeft, /TwoColumnRight, /TwoPageLeft, /TwoPageRight
```