### PR TITLE
ROB: Do not crash when the viewer preferences are not a dictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -328,6 +328,13 @@ class PdfDocCommon(ABC):
         if o is None:
             return None
         o = o.get_object()
+        if not isinstance(o, DictionaryObject):
+            logger_warning(
+                "Viewer preferences are not a dictionary: %(preferences)s",
+                source=__name__,
+                preferences=o,
+            )
+            return None
         if not isinstance(o, ViewerPreferences):
             o = ViewerPreferences(o)
             if hasattr(o, "indirect_reference") and o.indirect_reference is not None:

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1064,3 +1064,43 @@ def test_get_fields__fields_is_not_an_array(caplog, fields, expected):
 
     assert PdfReader(stream).get_fields() == {}
     assert expected in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            NumberObject(1), "Viewer preferences are not a dictionary: 1", id="number"
+        ),
+        pytest.param(
+            ArrayObject(), "Viewer preferences are not a dictionary: []", id="array"
+        ),
+        pytest.param(
+            TextStringObject("x"),
+            "Viewer preferences are not a dictionary: x",
+            id="string",
+        ),
+    ],
+)
+def test_viewer_preferences__not_a_dictionary(caplog, value, expected):
+    """A malformed entry raised an AttributeError from the ViewerPreferences init."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/ViewerPreferences")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).viewer_preferences is None
+    assert expected in caplog.text
+
+
+def test_viewer_preferences__reads_a_well_formed_dictionary():
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.create_viewer_preferences().center_window = True
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).viewer_preferences == {"/CenterWindow": True}


### PR DESCRIPTION
The property hands whatever `/ViewerPreferences` holds to the `ViewerPreferences` constructor, which calls `.items()` on it behind a `type: ignore`:

```python
>>> reader.viewer_preferences
AttributeError: 'NumberObject' object has no attribute 'items'
```

An entry that cannot be read as preferences is reported and treated as absent, which is what the property already returns when the key is missing.

Reverting the change fails the three new tests