### PR TITLE
BUG: Detect a duplicate dictionary key whose first value is falsy

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -630,7 +630,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 retval.update(data)
                 return retval  # return partial data
 
-            if not data.get(key):
+            if key not in data:
                 data[key] = value
             else:
                 # multiple definitions of key not permitted

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -55,6 +55,50 @@ def test_dictionary_object__get_next_object_position() -> None:
     ) == 15
 
 
+def test_dictionary_object__duplicate_key_with_falsy_first_value__strict() -> None:
+    stream = BytesIO(b"<< /Count 0 /Count 5 >>")
+
+    with pytest.raises(
+            expected_exception=PdfReadError,
+            match=r"^Multiple definitions in dictionary"
+    ):
+        DictionaryObject.read_from_stream(stream, mock.Mock(strict=True))
+
+
+def test_dictionary_object__duplicate_key_with_falsy_first_value__non_strict(
+        caplog: pytest.LogCaptureFixture
+) -> None:
+    stream = BytesIO(b"<< /Count 0 /Count 5 >>")
+
+    dictionary = DictionaryObject.read_from_stream(stream, mock.Mock(strict=False))
+
+    assert caplog.messages == ["Multiple definitions in dictionary at byte 0x14 for key /Count"]
+    # The first value wins, which is how a duplicate with a non-falsy first value
+    # has always behaved. Before the fix this case kept 5 and logged nothing.
+    assert dictionary == {NameObject("/Count"): NumberObject(0)}
+
+
+def test_dictionary_object__duplicate_key_with_non_falsy_first_value__strict() -> None:
+    stream = BytesIO(b"<< /Count 7 /Count 5 >>")
+
+    with pytest.raises(
+            expected_exception=PdfReadError,
+            match=r"^Multiple definitions in dictionary"
+    ):
+        DictionaryObject.read_from_stream(stream, mock.Mock(strict=True))
+
+
+def test_dictionary_object__different_keys_with_falsy_first_value() -> None:
+    stream = BytesIO(b"<< /Count 0 /Size 5 >>")
+
+    dictionary = DictionaryObject.read_from_stream(stream, mock.Mock(strict=True))
+
+    assert dictionary == {
+        NameObject("/Count"): NumberObject(0),
+        NameObject("/Size"): NumberObject(5),
+    }
+
+
 def test_tree_object__cyclic_reference(caplog: pytest.LogCaptureFixture) -> None:
     writer = PdfWriter()
     child1_object = DictionaryObject()


### PR DESCRIPTION
## Problem

`DictionaryObject.read_from_stream()` decides whether a key has already been seen with:

```python
if not data.get(key):
    data[key] = value
else:
    # multiple definitions of key not permitted
```

The test checks truthiness, not presence. A first value of `NumberObject(0)` is falsy. On the second occurrence `data.get(key)` returns `0`, so `not 0` is `True`. The branch then treats the key as new. It does not report the duplicate, and the second value replaces the first.

This happens even with `strict=True`, where the reader is supposed to raise.

Behaviour on current main:

| input | result |
|---|---|
| `<< /Count 7 /Count 5 >>` | warns, keeps `7` |
| `<< /Count 0 /Count 5 >>` | silent, keeps `5` |

The second row is the bug. pypdf does not raise, and it does not log. It also keeps the opposite value from every other duplicate.

## Change

```python
if key not in data:
```

Presence, not truthiness. The falsy case now behaves like every other duplicate: `strict=True` raises, non-strict warns, and the first value is kept.

| input | before | after |
|---|---|---|
| `<< /Count 7 /Count 5 >>` | warns, keeps `7` | unchanged |
| `<< /Count 0 /Count 5 >>` | silent, keeps `5` | warns, keeps `0` |
| `<< /Count 0 /Size 5 >>` | both keys kept | unchanged |

The non-strict result for the second row changes from `5` to `0`. That change is the point. It now matches the first row, which has always kept the first value.

## Tests

Four tests in `tests/generic/test_data_structures.py`, all from bytes in memory, no fixture download:

- duplicate key with a falsy first value raises under `strict=True`
- the same input under non-strict logs the message and keeps the first value
- duplicate key with a non-falsy first value still raises, unchanged
- two different keys where the first value is `0` parse normally, so there is no false positive

Reverting the one-line change fails the first two and leaves the last two passing.

`tests/generic/` reports 90 passed with the change and 86 without it. One test, `test_files.py::test_embedded_file__basic`, fails either way in my environment because a fixture is missing locally.

`ruff check` passes on both files.

## AI usage disclosure

Per the AI policy in CONTRIBUTING.md: I used Claude Code (Anthropic, Opus 5) while working on this. I reviewed the change, reproduced the behaviour myself before and after, and understand and stand behind it. Happy to explain any part of it or adjust the approach.
