### PR TITLE
ROB: Do not crash when the page labels are not a dictionary

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -202,7 +202,14 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
     root = cast(DictionaryObject, reader.root_object)
     if "/PageLabels" not in root:
         return str(index + 1)  # Fallback
-    number_tree = cast(DictionaryObject, root["/PageLabels"].get_object())
+    number_tree = root["/PageLabels"].get_object()
+    if not isinstance(number_tree, DictionaryObject):
+        logger_warning(
+            "Page labels are not a dictionary: %(number_tree)s",
+            source=__name__,
+            number_tree=number_tree,
+        )
+        return str(index + 1)  # Fallback
     if "/Nums" in number_tree:
         return get_label_from_nums(number_tree, index)
     if "/Kids" in number_tree and not isinstance(number_tree["/Kids"], NullObject):

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -254,9 +254,13 @@ def test_index2label__malformed_kid_limits(limits, caplog):
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        (NumberObject(1), "Page labels are not a dictionary: 1"),
-        (ArrayObject(), "Page labels are not a dictionary: []"),
-        (TextStringObject("x"), "Page labels are not a dictionary: x"),
+        pytest.param(
+            NumberObject(1), "Page labels are not a dictionary: 1", id="number"
+        ),
+        pytest.param(ArrayObject(), "Page labels are not a dictionary: []", id="array"),
+        pytest.param(
+            TextStringObject("x"), "Page labels are not a dictionary: x", id="string"
+        ),
     ],
 )
 def test_index2label__page_labels_not_a_dictionary(caplog, value, expected):

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import pytest
 
-from pypdf import PdfReader
+from pypdf import PdfReader, PdfWriter
 from pypdf._page_labels import (
     get_label_from_nums,
     index2label,
@@ -21,6 +21,7 @@ from pypdf.generic import (
     NameObject,
     NullObject,
     NumberObject,
+    TextStringObject,
 )
 
 from . import RESOURCE_ROOT, get_data_from_url
@@ -248,3 +249,25 @@ def test_index2label__malformed_kid_limits(limits, caplog):
     assert index2label(reader, 5) == "6"
     assert "Ignoring kid with missing or malformed /Limits" in caplog.text
     assert "Could not reliably determine page label" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (NumberObject(1), "Page labels are not a dictionary: 1"),
+        (ArrayObject(), "Page labels are not a dictionary: []"),
+        (TextStringObject("x"), "Page labels are not a dictionary: x"),
+    ],
+)
+def test_index2label__page_labels_not_a_dictionary(caplog, value, expected):
+    """A malformed /PageLabels raised a TypeError from the first membership test."""
+    writer = PdfWriter()
+    for _ in range(2):
+        writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/PageLabels")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).page_labels == ["1", "2"]
+    assert expected in caplog.text


### PR DESCRIPTION
`index2label` casts `/PageLabels` to a `DictionaryObject` and tests membership on the result:

```python
>>> reader.page_labels
TypeError: argument of type 'NumberObject' is not iterable
```

The function already falls back to the page position when `/PageLabels` is absent, so an entry it cannot read is reported and takes the same path.

Reverting the change fails the three new tests