### PR TITLE
BUG: Check the value assigned to print_scaling

### DIFF
--- a/pypdf/generic/_viewerpref.py
+++ b/pypdf/generic/_viewerpref.py
@@ -151,7 +151,9 @@ class ViewerPreferences(DictionaryObject):
         cls.view_clip = _add_prop_name("/ViewClip", [], None)
         cls.print_area = _add_prop_name("/PrintArea", [], None)
         cls.print_clip = _add_prop_name("/PrintClip", [], None)
-        cls.print_scaling = _add_prop_name("/PrintScaling", [], None)
+        cls.print_scaling = _add_prop_name(
+            "/PrintScaling", ["/None", "/AppDefault"], None
+        )
         cls.duplex = _add_prop_name(
             "/Duplex", ["/Simplex", "/DuplexFlipShortEdge", "/DuplexFlipLongEdge"], None
         )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3576,3 +3576,22 @@ def test_page_mode_warning_lists_the_valid_modes(caplog):
         "Mode should be one of: /UseNone, /UseOutlines, /UseThumbs, "
         "/FullScreen, /UseOC, /UseAttachments"
     ) in caplog.text
+
+
+@pytest.mark.parametrize("value", ["/None", "/AppDefault"])
+def test_print_scaling_accepts_the_spec_values(value):
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    viewer_preferences.print_scaling = value
+    assert viewer_preferences.print_scaling == value
+
+
+@pytest.mark.parametrize("value", ["/Nonsense", "/none", "/appdefault"])
+def test_print_scaling_rejects_other_values(value):
+    """/PrintScaling was declared without its allowed values, so nothing checked it."""
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    with pytest.raises(ValueError, match="is an unacceptable value"):
+        viewer_preferences.print_scaling = value


### PR DESCRIPTION
`/PrintScaling` is declared with an empty list of acceptable values:

```python
cls.print_scaling = _add_prop_name("/PrintScaling", [], None)
```

So any name is written through unchecked, and the generated docstring reads "Acceptable values: []".

The spec allows `/None` and `/AppDefault`, which is what `docs/user/viewer-preferences.md` shows. `direction` and `duplex` beside it are declared with their values and reject anything else.

Reverting the change fails the three new tests