### PR TITLE
BUG: Check the box names assigned to the area and clip preferences

### DIFF
--- a/pypdf/generic/_viewerpref.py
+++ b/pypdf/generic/_viewerpref.py
@@ -32,10 +32,21 @@ from typing import (
     cast,
 )
 
+from ..constants import PageAttributes
 from ._base import BooleanObject, NameObject, NumberObject, is_null_or_none
 from ._data_structures import ArrayObject, DictionaryObject
 
 f_obj = BooleanObject(False)
+
+#: The page boundaries a viewer preference may name, per Table 147 in the 2.0
+#: reference.
+BOX_NAMES = [
+    PageAttributes.MEDIABOX,
+    PageAttributes.CROPBOX,
+    PageAttributes.BLEEDBOX,
+    PageAttributes.TRIMBOX,
+    PageAttributes.ARTBOX,
+]
 
 
 class ViewerPreferences(DictionaryObject):
@@ -147,10 +158,10 @@ class ViewerPreferences(DictionaryObject):
         cls.direction = _add_prop_name(
             "/Direction", ["/L2R", "/R2L"], NameObject("/L2R")
         )
-        cls.view_area = _add_prop_name("/ViewArea", [], None)
-        cls.view_clip = _add_prop_name("/ViewClip", [], None)
-        cls.print_area = _add_prop_name("/PrintArea", [], None)
-        cls.print_clip = _add_prop_name("/PrintClip", [], None)
+        cls.view_area = _add_prop_name("/ViewArea", BOX_NAMES, None)
+        cls.view_clip = _add_prop_name("/ViewClip", BOX_NAMES, None)
+        cls.print_area = _add_prop_name("/PrintArea", BOX_NAMES, None)
+        cls.print_clip = _add_prop_name("/PrintClip", BOX_NAMES, None)
         cls.print_scaling = _add_prop_name(
             "/PrintScaling", ["/None", "/AppDefault"], None
         )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3620,6 +3620,8 @@ def test_box_preferences_reject_other_names(preference):
     viewer_preferences = writer.create_viewer_preferences()
     with pytest.raises(ValueError, match="is an unacceptable value"):
         setattr(viewer_preferences, preference, "/Nonsense")
+
+
 @pytest.mark.parametrize("values", [[1], [1, 2, 3]])
 def test_print_pagerange_rejects_an_odd_length(values):
     """The array holds first/last page pairs, so an odd length is incomplete."""

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -39,6 +39,7 @@ from pypdf.generic import (
     StreamObject,
     TextStringObject,
 )
+from pypdf.generic._viewerpref import BOX_NAMES
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url, is_sublist
 from .test_images import image_similarity
@@ -3595,3 +3596,27 @@ def test_print_scaling_rejects_other_values(value):
     viewer_preferences = writer.create_viewer_preferences()
     with pytest.raises(ValueError, match="is an unacceptable value"):
         viewer_preferences.print_scaling = value
+
+
+@pytest.mark.parametrize(
+    "preference", ["view_area", "view_clip", "print_area", "print_clip"]
+)
+@pytest.mark.parametrize("value", BOX_NAMES)
+def test_box_preferences_accept_the_page_boxes(preference, value):
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    setattr(viewer_preferences, preference, value)
+    assert getattr(viewer_preferences, preference) == value
+
+
+@pytest.mark.parametrize(
+    "preference", ["view_area", "view_clip", "print_area", "print_clip"]
+)
+def test_box_preferences_reject_other_names(preference):
+    """These were declared without their allowed values, so nothing checked them."""
+    writer = PdfWriter()
+    writer.add_blank_page(100, 100)
+    viewer_preferences = writer.create_viewer_preferences()
+    with pytest.raises(ValueError, match="is an unacceptable value"):
+        setattr(viewer_preferences, preference, "/Nonsense")


### PR DESCRIPTION
`/ViewArea`, `/ViewClip`, `/PrintArea` and `/PrintClip` are each declared with an empty list of acceptable values:

```python
cls.view_area = _add_prop_name("/ViewArea", [], None)
```

So any name is written through unchecked, and the generated docstrings read "Acceptable values: []":

```python
>>> viewer_preferences.view_area = "/Nonsense"
>>> viewer_preferences.view_area
'/Nonsense'
```

All four name one of the five page boundaries, which `PageAttributes` already defines, so the allowed set is taken from there rather than spelled out again. `direction` and `duplex` beside them already reject a value outside their set.

Reverting the change fails the four new tests