### PR TITLE
ROB: Do not crash when the AcroForm entry is not a dictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -593,7 +593,18 @@ class PdfDocCommon(ABC):
             stack = []
             # get the AcroForm tree
             if CA.ACRO_FORM in catalog:
-                tree = cast(Optional[DictionaryObject], catalog[CA.ACRO_FORM])
+                entry = catalog[CA.ACRO_FORM]
+                acro_form = None if entry is None else entry.get_object()
+                if acro_form is not None and not isinstance(
+                    acro_form, DictionaryObject
+                ):
+                    logger_warning(
+                        "AcroForm is not a dictionary: %(acro_form)s",
+                        source=__name__,
+                        acro_form=acro_form,
+                    )
+                    return None
+                tree = acro_form
             else:
                 return None
         if tree is None:

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1287,3 +1287,26 @@ def test_build_field__entry_is_not_a_dictionary(caplog, value, expected):
 
     assert PdfReader(stream).get_fields() == {}
     assert expected in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "AcroForm is not a dictionary: 1", id="number"),
+        pytest.param(ArrayObject(), "AcroForm is not a dictionary: []", id="array"),
+        pytest.param(
+            TextStringObject("x"), "AcroForm is not a dictionary: x", id="string"
+        ),
+    ],
+)
+def test_get_fields__acro_form_is_not_a_dictionary(caplog, value, expected):
+    """A malformed /AcroForm raised a TypeError from the /Fields membership test."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/AcroForm")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).get_fields() is None
+    assert expected in caplog.text


### PR DESCRIPTION
If a PDF has a /AcroForm entry that is not a dictionary, reading the form fields crashes. The code assumes the entry is a dictionary and looks for /Fields inside it. If it is a number, a string or an array instead, that check fails with a plain Python error.

get_fields already returns None when there is no /AcroForm at all, so now an entry it cannot read does the same thing and logs a warning.

This is the same problem as #4019, one level higher — that one fixed the /Fields array, this one fixes the /AcroForm entry itself.