### PR TITLE
BUG: Reject a non-positive number of copies

### DIFF
--- a/pypdf/generic/_viewerpref.py
+++ b/pypdf/generic/_viewerpref.py
@@ -88,6 +88,8 @@ class ViewerPreferences(DictionaryObject):
         return self.get(key, default)
 
     def _set_int(self, key: str, v: int) -> None:
+        if v < 0:
+            raise ValueError(f"{v} is an unacceptable value for {key}")
         self[NameObject(key)] = NumberObject(v)
 
     @property

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3618,3 +3618,22 @@ def test_print_pagerange_accepts_page_pairs(values):
         [NumberObject(value) for value in values]
     )
     assert list(viewer_preferences.print_pagerange) == values
+
+
+@pytest.mark.parametrize("value", [-1, -5])
+def test_num_copies_rejects_negative(value):
+    """A negative copy count cannot be interpreted by a reader."""
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    with pytest.raises(ValueError, match="is an unacceptable value for /NumCopies"):
+        viewer_preferences.num_copies = value
+
+
+@pytest.mark.parametrize("value", [0, 1, 2, 99])
+def test_num_copies_accepts_zero_and_above(value):
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    viewer_preferences.num_copies = value
+    assert viewer_preferences.num_copies == value


### PR DESCRIPTION
`/NumCopies` is written through without a check:

```python
>>> viewer_preferences.num_copies = 0
>>> viewer_preferences.num_copies
0
>>> viewer_preferences.num_copies = -5
>>> viewer_preferences.num_copies
-5
```

So a document can ask a viewer to print no copies, or a negative number of them.

The name-valued preferences beside it already refuse a value outside their allowed set and report it the same way, so this uses the same message shape. `_set_int` backs only `num_copies`, so nothing else is affected.

Reverting the change fails the three new tests