### PR TITLE
ENH: Draw borders and backgrounds for appearance streams and annotations

### DIFF
--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -113,11 +113,13 @@ class BaseStreamAppearance(DecodedStreamObject):
         # color is defined, and border color is not set to transparent.
         if self._layout.border_width > 0:
             if isinstance(self._layout.border_color, Color):
+                border_width_string = f"{self._layout.border_width} w\n" if self._layout.border_width != 1 else ""
                 ap_stream_parts.append(
                     f"{self._layout.border_width} "
                     f"{self._layout.border_width} "
                     f"{self._layout.rectangle.width - 2 * self._layout.border_width} "
                     f"{self._layout.rectangle.height - 2 * self._layout.border_width} re\n"
+                    f"{border_width_string}"
                     f"{self._layout.border_color.as_operator(stroke=True)}\n"
                     "s\n"
                 )

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -404,8 +404,9 @@ class TextStreamAppearance(BaseStreamAppearance):
         default_appearance = f"{font_name} {font_size} Tf {font_color.as_operator()}"
 
         ap_stream = (
-            f"q\n/Tx BMC \nq\n{2 * max(margin, 1)} {margin} {field_width} {field_height} "
-            f"re\nW\nBT\n{default_appearance}\n"
+            f"q\n/Tx BMC \nq\n"
+            f"{2 * max(margin, 1)} {margin} {field_width - 2 * max(margin, 1)} {field_height - margin} re\n"
+            f"W\nBT\n{default_appearance}\n"
         ).encode()
         current_x_pos: float = 0  # Initial virtual position within the text object.
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -27,6 +27,7 @@ from ..generic import (
     StreamObject,
 )
 from ..generic._base import ByteStringObject, TextStringObject
+from ._color import Color
 
 if TYPE_CHECKING:
     from pypdf._writer import PdfWriter
@@ -53,6 +54,8 @@ class BaseStreamConfig:
     rectangle: RectangleObject = field(default_factory=lambda: RectangleObject((0.0, 0.0, 0.0, 0.0)))
     border_width: int = 1  # The width of the border in points
     border_style: str = BorderStyles.SOLID
+    border_color: Color | None = None
+    background_color: Color | None = None
     rotation: int = 0
 
 
@@ -99,6 +102,32 @@ class BaseStreamAppearance(DecodedStreamObject):
             self._add_matrix(rotation)
 
         ap_stream_parts = []
+        # Only add a background color when color is defined and not transparent
+        if isinstance(self._layout.background_color, Color):
+            ap_stream_parts.append(
+                f"0 0 {self._layout.rectangle.width} {self._layout.rectangle.height} re\n"
+                f"{self._layout.background_color.as_operator()}\n"
+                "f\n"
+            )
+        # Only add a border when border width is larger than 0, border
+        # color is defined, and border color is not set to transparent.
+        if self._layout.border_width > 0:
+            if isinstance(self._layout.border_color, Color):
+                ap_stream_parts.append(
+                    f"{self._layout.border_width} "
+                    f"{self._layout.border_width} "
+                    f"{self._layout.rectangle.width - 2 * self._layout.border_width} "
+                    f"{self._layout.rectangle.height - 2 * self._layout.border_width} re\n"
+                    f"{self._layout.border_color.as_operator(stroke=True)}\n"
+                    "s\n"
+                )
+            else:
+                # If we aren't drawing a border, then set border_width to 0. This means less margin to
+                # take into account and results in larger font sizes.
+                self._layout.border_width = 0
+        if ap_stream_parts:
+            ap_stream_parts.insert(0, "q\n")
+            ap_stream_parts.append("Q\n")
         self._ap_stream_data = "".join(ap_stream_parts).encode()
 
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -415,7 +415,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             if selection and line in _unicode_to_glyph_id("".join(selection), reverse_cmap):
                 # Might be improved, but cannot find how to get fill working => replaced with lined box
                 ap_stream += (
-                    f"1 {y_offset - (line_number * font_size * leading_factor) - 1} "
+                    f"1 {round(y_offset - (line_number * font_size * leading_factor) - 1, 3)} "
                     f"{rectangle.width - 2} {font_size + 2} re\n"
                     f"0.5 0.5 0.5 rg s\n{default_appearance}\n"
                 ).encode()

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -292,11 +292,11 @@ class TextStreamAppearance(BaseStreamAppearance):
             (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
         )
 
