### PR TITLE
ROB: Do not crash when the destination tree is not a dictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -489,12 +489,22 @@ class PdfDocCommon(ABC):
             catalog = self.root_object
 
             # get the name tree
+            candidate: Optional[PdfObject] = None
             if CA.DESTS in catalog:
-                tree = cast(DictionaryObject, catalog[CA.DESTS])
+                candidate = catalog[CA.DESTS].get_object()
             elif CA.NAMES in catalog:
-                names = cast(DictionaryObject, catalog[CA.NAMES])
-                if CA.DESTS in names:
-                    tree = cast(DictionaryObject, names[CA.DESTS])
+                names = catalog[CA.NAMES].get_object()
+                if isinstance(names, DictionaryObject) and CA.DESTS in names:
+                    candidate = names[CA.DESTS].get_object()
+            if candidate is not None and not isinstance(candidate, DictionaryObject):
+                logger_warning(
+                    "Destination tree is not a dictionary: %(tree)s",
+                    source=__name__,
+                    tree=candidate,
+                )
+                return retval
+            if candidate is not None:
+                tree = candidate
 
         if is_null_or_none(tree):
             return retval

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1147,3 +1147,64 @@ def test_outline__reads_a_well_formed_outline():
         "Chapter 1",
         "Chapter 2",
     ]
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        pytest.param(
+            "/Dests",
+            NumberObject(1),
+            "Destination tree is not a dictionary: 1",
+            id="number",
+        ),
+        pytest.param(
+            "/Dests",
+            ArrayObject(),
+            "Destination tree is not a dictionary: []",
+            id="array",
+        ),
+        pytest.param(
+            "/Dests",
+            TextStringObject("x"),
+            "Destination tree is not a dictionary: x",
+            id="string",
+        ),
+    ],
+)
+def test_get_named_destinations__tree_is_not_a_dictionary(caplog, key, value, expected):
+    """A malformed name tree raised a TypeError from the first membership test."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject(key)] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).named_destinations == {}
+    assert expected in caplog.text
+
+
+def test_get_named_destinations__names_is_not_a_dictionary():
+    """A /Names entry that cannot hold /Dests simply yields no destinations."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/Names")] = NumberObject(1)
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).named_destinations == {}
+
+
+def test_get_named_destinations__reads_a_well_formed_tree():
+    writer = PdfWriter()
+    for _ in range(2):
+        writer.add_blank_page(width=72, height=72)
+    writer.add_named_destination("Chapter 1", 0)
+    writer.add_named_destination("Chapter 2", 1)
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert sorted(PdfReader(stream).named_destinations) == ["Chapter 1", "Chapter 2"]


### PR DESCRIPTION
`_get_named_destinations` casts `/Dests` and `/Names` to a `DictionaryObject` and then tests membership on the result, so a file where either holds a number, a string or an array brings down the read:

```python
>>> reader.named_destinations
TypeError: argument of type 'NumberObject' is not iterable
```

The references are resolved first, since both are usually indirect, and a tree that cannot be walked is reported the way the cycle in the same function already is.

Reverting the change fails the four new tests