### PR TITLE
ROB: Do not crash on a form field entry that is not a dictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -663,6 +663,13 @@ class PdfDocCommon(ABC):
         field_attributes: Any,
         stack: list[PdfObject],
     ) -> None:
+        if not isinstance(field, DictionaryObject):
+            logger_warning(
+                "Form field is not a dictionary: %(field)s",
+                source=__name__,
+                field=field,
+            )
+            return
         if all(attr not in field for attr in ("/T", "/TM")):
             return
         key = self._get_qualified_field_name(parent=field)

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1288,7 +1288,3 @@ def test_build_field__entry_is_not_a_dictionary(caplog, value, expected):
     assert PdfReader(stream).get_fields() == {}
     assert expected in caplog.text
 
-
-def test_build_field__reads_a_well_formed_field():
-    reader = PdfReader(RESOURCE_ROOT / "form.pdf")
-    assert reader.get_fields()

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1287,4 +1287,3 @@ def test_build_field__entry_is_not_a_dictionary(caplog, value, expected):
 
     assert PdfReader(stream).get_fields() == {}
     assert expected in caplog.text
-

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1262,3 +1262,33 @@ def test_outline__reads_a_well_formed_outlines_entry():
     stream.seek(0)
 
     assert [item.title for item in PdfReader(stream).outline] == ["Chapter 1"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "Form field is not a dictionary: 1", id="number"),
+        pytest.param(ArrayObject(), "Form field is not a dictionary: []", id="array"),
+        pytest.param(
+            TextStringObject("x"), "Form field is not a dictionary: x", id="string"
+        ),
+    ],
+)
+def test_build_field__entry_is_not_a_dictionary(caplog, value, expected):
+    """A field entry that is not a dictionary raised a TypeError from the /T test."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/AcroForm")] = DictionaryObject(
+        {NameObject("/Fields"): ArrayObject([value])}
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).get_fields() == {}
+    assert expected in caplog.text
+
+
+def test_build_field__reads_a_well_formed_field():
+    reader = PdfReader(RESOURCE_ROOT / "form.pdf")
+    assert reader.get_fields()


### PR DESCRIPTION

If the /Fields array contains something that is not a dictionary, reading the form fields crashes. _build_field checks for /T and /TM inside each entry.

Now an entry that cannot be read is logged and skipped, so the other fields in the form are still returned instead of losing all of them.