### PR TITLE
ROB: Skip trailing duplicate %%EOF markers when locating startxref

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -813,9 +813,7 @@ class PdfReader(PdfDocCommon):
         # very last of them, so the line above it is another marker rather
         # than the offset. Skip that trailing run to reach the real offset;
         # the revision being read is unchanged, only the marker padding is
-        # ignored. The scan is bounded like the one in
-        # _find_previous_startxref_pos so a crafted file cannot make it run
-        # over the whole stream.
+        # ignored.
         duplicate_markers = 0
         while line.startswith(b"%%EOF") and stream.tell() > 0:
             if duplicate_markers == self._MAX_STARTXREF_RECOVERY_LINES:

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -808,6 +808,24 @@ class PdfReader(PdfDocCommon):
 
         """
         line = read_previous_line(stream)
+        # Some producers append further %%EOF markers below the one that
+        # closes the last revision (#4008). _find_eof_marker() stops at the
+        # very last of them, so the line above it is another marker rather
+        # than the offset. Skip that trailing run to reach the real offset;
+        # the revision being read is unchanged, only the marker padding is
+        # ignored. The scan is bounded like the one in
+        # _find_previous_startxref_pos so a crafted file cannot make it run
+        # over the whole stream.
+        duplicate_markers = 0
+        while line.startswith(b"%%EOF") and stream.tell() > 0:
+            if duplicate_markers == self._MAX_STARTXREF_RECOVERY_LINES:
+                break
+            line = read_previous_line(stream)
+            duplicate_markers += 1
+        if duplicate_markers:
+            logger_warning(
+                "Duplicate %%EOF marker(s) found, skipping them", source=__name__
+            )
         try:
             startxref = int(line)
         except ValueError:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -459,6 +459,52 @@ def test_find_previous_startxref_pos_recovery_variants():
 
 
 @pytest.mark.parametrize(
+    ("suffix", "duplicates"),
+    [
+        (b"", 0),
+        (b"%%EOF\n", 1),
+        (b"\n%%EOF\n", 1),
+        (b"\n%%EOF\n\n%%EOF\n", 2),
+        (b"\n%%EOF", 1),
+    ],
+    ids=["none", "adjacent", "blank-line", "two-extra", "no-trailing-newline"],
+)
+@pytest.mark.parametrize("strict", [False, True])
+def test_duplicate_eof_markers(caplog, suffix, duplicates, strict):
+    """%%EOF markers appended below the final one still resolve startxref (#4008)."""
+    writer = PdfWriter()
+    writer.add_blank_page(200, 200)
+    buffer = BytesIO()
+    writer.write(buffer)
+    pdf_data = buffer.getvalue() + suffix
+
+    reader = PdfReader(BytesIO(pdf_data), strict=strict)
+    assert len(reader.pages) == 1
+
+    expected = ["Duplicate %%EOF marker(s) found, skipping them"] if duplicates else []
+    assert normalize_warnings(caplog.text) == (expected or [""])
+
+
+@pytest.mark.parametrize(
+    "pdf_data",
+    [
+        # The run of markers is exhausted by reaching the start of the stream.
+        b"%%EOF\n%%EOF\n",
+        # Same, but with something above the run that is not an offset either.
+        b"%PDF-1.7\n%%EOF\n%%EOF\n",
+        # The run is longer than the bound on the backward scan, so the scan
+        # gives up instead of walking the whole stream.
+        b"%PDF-1.7\n" + b"%%EOF\n" * (PdfReader._MAX_STARTXREF_RECOVERY_LINES + 10),
+    ],
+    ids=["start-of-stream", "no-offset-above", "beyond-scan-limit"],
+)
+def test_duplicate_eof_markers_without_startxref(pdf_data):
+    """A run of %%EOF markers with no offset above it is still reported as broken."""
+    with pytest.raises(PdfReadError, match="startxref not found"):
+        PdfReader(BytesIO(pdf_data))
+
+
+@pytest.mark.parametrize(
     ("pdffile", "password", "should_fail"),
     [
         ("encrypted-file.pdf", "test", False),


### PR DESCRIPTION
Closes #4008.

## The problem

`_find_eof_marker()` stops at the **very last** `%%EOF` in the file. When a
producer appends further `%%EOF` markers below the one that closes the last
revision, the line above the marker that was found is another marker, not the
xref offset:

```
startxref
17750822
%%EOF

%%EOF          <- _find_eof_marker() stops here
```

`_find_startxref_pos()` then does `int(b"%%EOF")`, which raises `ValueError`, and
because `b"%%EOF"` does not start with `b"startxref"` it falls straight through
to `raise PdfReadError("startxref not found")`. The document never opens, even
though the xref pointer just above is perfectly intact and other viewers read
the file fine. This is the layout @stefan6419846 identified in the issue.

Minimal reproducer (no external file needed):

```python
import io
from pypdf import PdfReader, PdfWriter

writer = PdfWriter()
writer.add_blank_page(200, 200)
buffer = io.BytesIO()
writer.write(buffer)

PdfReader(io.BytesIO(buffer.getvalue() + b"\n%%EOF\n"))
# pypdf.errors.PdfReadError: startxref not found
```

## The fix

Skip the trailing run of markers so the offset above the *first* marker of the
run is read.

Two deliberate choices:

* **No strict-mode carve-out.** The `startxref`-keyword-missing branch just below
  is gated on `self.strict` because recovering there means falling back to an
  *earlier revision*, which violates the standard (#3238). Skipping duplicate
  trailing markers does not change which revision is used — it only ignores
  marker padding, and the offset that gets read is the one the file itself
  points at. That matches the existing unconditional `"startxref on same line as
  offset"` recovery in the same function. Happy to gate it on `strict` instead if
  you would rather have strict mode reject these files.
* **Bounded scan.** Reuses `_MAX_STARTXREF_RECOVERY_LINES`, like
  `_find_previous_startxref_pos()`, so a crafted file made of nothing but `%%EOF`
  lines cannot make the backward scan walk the whole stream.

A warning is logged whenever markers are skipped, so the malformation stays
visible.

## Tests

`test_duplicate_eof_markers` is parametrised over marker layouts x `strict`:
no extra marker (control), an adjacent marker, a marker after a blank line (the
layout in the issue), two extra markers, and a marker with no trailing newline --
10 cases. `test_duplicate_eof_markers_without_startxref` adds 3 more, pinning
that a run of markers with no offset above it is still reported as broken: when
the run reaches the start of the stream, when a non-offset line sits above it,
and when the run is longer than the bound on the backward scan.

Verified red/green: with the tests present and `pypdf/_reader.py` reverted, the 8
duplicate-marker cases fail and the controls pass; with the fix, all 13 pass.
`tests/test_reader.py` goes from 100 to 113 passed with no change to the
pre-existing failures (5, all `FileNotFoundError` from the `sample-files`
submodule not being checked out locally), and the full suite gains the same 13
with its pre-existing failure count unchanged. Branch coverage over the added
block is complete. `ruff check` (v0.16.0, the pinned `.pre-commit-config.yaml`
revision) is clean on both changed files.

I did not download the reporter's PDF; the reproducer above produces the exact
byte layout and traceback from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


