### PR TITLE
BUG: Report an out-of-range page number when adding a destination or URI

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1944,12 +1944,20 @@ class PdfWriter(PdfDocCommon):
 
         return page_destination_ref
 
+    def _get_page_reference(self, page_number: int) -> Any:
+        """Look up a page by number, reporting a bad index rather than an IndexError from the kids array."""
+        pages = cast(DictionaryObject, self.get_object(self._pages))
+        kids = cast(ArrayObject, pages[PagesAttributes.KIDS])
+        if not (-len(kids) <= page_number < len(kids)):
+            raise IndexError(f"Page number {page_number} is out of range")
+        return kids[page_number]
+
     def add_named_destination(
         self,
         title: str,
         page_number: int,
     ) -> IndirectObject:
-        page_ref = self.get_object(self._pages)[PagesAttributes.KIDS][page_number]  # type: ignore[index]
+        page_ref = self._get_page_reference(page_number)
         dest = DictionaryObject()
         dest.update(
             {
@@ -2300,7 +2308,7 @@ class PdfWriter(PdfDocCommon):
                 drawn if this argument is omitted.
 
         """
-        page_link = self.get_object(self._pages)[PagesAttributes.KIDS][page_number]  # type: ignore[index]
+        page_link = self._get_page_reference(page_number)
         page_ref = cast(dict[str, Any], self.get_object(page_link))
 
         border_arr: BorderArrayType

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -1948,7 +1948,8 @@ class PdfWriter(PdfDocCommon):
         """Look up a page by number, reporting a bad index rather than an IndexError from the kids array."""
         pages = cast(DictionaryObject, self.get_object(self._pages))
         kids = cast(ArrayObject, pages[PagesAttributes.KIDS])
-        if not (-len(kids) <= page_number < len(kids)):
+        count = len(kids)
+        if not (-count <= page_number < count):
             raise IndexError(f"Page number {page_number} is out of range")
         return kids[page_number]
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3662,3 +3662,30 @@ def test_num_copies_accepts_zero_and_above(value):
     viewer_preferences = writer.create_viewer_preferences()
     viewer_preferences.num_copies = value
     assert viewer_preferences.num_copies == value
+
+
+@pytest.mark.parametrize("page_number", [3, 99, -4, -99])
+def test_add_named_destination_out_of_range(page_number):
+    """An out-of-range page surfaced as an IndexError from the kids array."""
+    writer = PdfWriter()
+    for _ in range(3):
+        writer.add_blank_page(100, 100)
+    with pytest.raises(IndexError, match=f"Page number {page_number} is out of range"):
+        writer.add_named_destination("destination", page_number)
+
+
+@pytest.mark.parametrize("page_number", [3, 99, -4, -99])
+def test_add_uri_out_of_range(page_number):
+    writer = PdfWriter()
+    for _ in range(3):
+        writer.add_blank_page(100, 100)
+    with pytest.raises(IndexError, match=f"Page number {page_number} is out of range"):
+        writer.add_uri(page_number, "https://example.com", RectangleObject([0, 0, 1, 1]))
+
+
+@pytest.mark.parametrize("page_number", [0, 2, -1, -3])
+def test_add_named_destination_in_range(page_number):
+    writer = PdfWriter()
+    for _ in range(3):
+        writer.add_blank_page(100, 100)
+    assert writer.add_named_destination("destination", page_number) is not None


### PR DESCRIPTION
`add_named_destination` and `add_uri` index the kids array with the page number directly:

```python
>>> writer.add_named_destination("destination", 99)
IndexError: list index out of range
>>> writer.add_uri(99, "https://example.com", rect)
IndexError: list index out of range
```

Nothing in the message points at the argument that caused it.

`_VirtualList` already raises `IndexError` with the index it was given, so both now report the page number through a shared lookup and keep accepting negative ones.

Reverting the change fails the eight new tests