### PR TITLE
ROB: Do not crash when the XObject resources are not a dictionary

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -661,15 +661,15 @@ class PageObject(DictionaryObject):
             # for inline images, cache dict entries are not None
             return [image_name for image_name, image_value in self._content_stream_images.items() if image_value]
 
-        x_object_entry = resources[RES.XOBJECT].get_object()  # type: ignore
-        if not isinstance(x_object_entry, DictionaryObject):
+        x_object = resources[RES.XOBJECT].get_object()  # type: ignore[index]
+        if not isinstance(x_object, DictionaryObject):
             logger_warning(
                 "XObject resources are not a dictionary: %(x_object)s",
                 source=__name__,
-                x_object=x_object_entry,
+                x_object=x_object,
             )
             return []
-        x_object = cast(Any, x_object_entry)
+        x_object = cast(Any, x_object)
 
         # Iterate through all XObject resources
         for o in x_object:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -661,7 +661,15 @@ class PageObject(DictionaryObject):
             # for inline images, cache dict entries are not None
             return [image_name for image_name, image_value in self._content_stream_images.items() if image_value]
 
-        x_object = resources[RES.XOBJECT].get_object()  # type: ignore
+        x_object_entry = resources[RES.XOBJECT].get_object()  # type: ignore
+        if not isinstance(x_object_entry, DictionaryObject):
+            logger_warning(
+                "XObject resources are not a dictionary: %(x_object)s",
+                source=__name__,
+                x_object=x_object_entry,
+            )
+            return []
+        x_object = cast(Any, x_object_entry)
 
         # Iterate through all XObject resources
         for o in x_object:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -669,20 +669,20 @@ class PageObject(DictionaryObject):
                 x_object=x_object,
             )
             return []
-        x_object = cast(Any, x_object)
 
         # Iterate through all XObject resources
         for o in x_object:
+            entry = x_object[o]
             # Skip non-stream objects (only process StreamObject)
-            if not isinstance(x_object[o], StreamObject):
+            if not isinstance(entry, StreamObject):
                 continue
-            if x_object[o][ImageAttributes.SUBTYPE] == "/Image":
+            if entry.get(ImageAttributes.SUBTYPE, "") == "/Image":
                 # If it's an image, add it to lst for further processing
                 lst.append(o if len(ancest) == 0 else [*ancest, o])
             else:
                 # If it's a form, recursively search for images inside it
                 # Forms may contain images that are Do-referenced in their content stream
-                lst.extend(self._get_ids_image(x_object[o], [*ancest, o], call_stack))
+                lst.extend(self._get_ids_image(entry, [*ancest, o], call_stack))
 
         # Removes duplicates and preserves order
         deduplicated = lst.copy()

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -652,8 +652,8 @@ class PageObject(DictionaryObject):
         lst: list[Union[str, list[str]]] = []
         if (
                 PG.RESOURCES not in obj or
-                is_null_or_none(resources := obj[PG.RESOURCES]) or
-                RES.XOBJECT not in cast(DictionaryObject, resources)
+                is_null_or_none(resources := cast(DictionaryObject, obj[PG.RESOURCES])) or
+                RES.XOBJECT not in resources
         ):
             # Forms without XObject resources have no images inside them
             if len(ancest) > 0:
@@ -661,7 +661,7 @@ class PageObject(DictionaryObject):
             # for inline images, cache dict entries are not None
             return [image_name for image_name, image_value in self._content_stream_images.items() if image_value]
 
-        x_object = resources[RES.XOBJECT].get_object()  # type: ignore[index]
+        x_object = resources[RES.XOBJECT].get_object()
         if not isinstance(x_object, DictionaryObject):
             logger_warning(
                 "XObject resources are not a dictionary: %(x_object)s",

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -19,12 +19,14 @@ from pypdf._page import ImageFile
 from pypdf.errors import LimitReachedError
 from pypdf.filters import JBIG2Decode
 from pypdf.generic import (
+    ArrayObject,
     ContentStream,
     DecodedStreamObject,
     DictionaryObject,
     NameObject,
     NullObject,
     NumberObject,
+    TextStringObject,
 )
 from pypdf.generic._image_xobject import _handle_flate
 
@@ -993,3 +995,34 @@ def test_do_image_lazy_decode_preserves_none():
     assert page._content_stream_images is not None
     # Do images should remain as None (never cached, decoded on demand each time)
     assert page._content_stream_images["/Im1"] is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            NumberObject(1), "XObject resources are not a dictionary: 1", id="number"
+        ),
+        pytest.param(
+            ArrayObject(), "XObject resources are not a dictionary: []", id="array"
+        ),
+        pytest.param(
+            TextStringObject("x"),
+            "XObject resources are not a dictionary: x",
+            id="string",
+        ),
+    ],
+)
+def test_images__xobject_is_not_a_dictionary(caplog, value, expected):
+    """A malformed /XObject raised a TypeError when the loop tried to iterate it."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Resources")] = DictionaryObject(
+        {NameObject("/XObject"): value}
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert list(PdfReader(stream).pages[0].images) == []
+    assert expected in caplog.text


### PR DESCRIPTION
If a page has an /XObject entry that is not a dictionary, listing the images crashes. _get_ids_image reads /XObject from the page resources and loops over it straight away.

The line that reads it already had a type: ignore on it, so the type was known not to be guaranteed. The function returns an empty list when there is no /XObject at all, so now one it cannot read does the same.

Pages with real images are not affected — I checked against the files in resources/.