-        # Set margins based on border width and style, but never less than 1 point
+        # Set margins based on border width and style
         factor = 2 if self._layout.border_style in {"/B", "/I"} else 1
-        margin = max(self._layout.border_width * factor, 1)
+        margin = self._layout.border_width * factor
         field_height = rectangle.height - 2 * margin
-        field_width = rectangle.width - 4 * margin
+        field_width = rectangle.width - 4 * max(margin, 1)
 
         reverse_cmap, encoding_cmap = font._get_typographic_maps()
 
@@ -395,7 +395,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         # Set the vertical offset
         if is_multiline:
             y_offset = (
-                rectangle.height + margin - font.font_descriptor.bbox[3] * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
+                field_height + margin - font.font_descriptor.bbox[3] * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
             )
         else:
             y_offset = margin + (
@@ -404,7 +404,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         default_appearance = f"{font_name} {font_size} Tf {font_color}"
 
         ap_stream = (
-            f"q\n/Tx BMC \nq\n{2 * margin} {margin} {field_width} {field_height} "
+            f"q\n/Tx BMC \nq\n{2 * max(margin, 1)} {margin} {field_width} {field_height} "
             f"re\nW\nBT\n{default_appearance}\n"
         ).encode()
         current_x_pos: float = 0  # Initial virtual position within the text object.
@@ -429,11 +429,11 @@ class TextStreamAppearance(BaseStreamAppearance):
                 # Absolute start X = (Cell Index, i.e., line_number * Cell Width) + Centering Offset
                 desired_abs_x_start = (line_number * cell_width) + centering_offset_in_cell
             elif alignment == TextAlignment.RIGHT:
-                desired_abs_x_start = rectangle.width - margin * 2 - line_width
+                desired_abs_x_start = rectangle.width - max(margin, 1) * 2 - line_width
             elif alignment == TextAlignment.CENTER:
                 desired_abs_x_start = (rectangle.width - line_width) / 2
             else:  # Left aligned; default
-                desired_abs_x_start = margin * 2
+                desired_abs_x_start = max(margin, 1) * 2
             # Calculate x_rel_offset: how much to move from the current_x_pos
             # to reach the desired_abs_x_start.
             x_rel_offset = desired_abs_x_start - current_x_pos

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -499,8 +499,8 @@ class TextStreamAppearance(BaseStreamAppearance):
         Initializes a TextStreamAppearance object.
 
         This constructor creates a new PDF stream object configured as an XObject
-        of subtype Form. It uses the `_appearance_stream_data` method to generate
-        the content for the stream.
+        of subtype Form. It uses the `_generate_appearance_stream_data` method to
+        generate the content for the stream.
 
         Args:
             layout: The basic layout parameters.

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -450,7 +450,7 @@ class TextStreamAppearance(BaseStreamAppearance):
 
             # Td is a relative translation (Tx and Ty).
             # It updates the current text position.
-            ap_stream += f"{x_rel_offset} {y_rel_offset} Td\n".encode()
+            ap_stream += f"{round(x_rel_offset, 3)} {round(y_rel_offset, 3)} Td\n".encode()
             # Update current_x_pos based on the Td operation for the next iteration.
             # This is the X position where the *current line* will start.
             current_x_pos = desired_abs_x_start

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -405,7 +405,8 @@ class TextStreamAppearance(BaseStreamAppearance):
 
         ap_stream = (
             f"q\n/Tx BMC \nq\n"
-            f"{2 * max(margin, 1)} {margin} {field_width - 2 * max(margin, 1)} {field_height - margin} re\n"
+            f"{2 * max(margin, 1)} {margin} "
+            f"{round(field_width - 2 * max(margin, 1), 3)} {round(field_height - margin, 3)} re\n"
             f"W\nBT\n{default_appearance}\n"
         ).encode()
         current_x_pos: float = 0  # Initial virtual position within the text object.

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -98,6 +98,9 @@ class BaseStreamAppearance(DecodedStreamObject):
         if rotation:
             self._add_matrix(rotation)
 
+        ap_stream_parts = []
+        self._ap_stream_data = "".join(ap_stream_parts).encode()
+
 
 class TextAlignment(IntEnum):
     """Defines the alignment options for text within a form field's appearance stream."""
@@ -493,7 +496,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             font = Font.from_core_font_name()
             font_resource = font.as_font_resource()
 
-        ap_stream_data = self._generate_appearance_stream_data(
+        self._ap_stream_data += self._generate_appearance_stream_data(
             text,
             selection,
             font,
@@ -506,8 +509,8 @@ class TextStreamAppearance(BaseStreamAppearance):
             max_length=max_length
         )
 
-        self.set_data(ByteStringObject(ap_stream_data))
-        self[NameObject("/Length")] = NumberObject(len(ap_stream_data))
+        self.set_data(ByteStringObject(self._ap_stream_data))
+        self[NameObject("/Length")] = NumberObject(len(self._ap_stream_data))
         # Update Resources with font information
         self[NameObject("/Resources")] = DictionaryObject({
             NameObject("/Font"): DictionaryObject({

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -793,15 +793,22 @@ class TextStreamAppearance(BaseStreamAppearance):
             border_style = cast(DictionaryObject, field["/BS"]).get("/S", border_style)
 
         rotation = 0
+        border_color: Color | None = None
+        background_color: Color | None = None
         appearance_characteristics = field.get_inherited("/MK", None)
         if isinstance(appearance_characteristics, DictionaryObject):
             rotation = int(appearance_characteristics.get("/R", 0))
+            # Color.from_normalized_values([]) results in None for a "/BC" or "/BG" value of []
+            border_color = Color.from_normalized_values(appearance_characteristics.get("/BC"))
+            background_color = Color.from_normalized_values(appearance_characteristics.get("/BG"))
 
         # Create the TextStreamAppearance instance
         layout = BaseStreamConfig(
             rectangle=rectangle,
             border_width=border_width,
             border_style=border_style,
+            border_color=border_color,
+            background_color=background_color,
             rotation=rotation
         )
 

--- a/pypdf/generic/_appearance_stream.py
+++ b/pypdf/generic/_appearance_stream.py
@@ -27,7 +27,7 @@ from ..generic import (
     StreamObject,
 )
 from ..generic._base import ByteStringObject, TextStringObject
-from ._color import Color
+from ._color import Color, DeviceGray
 
 if TYPE_CHECKING:
     from pypdf._writer import PdfWriter
@@ -254,7 +254,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         font: Font,
         font_name: str = "/Helv",
         font_size: float = 0.0,
-        font_color: str = "0 g",
+        font_color: Color | None = None,
         is_multiline: bool = False,
         alignment: TextAlignment = TextAlignment.LEFT,
         is_comb: bool = False,
@@ -274,8 +274,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             font_name: The name of the font resource to use (e.g., "/Helv").
             font_size: The font size. If 0, it is automatically calculated
                 based on whether the field is multiline or not.
-            font_color: The color to apply to the font, represented as a PDF
-                graphics state string (e.g., "0 g" for black).
+            font_color: The color to apply to the font, represented as a class Color
             is_multiline: A boolean indicating if the text field is multiline.
             alignment: Text alignment, can be TextAlignment.LEFT, .RIGHT, or .CENTER.
             is_comb: Boolean that designates fixed-length fields, where every character
@@ -287,6 +286,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             A byte string containing the PDF content stream data.
 
         """
+        font_color = font_color or DeviceGray()
         rectangle = self._layout.rectangle
         leading_factor = (
             (font.font_descriptor.bbox[3] - font.font_descriptor.bbox[1]) / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR
@@ -401,7 +401,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             y_offset = margin + (
                 (field_height - font.font_descriptor.ascent * font_size / TEXT_SPACE_TO_GLYPH_SPACE_FACTOR) / 2
             )
-        default_appearance = f"{font_name} {font_size} Tf {font_color}"
+        default_appearance = f"{font_name} {font_size} Tf {font_color.as_operator()}"
 
         ap_stream = (
             f"q\n/Tx BMC \nq\n{2 * max(margin, 1)} {margin} {field_width} {field_height} "
@@ -489,7 +489,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         font_resource: DictionaryObject | IndirectObject | None = None,
         font_name: str = "/Helv",
         font_size: float = 0.0,
-        font_color: str = "0 g",
+        font_color: Color | None = None,
         is_multiline: bool = False,
         alignment: TextAlignment = TextAlignment.LEFT,
         is_comb: bool = False,
@@ -533,7 +533,7 @@ class TextStreamAppearance(BaseStreamAppearance):
             font,
             font_name=font_name,
             font_size=font_size,
-            font_color=font_color,
+            font_color=font_color or DeviceGray(),
             is_multiline=is_multiline,
             alignment=alignment,
             is_comb=is_comb,
@@ -751,7 +751,7 @@ class TextStreamAppearance(BaseStreamAppearance):
         da_font_name = font_properties.pop(font_properties.index("Tf") - 2)
         font_size = float(font_properties.pop(font_properties.index("Tf") - 1))
         font_properties.remove("Tf")
-        font_color = " ".join(font_properties)
+        font_color = Color.from_normalized_values(tuple(float(val) for val in font_properties[:-1]))
         # Determine the font name to use, prioritizing the user's input
         if user_font_name:
             font_name = user_font_name

--- a/pypdf/generic/_color.py
+++ b/pypdf/generic/_color.py
@@ -1,0 +1,85 @@
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Union
+
+
+@dataclass
+class Color:
+    """
+    A factory class to generate one of class GrayscaleColor, RGBColor or CMYKColor. Call with
+    Color.from_normalized_values() on a tuple of length 1 for grayscale, 3 for RGB, or 4 for CMYK.
+    """
+    color_operator: str = field(init=False)
+    _ordered_fields: tuple[str, ...] = field(init=False)
+
+    @classmethod
+    def from_normalized_values(
+        cls,
+        color: Union[Sequence[float], None]
+    ) -> Union["Color", None]:
+        """
+        Method to instantiate a color class. Can be called with value of None for cases where an appearance
+        characteristics dictionary contains an empty "/BG" or "/BC" value,  which returns None and signifies
+        transparent color. See Table 189, "Entries in an appearance characteristics dictionary" of the PDF
+        specification 1.7.
+
+        Args:
+            color: A sequence of 1 (for DeviceGray), 3 (for DeviceRGB) or 4 (for DeviceCMYK) float values
+                in the range of 0.0 to 1.0 (representing normalized color channel values), or None to return None.
+        """
+        color_types: dict[int, type[Color]] = {
+            1: DeviceGray,
+            3: DeviceRGB,
+            4: DeviceCMYK,
+        }
+
+        if (
+            color is not None
+            and (color_length := len(color)) in color_types
+            and all(isinstance(val, (int, float)) and 0.0 <= val <= 1.0 for val in color)
+        ):
+            # Create instance of the appropriate subclass
+            color_subclass = color_types[color_length]
+            kwargs = dict(zip(color_subclass._ordered_fields, color))
+            return color_subclass(**kwargs)
+
+        return None
+
+    def as_operator(self, stroke: bool = False) -> str:
+        """
+        Returns the PDF color operator as a string.
+
+        Args:
+            stroke: Returns stroke (i.e., uppercase) color operator if True
+        """
+        values = [f"{round(getattr(self, field), 3):g}" for field in self._ordered_fields]
+        return f"{' '.join(values)} {self.color_operator.upper() if stroke else self.color_operator}"
+
+
+@dataclass
+class DeviceGray(Color):
+    gray: float = 0.0
+
+    color_operator = "g"
+    _ordered_fields = ("gray",)
+
+
+@dataclass
+class DeviceRGB(Color):
+    red: float = 0.0
+    green: float = 0.0
+    blue: float = 0.0
+
+    color_operator = "rg"
+    _ordered_fields = ("red", "green", "blue")
+
+
+@dataclass
+class DeviceCMYK(Color):
+    cyan: float = 0.0
+    magenta: float = 0.0
+    yellow: float = 0.0
+    black: float = 1.0
+
+    color_operator = "k"
+    _ordered_fields = ("cyan", "magenta", "yellow", "black")

--- a/tests/generic/test_color.py
+++ b/tests/generic/test_color.py
@@ -1,0 +1,29 @@
+"""Test the pypdf.generic.color module"""
+
+from collections.abc import Sequence
+from typing import Optional
+
+import pytest
+
+from pypdf.generic import ArrayObject
+from pypdf.generic._color import Color
+
+
+@pytest.mark.parametrize(
+    ("sequence", "outcome"),
+    [
+        (ArrayObject([]), ""),
+        (["a", "b", "c", "d", "e"], ""),
+        ((4, 5, 0), ""),
+        ((.4,), "0.4 g"),
+        ((.2, .2, .8), "0.2 0.2 0.8 rg"),
+        ((.800, .640, .300, 1), "0.8 0.64 0.3 1 k")
+    ]
+)
+def test_color(sequence: Optional[Sequence[float]], outcome: str) -> None:
+    color = Color.from_normalized_values(sequence)
+    if not color:  # This tests the input guards in Color.from_normalized_values()
+        assert color is None
+    else:
+        assert color.as_operator() == outcome
+        assert color.as_operator(stroke=True) == outcome.upper()

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -40,13 +40,13 @@ def test_comb():
     )
     assert (
         b"q\n/Tx BMC \nq\n2 0 191.285 18.455 re\nW\nBT\n/Helv 10.0 Tf 0 g\n"
-        b"7.084250000000001 5.637499999999999 Td\n(0) Tj\n"
-        b"19.7285 0.0 Td\n(1) Tj\n19.728500000000004 0.0 Td\n(2) Tj\n"
-        b"19.728499999999997 0.0 Td\n(3) Tj\n"
-        b"19.728499999999997 0.0 Td\n(4) Tj\n"
-        b"19.728499999999997 0.0 Td\n(5) Tj\n"
-        b"19.72850000000001 0.0 Td\n(6) Tj\n"
-        b"19.728499999999997 0.0 Td\n(7) Tj\nET\nQ\nEMC\nQ\n"
+        b"7.084 5.637 Td\n(0) Tj\n"
+        b"19.729 0.0 Td\n(1) Tj\n19.729 0.0 Td\n(2) Tj\n"
+        b"19.728 0.0 Td\n(3) Tj\n"
+        b"19.728 0.0 Td\n(4) Tj\n"
+        b"19.728 0.0 Td\n(5) Tj\n"
+        b"19.729 0.0 Td\n(6) Tj\n"
+        b"19.728 0.0 Td\n(7) Tj\nET\nQ\nEMC\nQ\n"
     ) in appearance_stream.get_data()
 
     layout.rectangle = RectangleObject((0.0, 0.0, 20.852, 20.84))

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -158,7 +158,6 @@ def test_appearance_stream_rtl():
         font=font,
         font_name=font_name,
         font_size=12.0,
-        font_color="0 g",
         is_multiline=False
     )
     # The regex returns two matches. The first matches the text in /Span << /ActualText <[group 0]> >> BDC
@@ -176,7 +175,6 @@ def test_appearance_stream_rtl():
             font=font,
             font_name=font_name,
             font_size=12.0,
-            font_color="0 g",
             is_multiline=False
         )
         [hex_glyphs_rtl_disabled] = re.findall("^<(.+?)>", appearance.get_data().decode(), re.MULTILINE)
@@ -193,7 +191,6 @@ def test_appearance_stream_rtl():
             font=font,
             font_name=font_name,
             font_size=12.0,
-            font_color="0 g",
             is_multiline=False
         )
         [hex_glyphs_rtl_enabled_fonttools_disabled] = re.findall(

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -39,10 +39,9 @@ def test_comb():
         layout=layout, text=text, font_size=font_size, is_comb=is_comb, max_length=max_length
     )
     assert (
-        b"q\n/Tx BMC \nq\n2 1 193.285 16.455 re\nW\nBT\n/Helv 10.0 Tf 0 g\n"
+        b"q\n/Tx BMC \nq\n2 0 191.285 18.455 re\nW\nBT\n/Helv 10.0 Tf 0 g\n"
         b"7.084250000000001 5.637499999999999 Td\n(0) Tj\n"
-        b"19.7285 0.0 Td\n(1) Tj\n"
-        b"19.728500000000004 0.0 Td\n(2) Tj\n"
+        b"19.7285 0.0 Td\n(1) Tj\n19.728500000000004 0.0 Td\n(2) Tj\n"
         b"19.728499999999997 0.0 Td\n(3) Tj\n"
         b"19.728499999999997 0.0 Td\n(4) Tj\n"
         b"19.728499999999997 0.0 Td\n(5) Tj\n"
@@ -57,7 +56,7 @@ def test_comb():
         layout=layout, text=text, font_size=font_size, is_comb=is_comb, max_length=max_length
     )
     assert (
-        b"q\n/Tx BMC \nq\n2 1 16.852 18.84 re\nW\nBT\n/Helv 10.0 Tf 0 g\n7.091 6.83 Td\n(A) Tj\nET\nQ\nEMC\nQ\n"
+        b"q\n/Tx BMC \nq\n2 0 14.852 20.84 re\nW\nBT\n/Helv 10.0 Tf 0 g\n7.091 6.83 Td\n(A) Tj\nET\nQ\nEMC\nQ\n"
     ) in appearance_stream.get_data()
 
 

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -37,7 +37,7 @@ def test_comb():
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_comb=is_comb, max_length=max_length
     )
-    assert appearance_stream.get_data() == (
+    assert (
         b"q\n/Tx BMC \nq\n2 1 193.285 16.455 re\nW\nBT\n/Helv 10.0 Tf 0 g\n"
         b"7.084250000000001 5.637499999999999 Td\n(0) Tj\n"
         b"19.7285 0.0 Td\n(1) Tj\n"
@@ -47,7 +47,7 @@ def test_comb():
         b"19.728499999999997 0.0 Td\n(5) Tj\n"
         b"19.72850000000001 0.0 Td\n(6) Tj\n"
         b"19.728499999999997 0.0 Td\n(7) Tj\nET\nQ\nEMC\nQ\n"
-    )
+    ) in appearance_stream.get_data()
 
     layout.rectangle = RectangleObject((0.0, 0.0, 20.852, 20.84))
     text = "AA"
@@ -55,9 +55,9 @@ def test_comb():
     appearance_stream = TextStreamAppearance(
         layout=layout, text=text, font_size=font_size, is_comb=is_comb, max_length=max_length
     )
-    assert appearance_stream.get_data() == (
+    assert (
         b"q\n/Tx BMC \nq\n2 1 16.852 18.84 re\nW\nBT\n/Helv 10.0 Tf 0 g\n7.091 6.83 Td\n(A) Tj\nET\nQ\nEMC\nQ\n"
-    )
+    ) in appearance_stream.get_data()
 
 
 def test_scale_text():

--- a/tests/test_appearance_stream.py
+++ b/tests/test_appearance_stream.py
@@ -24,6 +24,7 @@ from pypdf.generic._appearance_stream import (
     BaseStreamConfig,
     TextStreamAppearance,
 )
+from pypdf.generic._color import Color
 
 from . import RESOURCE_ROOT
 
@@ -442,3 +443,21 @@ def test_merge_transformed_page_annotation_with_multi_state_appearance():
     for state in merged_states.values():
         matrix = tuple(round(float(x), 6) for x in state.get_object()["/Matrix"])
         assert matrix == (0.0, 1.0, -1.0, 0.0, 200.0, 0.0)
+
+
+def test_base_stream_appearance():
+    layout = BaseStreamConfig(
+        rectangle=RectangleObject([0, 0, 400, 20]),
+        border_width=3,
+        rotation=90,
+        border_color=Color.from_normalized_values((.2, .3, .5)),
+        background_color=Color.from_normalized_values((.8, .5, .2))
+    )
+    appearance = BaseStreamAppearance(
+        layout=layout,
+    )
+    assert appearance["/Matrix"] == [0.0, 1, -1, 0.0, 20, 0.0]
+    assert appearance._ap_stream_data == (
+        b"q\n0 0 400.0 20.0 re\n0.8 0.5 0.2 rg\nf\n"
+        b"3 3 394.0 14.0 re\n3 w\n0.2 0.3 0.5 RG\ns\nQ\n"
+    )

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2781,7 +2781,7 @@ def test_field_box_upside_down():
     writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.update_page_form_field_values(None, {"FreightTrainMiles": "0"})
     assert  (
-        b"q\n/Tx BMC \nq\n2 0 100.29520000000001 11.835000000000036 re\n"
+        b"q\n/Tx BMC \nq\n2 0 100.295 11.835 re\n"
         b"W\nBT\n/Arial 8.0 Tf 0 g\n2 3.046 Td\n(0) Tj\nET\n"
         b"Q\nEMC\nQ\n"
     ) in writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2781,8 +2781,8 @@ def test_field_box_upside_down():
     writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.update_page_form_field_values(None, {"FreightTrainMiles": "0"})
     assert  (
-        b"q\n/Tx BMC \nq\n2 0 102.29520000000001 11.835000000000036 re\n"
-        b"W\nBT\n/Arial 8.0 Tf 0 g\n2 3.0455000000000183 Td\n(0) Tj\nET\n"
+        b"q\n/Tx BMC \nq\n2 0 100.29520000000001 11.835000000000036 re\n"
+        b"W\nBT\n/Arial 8.0 Tf 0 g\n2 3.046 Td\n(0) Tj\nET\n"
         b"Q\nEMC\nQ\n"
     ) in writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data()
     box = writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"]["/BBox"]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2780,11 +2780,11 @@ def test_field_box_upside_down():
     name = "iss2724.pdf"
     writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.update_page_form_field_values(None, {"FreightTrainMiles": "0"})
-    assert writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data() == (
+    assert  (
         b"q\n/Tx BMC \nq\n2 1 102.29520000000001 9.835000000000036 re\n"
         b"W\nBT\n/Arial 8.0 Tf 0 g\n2 3.0455000000000183 Td\n(0) Tj\nET\n"
         b"Q\nEMC\nQ\n"
-    )
+    ) in writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data()
     box = writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"]["/BBox"]
     assert box[2] > 0
     assert box[3] > 0

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2781,7 +2781,7 @@ def test_field_box_upside_down():
     writer = PdfWriter(BytesIO(get_data_from_url(url=url, name=name)))
     writer.update_page_form_field_values(None, {"FreightTrainMiles": "0"})
     assert  (
-        b"q\n/Tx BMC \nq\n2 1 102.29520000000001 9.835000000000036 re\n"
+        b"q\n/Tx BMC \nq\n2 0 102.29520000000001 11.835000000000036 re\n"
         b"W\nBT\n/Arial 8.0 Tf 0 g\n2 3.0455000000000183 Td\n(0) Tj\nET\n"
         b"Q\nEMC\nQ\n"
     ) in writer.pages[0]["/Annots"][13].get_object()["/AP"]["/N"].get_data()


### PR DESCRIPTION
This PR adds functionality to add background color and borders with colours to appearance streams. It introduces a new Color class to store different kinds of colour (CMYK, RGB, greyscale). For text annotations, it parses the "/MK" dictionary to derive background and border colors.

In terms of output, this PR now more critically decides whether or not to keep into account borders in deciding vertical margin sizes and does not take any margin into account when no border is expected to be drawn (for instance, when border color is defined with an empty array, and/or when border width is set to 0). Especially for small text boxes, this results in markedly larger font size and contributes to readability.

I added a bit of finetuning to text placement as well, because I noticed very slight clipping here and there, which now should be fully gone. Also, I decided to round floats to three decimals to prevent being overly precise where applicable.

The ultimate aim of this PR is to contribute to resolving https://github.com/py-pdf/pypdf/issues/2253. In the discussion in that issue, we concluded that a proper API for setting font resource name and size is yet missing. Also, it seemed to me that such an API should be easily extendable with whatever other formatting options might be possible, i.e.:

- Font resource name
- Font size
- Font color
- Border width
- Border color
- Background color
- Alignment
- (Potentially) Comb
- Rotation
- (Potentially) Password

This PR should make it easier to create such an API.

I definitely used Google Gemini to create this PR, but mostly to consult with, not for writing any code.

Finally, I've written every patch in this PR so that it is a small, self-contained change.