### PR TITLE
BUG: Reject an odd-length print page range

### DIFF
--- a/pypdf/generic/_viewerpref.py
+++ b/pypdf/generic/_viewerpref.py
@@ -76,6 +76,12 @@ class ViewerPreferences(DictionaryObject):
             return
         if not isinstance(v, ArrayObject):
             raise ValueError("ArrayObject is expected")
+        if key == "/PrintPageRange" and len(v) % 2:
+            # The array holds first/last page pairs, so an odd length leaves a
+            # range without its end.
+            raise ValueError(
+                f"/PrintPageRange holds page pairs, got {len(v)} entries: {v}"
+            )
         self[NameObject(key)] = v
 
     def _get_int(self, key: str, default: Optional[NumberObject]) -> Optional[NumberObject]:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3595,3 +3595,26 @@ def test_print_scaling_rejects_other_values(value):
     viewer_preferences = writer.create_viewer_preferences()
     with pytest.raises(ValueError, match="is an unacceptable value"):
         viewer_preferences.print_scaling = value
+
+
+@pytest.mark.parametrize("values", [[1], [1, 2, 3]])
+def test_print_pagerange_rejects_an_odd_length(values):
+    """The array holds first/last page pairs, so an odd length is incomplete."""
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    with pytest.raises(ValueError, match="/PrintPageRange holds page pairs"):
+        viewer_preferences.print_pagerange = ArrayObject(
+            [NumberObject(value) for value in values]
+        )
+
+
+@pytest.mark.parametrize("values", [[], [1, 10], [1, 10, 20, 30]])
+def test_print_pagerange_accepts_page_pairs(values):
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    viewer_preferences.print_pagerange = ArrayObject(
+        [NumberObject(value) for value in values]
+    )
+    assert list(viewer_preferences.print_pagerange) == values


### PR DESCRIPTION
`/PrintPageRange` holds first/last page pairs, as the viewer preferences documentation shows:

```python
writer.viewer_preferences.print_pagerange = ArrayObject(
    [NumberObject("1"), NumberObject("10"), NumberObject("20"), NumberObject("30")]
)
```

An array with an odd number of entries leaves a range without its end, and was written through unchecked.

The check is limited to that key because `_set_arr` is shared with `/Enforce`, which has no such constraint. An empty array stays valid.

Reverting the change fails the two new tests