### PR TITLE
BUG: Treat an empty /Filter array as no filter when extracting images

### DIFF
--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -585,7 +585,9 @@ def _xobj_to_image(
 
     # Get filters
     filters = x_object.get(StreamAttributes.FILTER, NullObject()).get_object()
-    lfilters = filters[-1] if isinstance(filters, list) else filters
+    # An empty array is a valid way of saying that no filter is applied: treat it
+    # like a missing /Filter entry rather than raising IndexError on the lookup.
+    lfilters = filters[-1] if isinstance(filters, list) and filters else filters
     decode_parms = x_object.get(StreamAttributes.DECODE_PARMS)
     if decode_parms and isinstance(decode_parms, (tuple, list)):
         decode_parms = decode_parms[0]

--- a/tests/generic/test_image_xobject.py
+++ b/tests/generic/test_image_xobject.py
@@ -509,3 +509,18 @@ def test_xobj_to_image__acyclic_smask_still_applied() -> None:
 
     assert extension == ".png"
     assert img.mode == "LA"
+
+
+def test_xobj_to_image__empty_filter_array() -> None:
+    """An empty /Filter array means no filter and must not raise IndexError."""
+    image = _minimal_image_xobject()
+    image[NameObject(StreamAttributes.FILTER)] = ArrayObject([])
+
+    extension, _, img = _xobj_to_image(image)
+
+    # Identical to the same image without any /Filter entry at all.
+    expected_extension, _, expected_img = _xobj_to_image(_minimal_image_xobject())
+    assert (extension, img.mode, img.tobytes()) == (
+        expected_extension, expected_img.mode, expected_img.tobytes()
+    )
+    assert extension == ".png"


### PR DESCRIPTION
Closes #4025.

## Problem

`_xobj_to_image()` reads the `/Filter` entry and then takes its last element:

```python
filters = x_object.get(StreamAttributes.FILTER, NullObject()).get_object()
lfilters = filters[-1] if isinstance(filters, list) else filters
```

The check only confirms that the value *is* a list, and then assumes it can be
indexed with `-1`. For an image whose `/Filter` is an **empty** array that raises
`IndexError: list index out of range`, exactly as reported:

```
{'/Height': 1, '/Width': 256, '/ColorSpace': '/DeviceRGB', '/BitsPerComponent': 8, '/Filter': []}
```

Because `page.images` builds its id list eagerly, the failure is not limited to
the offending image — iterating `page.images` raises for the whole page.

## Fix

An empty array carries the same meaning as a missing `/Filter` entry: no filter
is applied. The lookup is now skipped when the array is empty, so the image
takes the same unfiltered path it would take with no `/Filter` key at all.

## Testing

`tests/generic/test_image_xobject.py::test_xobj_to_image__empty_filter_array`
builds the minimal image XObject with `/Filter []` and asserts the result is
byte-identical to the same XObject with no `/Filter` entry.

Verified locally:

- without the source change the new test fails with the reported
  `IndexError: list index out of range` at the `filters[-1]` line;
- with it, `tests/generic/test_image_xobject.py` is 27 passed;
- `ruff` and `mypy` (1.17.1, the pinned pre-commit revision) are clean on both
  changed files.

The remaining failures in `tests/test_images.py` / `tests/test_filters.py` on my
machine are pre-existing `FileNotFoundError`s for network fixtures — identical
counts (37 failed / 130 passed) with and without this patch.

## Note on the base

My fork is 68 commits behind and I currently cannot push a branch based on the
newer `main`, so this branch is built on the fork's own tip. The merge base is
`f6287fa` and the diff against `main` is exactly the two files above (+18/-1) —
no unrelated drift is included. I re-ran the tests, `ruff` and `mypy` against
both `main` and the fork tip; both are green. Happy to rebase if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
