### PR TITLE
ENH: _cmap.py: Also parse encoding for embedded CFF Type1 fonts

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -11,7 +11,6 @@ from .generic import (
     DictionaryObject,
     NullObject,
     StreamObject,
-    is_null_or_none,
 )
 
 _predefined_cmap: dict[str, str] = {
@@ -138,8 +137,24 @@ def _parse_to_unicode(
 
     if "/ToUnicode" not in ft:
         if ft.get("/Subtype", "") == "/Type1":
-            return _type1_alternative(ft, map_dict, int_entry)
+            font_descriptor = ft.get("/FontDescriptor", None)
+            if not font_descriptor:
+                return map_dict, int_entry
+
+            if (
+                "/FontFile" in font_descriptor and
+                isinstance(font_file_dict := font_descriptor["/FontFile"], StreamObject)
+            ):
+                font_file_data = font_file_dict.get_data()
+                if not font_file_data:
+                    return map_dict, int_entry
+
+                return _type1_alternative(font_file_data, map_dict, int_entry)
+
+            return map_dict, int_entry
+
         return {}, []
+
     process_rg: bool = False
     process_char: bool = False
     multiline_rg: Union[
@@ -382,18 +397,11 @@ def _glyph_name_to_unicode(glyph_name: str) -> Union[str, None]:
 
 
 def _type1_alternative(
-    ft: DictionaryObject,
+    font_data: bytes,
     map_dict: dict[Any, Any],
     int_entry: list[int],
 ) -> tuple[dict[Any, Any], list[int]]:
-    if "/FontDescriptor" not in ft:
-        return map_dict, int_entry
-    ft_desc = cast(DictionaryObject, ft["/FontDescriptor"]).get("/FontFile")
-    if is_null_or_none(ft_desc):
-        return map_dict, int_entry
-    assert ft_desc is not None, "mypy"
-    txt = ft_desc.get_object().get_data()
-    txt = txt.split(b"eexec\n")[0]  # only clear part
+    txt = font_data.split(b"eexec\n")[0]  # Only the clear part
     encoding_part = txt.split(b"/Encoding")
     if len(encoding_part) < 2:
         return map_dict, int_entry

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -369,6 +369,18 @@ def parse_bfchar(line: bytes, map_dict: dict[Any, Any], int_entry: list[int]) ->
         lst = lst[2:]
 
 
+def _glyph_name_to_unicode(glyph_name: str) -> Union[str, None]:
+    try:
+        return adobe_glyphs[glyph_name]
+    except KeyError:
+        if not glyph_name.startswith("/uni"):
+            return None
+        try:
+            return chr(int(glyph_name[4:], 16))
+        except ValueError:  # pragma: no cover
+            return None
+
+
 def _type1_alternative(
     ft: DictionaryObject,
     map_dict: dict[Any, Any],
@@ -385,7 +397,7 @@ def _type1_alternative(
     encoding_part = txt.split(b"/Encoding")
     if len(encoding_part) < 2:
         return map_dict, int_entry
-    txt = encoding_part[1]  # to get the encoding part
+    txt = encoding_part[1]  # To get the encoding part
     lines = txt.replace(b"\r", b"\n").split(b"\n")
     for li in lines:
         if li.startswith(b"dup"):
@@ -396,16 +408,10 @@ def _type1_alternative(
                 i = int(words[1])
             except ValueError:  # pragma: no cover
                 continue
-            try:
-                v = adobe_glyphs[words[2].decode()]
-            except KeyError:
-                if words[2].startswith(b"/uni"):
-                    try:
-                        v = chr(int(words[2][4:], 16))
-                    except ValueError:  # pragma: no cover
-                        continue
-                else:
-                    continue
-            map_dict[chr(i)] = v
-            int_entry.append(i)
+
+            unipoint = _glyph_name_to_unicode(words[2].decode())
+            if unipoint:
+                map_dict[chr(i)] = unipoint
+                int_entry.append(i)
+
     return map_dict, int_entry

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -73,7 +73,7 @@ def _parse_encoding(
             )
 
         # Return StandardEncoding as fallback option. Note that a font's internal encoding can be used
-        # to overwrite this, which we do for Type1 fonts in _type1_alternative.
+        # to overwrite this, which we do for Type1 fonts in _character_map_from_type1_font_file.
         return dict(
             zip(range(256), charset_encoding["/StandardEncoding"])
         )
@@ -149,7 +149,7 @@ def _parse_to_unicode(
                 if not font_file_data:
                     return map_dict, int_entry
 
-                return _type1_alternative(font_file_data, map_dict, int_entry)
+                return _character_map_from_type1_font_file(font_file_data, map_dict, int_entry)
 
             return map_dict, int_entry
 
@@ -396,7 +396,7 @@ def _glyph_name_to_unicode(glyph_name: str) -> Union[str, None]:
             return None
 
 
-def _type1_alternative(
+def _character_map_from_type1_font_file(
     font_data: bytes,
     map_dict: dict[Any, Any],
     int_entry: list[int],

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -475,7 +475,7 @@ def _character_map_from_type1_font_file(
                 continue
             try:
                 i = int(words[1])
-            except ValueError:  # pragma: no cover
+            except ValueError:
                 continue
 
             unipoint = _glyph_name_to_unicode(words[2].decode())

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -1,6 +1,8 @@
+import struct
 from binascii import Error as BinasciiError
 from binascii import unhexlify
 from functools import partial
+from io import BytesIO
 from typing import Any, Union, cast
 
 from ._codecs import adobe_glyphs, charset_encoding
@@ -394,6 +396,33 @@ def _glyph_name_to_unicode(glyph_name: str) -> Union[str, None]:
             return chr(int(glyph_name[4:], 16))
         except ValueError:  # pragma: no cover
             return None
+
+
+def _character_map_from_cff_type1_font_file(
+    font_data: bytes,
+    map_dict: dict[Any, Any],
+    int_entry: list[int],
+) -> tuple[dict[Any, Any], list[int]]:
+    try:
+        from fontTools.cffLib import CFFFontSet  # noqa: PLC0415
+        cff_set = CFFFontSet()
+        cff_set.decompile(BytesIO(font_data), None)  # This can raise ValueError, AssertionError, struct.error.
+        cff_font = cff_set.topDictIndex[0]           # First font in CFF set; Can raise AttributeError or IndexError.
+        cff_encoding = cff_font.Encoding             # Can raise AttributeError.
+        # Encoding can fall back to literal strings "StandardEncoding" or "ExpertEncoding", which we do not parse.
+        if isinstance(cff_encoding, str):
+            return map_dict, int_entry
+        for i in range(min(len(cff_encoding), 256)):
+            glyph_name = cff_encoding[i]
+            if not glyph_name or glyph_name == ".notdef":
+                continue
+            if unipoint := _glyph_name_to_unicode(f"/{glyph_name}"):
+                map_dict[chr(i)] = unipoint
+                int_entry.append(i)
+        return map_dict, int_entry
+
+    except (struct.error, AssertionError, AttributeError, IndexError, ValueError):
+        return map_dict, int_entry
 
 
 def _character_map_from_type1_font_file(

--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -75,7 +75,7 @@ def _parse_encoding(
             )
 
         # Return StandardEncoding as fallback option. Note that a font's internal encoding can be used
-        # to overwrite this, which we do for Type1 fonts in _character_map_from_type1_font_file.
+        # to overwrite this, which we do for Type1 fonts in _character_map_from_(cff_)type1_font_file.
         return dict(
             zip(range(256), charset_encoding["/StandardEncoding"])
         )
@@ -130,28 +130,60 @@ def _parse_encoding(
 def _parse_to_unicode(
     ft: DictionaryObject
 ) -> tuple[dict[Any, Any], list[int]]:
-    # will store all translation code
-    # and map_dict[-1] we will have the number of bytes to convert
+    from ._font import HAS_FONTTOOLS  # noqa: PLC0415
+
+    # We store all character mappings in map_dict. In map_dict[-1] we store the byte length
+    # of the character codes (or CIDs) encoded inside the ToUnicode stream.
     map_dict: dict[Any, Any] = {}
 
-    # will provide the list of cmap keys as int to correct encoding
+    # We provide the list of cmap keys in int_entry to correct encoding later on in get_encoding().
     int_entry: list[int] = []
 
     if "/ToUnicode" not in ft:
         if ft.get("/Subtype", "") == "/Type1":
-            font_descriptor = ft.get("/FontDescriptor", None)
+            font_descriptor = ft.get("/FontDescriptor")
             if not font_descriptor:
                 return map_dict, int_entry
 
-            if (
-                "/FontFile" in font_descriptor and
-                isinstance(font_file_dict := font_descriptor["/FontFile"], StreamObject)
-            ):
-                font_file_data = font_file_dict.get_data()
-                if not font_file_data:
-                    return map_dict, int_entry
+            # We try to read encoding from an embedded font file, if we can. See Table 126 about embedded font
+            # file organization in the PDF specification 1.7 for details.
+            font_file_handlers = (
+                # A normal Type1 font file, can be part of a Type1 or MMType1 font dictionary.
+                (
+                    "/FontFile",
+                    lambda _: True,
+                    _character_map_from_type1_font_file
+                ),
+                # A CFF Type1 font file, as part of a Type1 or MMType1 font dictionary, when subtype is Type1C.
+                (
+                    "/FontFile3",
+                    lambda stream: stream.get("/Subtype") == "/Type1C",
+                    _character_map_from_cff_type1_font_file,
+                )
+            )
+            for font_file, condition, font_file_processor in font_file_handlers:
+                if (
+                    font_file in font_descriptor and
+                    isinstance(font_file_dict := font_descriptor[font_file], StreamObject) and
+                    condition(font_file_dict)
+                ):
+                    if font_file == "/FontFile3" and not HAS_FONTTOOLS:
+                        logger_warning(
+                            (
+                                "fontTools is required to fully parse the encoding of a CFF Type1 font in font "
+                                "dictionary %(ft)s, but is not installed. Consider installing fontTools if you "
+                                "encounter encoding problems."
+                            ),
+                            source=__name__,
+                            ft=ft,
+                        )
+                        return map_dict, int_entry
 
-                return _character_map_from_type1_font_file(font_file_data, map_dict, int_entry)
+                    font_file_data = font_file_dict.get_data()
+                    if not font_file_data:
+                        return map_dict, int_entry
+
+                    return font_file_processor(font_file_data, map_dict, int_entry)
 
             return map_dict, int_entry
 

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 
 from pypdf import PdfWriter, Transformation
-from pypdf._font import Font
+from pypdf._font import HAS_FONTTOOLS, Font
 from pypdf.generic import (
     ArrayObject,
     DecodedStreamObject,
@@ -126,7 +126,10 @@ Option D
     )
     assert b"OneWord" in appearance_stream.get_data()
 
-@pytest.mark.skipif(not HAS_RTL_SUPPORT, reason="Requires arabic-reshaper and python-bidi")
+@pytest.mark.skipif(
+    not HAS_RTL_SUPPORT or not HAS_FONTTOOLS,
+    reason="Requires arabic-reshaper, python-bidi and fontTools"
+)
 def test_appearance_stream_rtl():
     writer = PdfWriter(RESOURCE_ROOT / "fontsampler.pdf")
     layout = BaseStreamConfig(

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -1,6 +1,7 @@
 """Test the pypdf_cmap module."""
 import sys
 from io import BytesIO
+from unittest import mock
 
 import pytest
 
@@ -8,6 +9,7 @@ from pypdf import PdfReader, PdfWriter
 from pypdf._cmap import (
     __parse_bfrange__decode,
     _check_token_length,
+    _parse_to_unicode,
     get_encoding,
     parse_bfchar,
     parse_bfrange,
@@ -708,3 +710,44 @@ def test_japanese_cmap_encodings(cmap_name: str, python_codec: str, caplog) -> N
     assert "日本語テスト" in text, f"Japanese text garbled for {cmap_name}"
     assert "Hello ASCII"  in text, f"ASCII baseline broken for {cmap_name}"
     assert "Advanced encoding" not in caplog.text
+
+
+def test__character_map_from_cff_type1_font_file_guards(caplog):
+    font_file_stream = StreamObject()
+    font_dict = DictionaryObject(
+        {
+            NameObject("/Subtype"): NameObject("/Type1"),
+            NameObject("/BaseFont"): NameObject("/VSGOOE+Times-Roman"),
+            NameObject("/Type"): NameObject("/Font"),
+            NameObject("/Name"): NameObject("/R77"),
+        }
+    )
+    font_file_stream.update({NameObject("/Subtype"): NameObject("/Type1C")})
+    font_descriptor = DictionaryObject({NameObject("/FontFile3"): font_file_stream})
+    font_dict[NameObject("/FontDescriptor")] = font_descriptor
+    # Ensure a warning is logged when fontTools is missing for CFF Type1 font parsing
+    with mock.patch("pypdf._font.HAS_FONTTOOLS", False):
+        _parse_to_unicode(font_dict)
+    assert (
+        "fontTools is required to fully parse the encoding of a CFF Type1 font in font dictionary"
+        in caplog.text
+    )
+
+    # Test with fontTools
+    pytest.importorskip("fontTools", reason="Requires fontTools")
+
+    # Test raising an exception while parsing font data
+    font_file_stream.set_data(b"Corrupt font data")
+    font_file_stream.update({NameObject("/Subtype"): NameObject("/Type1C")})
+    font_descriptor = DictionaryObject({NameObject("/FontFile3"): font_file_stream})
+    font_dict[NameObject("/FontDescriptor")] = font_descriptor
+    _parse_to_unicode(font_dict)
+
+    # Ensure we return early when encoding is a string
+    mock_cff_set = mock.MagicMock()
+    mock_font_str_encoding = mock.MagicMock()
+    mock_font_str_encoding.Encoding = "StandardEncoding"
+    mock_cff_set.topDictIndex = [mock_font_str_encoding]
+
+    with mock.patch("fontTools.cffLib.CFFFontSet", return_value=mock_cff_set):
+        _parse_to_unicode(font_dict)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2042,7 +2042,8 @@ def test_update_form_fields3(caplog, tmp_path):
         # Also test that an ImportError is raised by the Font class
         assert "The 'fontTools' library is required to use 'from_truetype_font_file'" in caplog.text
 
-    # Test with fonttools
+    # Test with fontTools
+    pytest.importorskip("fontTools", reason="Requires fontTools")
     data = {
         "subsemnatul": "Σὲ γνωρίζω ἀπὸ τὴν κόψη",
         "localitatea": "شهرزاد",


### PR DESCRIPTION
For simple fonts that do not specify a ToUnicode cmap in their font dictionary, we already parse embedded Type1 fonts. This PR adds code that also does this in case that the embedded font is a CFF Type1 font file, provided that fontTools is installed.

This fixes the remainder of https://github.com/py-pdf/pypdf/issues/3973.

I used Google Gemini extensively to generate this PR, but I reviewed everything.

Incidentally, the same type of approached should actually also be followed for embedded TrueType fonts for /TrueType font file dictionaries. Then again, I'm assuming that the underlying issues as seen in https://github.com/py-pdf/pypdf/issues/3973 are exceedingly rare and I couldn't reproduce them with any of the existing documents in our test suite.