### PR TITLE
ROB: Do not crash when the AcroForm fields entry is not an array

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -584,7 +584,14 @@ class PdfDocCommon(ABC):
             return retval
         assert stack is not None
         if "/Fields" in tree:
-            fields = cast(ArrayObject, tree["/Fields"])
+            fields = tree["/Fields"].get_object()
+            if not isinstance(fields, ArrayObject):
+                logger_warning(
+                    "AcroForm /Fields is not an array: %(fields)s",
+                    source=__name__,
+                    fields=fields,
+                )
+                return retval
             for f in fields:
                 field = f.get_object()
                 self._build_field(field, retval, fileobj, field_attributes, stack)

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1035,3 +1035,26 @@ def test_get_outline__entry_count():
                 expected_exception=LimitReachedError, match=r"^Maximum outline entry limit reached: 1001 > 1000\.$"
             ):
         writer._get_outline()
+
+
+@pytest.mark.parametrize(
+    ("fields", "expected"),
+    [
+        (NumberObject(1), "AcroForm /Fields is not an array: 1"),
+        (TextStringObject("x"), "AcroForm /Fields is not an array: x"),
+        (DictionaryObject(), "AcroForm /Fields is not an array: {}"),
+    ],
+)
+def test_get_fields__fields_is_not_an_array(caplog, fields, expected):
+    """A malformed /Fields raised a TypeError when the loop tried to iterate it."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/AcroForm")] = DictionaryObject(
+        {NameObject("/Fields"): fields}
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).get_fields() == {}
+    assert expected in caplog.text

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1040,9 +1040,15 @@ def test_get_outline__entry_count():
 @pytest.mark.parametrize(
     ("fields", "expected"),
     [
-        (NumberObject(1), "AcroForm /Fields is not an array: 1"),
-        (TextStringObject("x"), "AcroForm /Fields is not an array: x"),
-        (DictionaryObject(), "AcroForm /Fields is not an array: {}"),
+        pytest.param(
+            NumberObject(1), "AcroForm /Fields is not an array: 1", id="number"
+        ),
+        pytest.param(
+            TextStringObject("x"), "AcroForm /Fields is not an array: x", id="string"
+        ),
+        pytest.param(
+            DictionaryObject(), "AcroForm /Fields is not an array: {}", id="dictionary"
+        ),
     ],
 )
 def test_get_fields__fields_is_not_an_array(caplog, fields, expected):


### PR DESCRIPTION
`get_fields` casts `/Fields` to an `ArrayObject` and iterates it, so a file where that entry holds a number, a string or a dictionary raises:

```python
>>> reader.get_fields()
TypeError: 'NumberObject' object is not iterable
```

The reference is resolved first, since `/Fields` is usually indirect, and an entry that cannot be walked is reported the same way as the other malformed structures the reader tolerates. Real forms are untouched.

Reverting the change fails the three new tests