### PR TITLE
ROB: Do not crash when the outlines entry is not a dictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -916,13 +916,21 @@ class PdfDocCommon(ABC):
 
             # get the outline dictionary and named destinations
             if Core.OUTLINES in catalog:
-                lines = cast(DictionaryObject, catalog[Core.OUTLINES])
+                lines = catalog[Core.OUTLINES].get_object()
 
                 if isinstance(lines, NullObject):
                     return outline
 
+                if not isinstance(lines, DictionaryObject):
+                    logger_warning(
+                        "Outlines are not a dictionary: %(lines)s",
+                        source=__name__,
+                        lines=lines,
+                    )
+                    return outline
+
                 # §12.3.3 Document outline, entries in the outline dictionary
-                if not is_null_or_none(lines) and "/First" in lines:
+                if "/First" in lines:
                     node = cast(DictionaryObject, lines["/First"])
             self._named_destinations = self._get_named_destinations()
 

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1208,3 +1208,57 @@ def test_get_named_destinations__reads_a_well_formed_tree():
     stream.seek(0)
 
     assert sorted(PdfReader(stream).named_destinations) == ["Chapter 1", "Chapter 2"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "Outlines are not a dictionary: 1", id="number"),
+        pytest.param(ArrayObject(), "Outlines are not a dictionary: []", id="array"),
+        pytest.param(
+            TextStringObject("x"), "Outlines are not a dictionary: x", id="string"
+        ),
+    ],
+)
+def test_outline__outlines_entry_is_not_a_dictionary(caplog, value, expected):
+    """A malformed /Outlines raised a TypeError from the /First membership test."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/Outlines")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).outline == []
+    assert expected in caplog.text
+
+
+@pytest.mark.parametrize(
+    "indirect",
+    [pytest.param(False, id="direct"), pytest.param(True, id="indirect")],
+)
+def test_outline__outlines_entry_is_null(indirect):
+    """A null entry, direct or behind a reference, still yields no outline."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    value = NullObject()
+    writer.root_object[NameObject("/Outlines")] = (
+        writer._add_object(value) if indirect else value
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).outline == []
+
+
+def test_outline__reads_a_well_formed_outlines_entry():
+    writer = PdfWriter()
+    for _ in range(2):
+        writer.add_blank_page(width=72, height=72)
+    writer.add_outline_item("Chapter 1", 0)
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert [item.title for item in PdfReader(stream).outline] == ["Chapter 1"]


### PR DESCRIPTION
`_get_outline` casts `/Outlines` to a `DictionaryObject` and tests `/First` membership on the result:

```python
>>> reader.outline
TypeError: argument of type 'NumberObject' is not iterable
```

The function already returns an empty outline for a null entry, so one it cannot read is reported and takes the same path.

This is a different line from #4018, which guards a node inside the walk rather than the catalog entry itself.

Reverting the change fails the three new tests