### PR TITLE
BUG: Check the page label style and type it as the strings it accepts

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -125,16 +125,6 @@ from .types import (
 from .xmp import XmpInformation
 
 ALL_DOCUMENT_PERMISSIONS = UserAccessPermissions.all()
-# The five numbering styles of Table 8.10 in the 1.7 reference, as written into
-# the /S entry of a page label dictionary.
-PageLabelStyleType = Literal["/D", "/R", "/r", "/A", "/a"]
-_PAGE_LABEL_STYLES = (
-    PageLabelStyle.DECIMAL,
-    PageLabelStyle.UPPERCASE_ROMAN,
-    PageLabelStyle.LOWERCASE_ROMAN,
-    PageLabelStyle.UPPERCASE_LETTER,
-    PageLabelStyle.LOWERCASE_LETTER,
-)
 
 
 class ObjectDeletionFlag(enum.IntFlag):
@@ -3251,7 +3241,7 @@ class PdfWriter(PdfDocCommon):
         self,
         page_index_from: int,
         page_index_to: int,
-        style: Optional[PageLabelStyleType] = None,
+        style: Optional[PageLabelStyle] = None,
         prefix: Optional[str] = None,
         start: Optional[int] = 0,
     ) -> None:
@@ -3285,9 +3275,9 @@ class PdfWriter(PdfDocCommon):
         """
         if style is None and prefix is None:
             raise ValueError("At least one of style and prefix must be given")
-        if style is not None and style not in _PAGE_LABEL_STYLES:
+        if style is not None and style not in tuple(PageLabelStyle):
             raise ValueError(
-                f"style must be one of: {', '.join(_PAGE_LABEL_STYLES)}, got {style!r}"
+                f"style must be one of: {', '.join(PageLabelStyle)}, got {style!r}"
             )
         if page_index_from < 0:
             raise ValueError("page_index_from must be greater or equal than 0")
@@ -3306,7 +3296,7 @@ class PdfWriter(PdfDocCommon):
         self,
         page_index_from: int,
         page_index_to: int,
-        style: Optional[PageLabelStyleType] = None,
+        style: Optional[PageLabelStyle] = None,
         prefix: Optional[str] = None,
         start: Optional[int] = 0,
     ) -> None:

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -125,6 +125,16 @@ from .types import (
 from .xmp import XmpInformation
 
 ALL_DOCUMENT_PERMISSIONS = UserAccessPermissions.all()
+# The five numbering styles of Table 8.10 in the 1.7 reference, as written into
+# the /S entry of a page label dictionary.
+PageLabelStyleType = Literal["/D", "/R", "/r", "/A", "/a"]
+_PAGE_LABEL_STYLES = (
+    PageLabelStyle.DECIMAL,
+    PageLabelStyle.UPPERCASE_ROMAN,
+    PageLabelStyle.LOWERCASE_ROMAN,
+    PageLabelStyle.UPPERCASE_LETTER,
+    PageLabelStyle.LOWERCASE_LETTER,
+)
 
 
 class ObjectDeletionFlag(enum.IntFlag):
@@ -3241,7 +3251,7 @@ class PdfWriter(PdfDocCommon):
         self,
         page_index_from: int,
         page_index_to: int,
-        style: Optional[PageLabelStyle] = None,
+        style: Optional[PageLabelStyleType] = None,
         prefix: Optional[str] = None,
         start: Optional[int] = 0,
     ) -> None:
@@ -3275,6 +3285,10 @@ class PdfWriter(PdfDocCommon):
         """
         if style is None and prefix is None:
             raise ValueError("At least one of style and prefix must be given")
+        if style is not None and style not in _PAGE_LABEL_STYLES:
+            raise ValueError(
+                f"style must be one of: {', '.join(_PAGE_LABEL_STYLES)}, got {style!r}"
+            )
         if page_index_from < 0:
             raise ValueError("page_index_from must be greater or equal than 0")
         if page_index_to < page_index_from:
@@ -3292,7 +3306,7 @@ class PdfWriter(PdfDocCommon):
         self,
         page_index_from: int,
         page_index_to: int,
-        style: Optional[PageLabelStyle] = None,
+        style: Optional[PageLabelStyleType] = None,
         prefix: Optional[str] = None,
         start: Optional[int] = 0,
     ) -> None:

--- a/pypdf/constants.py
+++ b/pypdf/constants.py
@@ -662,7 +662,7 @@ class OutlineFontFlag(IntFlag):
     bold = 2
 
 
-class PageLabelStyle:
+class PageLabelStyle(StrEnum):
     """
     Table 8.10 in the 1.7 reference.
     Table 161 in the 2.0 reference.

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1497,6 +1497,8 @@ def test_set_page_label(pdf_file_path):
         ValueError, match="If given, start must be greater or equal than one"
     ):
         writer.set_page_label(0, 5, "/r", start=-1)
+    with pytest.raises(ValueError, match=r"style must be one of: /D, /R, /r, /A, /a"):
+        writer.set_page_label(0, 5, "/Nonsense")
 
     pdf_file_path.unlink()
 
@@ -3662,3 +3664,21 @@ def test_num_copies_accepts_zero_and_above(value):
     viewer_preferences = writer.create_viewer_preferences()
     viewer_preferences.num_copies = value
     assert viewer_preferences.num_copies == value
+
+
+@pytest.mark.parametrize("style", ["/D", "/R", "/r", "/A", "/a"])
+def test_set_page_label_accepts_the_spec_styles(style):
+    writer = PdfWriter()
+    for _ in range(2):
+        writer.add_blank_page(100, 100)
+    writer.set_page_label(0, 1, style)
+
+
+@pytest.mark.parametrize("style", ["/Nonsense", "/d", "D", ""])
+def test_set_page_label_rejects_other_styles(style):
+    """An unknown style was written through and then ignored when read back."""
+    writer = PdfWriter()
+    for _ in range(2):
+        writer.add_blank_page(100, 100)
+    with pytest.raises(ValueError, match="style must be one of"):
+        writer.set_page_label(0, 1, style)


### PR DESCRIPTION
`set_page_label` validates its indices, its `start` and that a style or prefix is given, but not the style itself:

```python
>>> writer.set_page_label(0, 2, "/Nonsense")
>>> PdfReader(out).page_labels
['1', '2', '3']  # the style was dropped
```

`index2label` logs "Ignoring unknown page label numbering style" and falls back to the page position, so the caller is left with plain numbers and a log line.

The style was also annotated `Optional[PageLabelStyle]`, which is a plain class holding the five string constants rather than a type any caller can satisfy - every caller passes `"/D"`. Typed as the literal strings it takes, which clears two typeguard failures.

Reverting the change fails the four new tests