### PR TITLE
DEV: Use a single writer for the test PDF cache

### DIFF
--- a/.github/workflows/github-ci.yaml
+++ b/.github/workflows/github-ci.yaml
@@ -34,23 +34,12 @@ jobs:
       with:
         submodules: 'recursive'
         persist-credentials: false
-    - name: Cache Downloaded Files
+    - name: Restore Downloaded Files
       id: cache-downloaded-files-windows
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-${{ github.run_id }}
-        restore-keys: |
-          cache-downloaded-files-main-
-          cache-downloaded-files
-        enableCrossOsArchive: true
-    - name: Restore Downloaded Files
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      if: github.ref != 'refs/heads/main'
-      with:
-        path: '**/tests/pdf_cache/*'
-        key: cache-downloaded-files-main-
         restore-keys: |
           cache-downloaded-files-main-
           cache-downloaded-files
@@ -88,25 +77,16 @@ jobs:
       with:
         submodules: 'recursive'
         persist-credentials: false
-    - name: Cache Downloaded Files
+    - name: Restore Downloaded Files
       id: cache-downloaded-files-mac
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-${{ github.run_id }}
         restore-keys: |
           cache-downloaded-files-main-
           cache-downloaded-files
-    - name: Restore Downloaded Files
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      if: github.ref != 'refs/heads/main'
-      with:
-        path: '**/tests/pdf_cache/*'
-        key: cache-downloaded-files-main-
-        restore-keys: |
-          cache-downloaded-files-main-
-          cache-downloaded-files
+        enableCrossOsArchive: true
     - name: Setup Python (3.11+)
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       with:
@@ -158,25 +138,16 @@ jobs:
       with:
         submodules: 'recursive'
         persist-credentials: false
-    - name: Cache Downloaded Files
+    - name: Restore Downloaded Files
       id: cache-downloaded-files
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      if: github.ref == 'refs/heads/main'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: '**/tests/pdf_cache/*'
         key: cache-downloaded-files-main-${{ github.run_id }}
         restore-keys: |
           cache-downloaded-files-main-
           cache-downloaded-files
-    - name: Restore Downloaded Files
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-      if: github.ref != 'refs/heads/main'
-      with:
-        path: '**/tests/pdf_cache/*'
-        key: cache-downloaded-files-main-
-        restore-keys: |
-          cache-downloaded-files-main-
-          cache-downloaded-files
+        enableCrossOsArchive: true
     - name: Setup Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
       if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
@@ -230,6 +201,15 @@ jobs:
       run: |
         python -m pytest tests -n auto -vv -p no:benchmark -o faulthandler_timeout=60 --dist=loadfile
       if: ${{ startsWith(matrix.python-version, 'pypy') }}
+    # Test downloads are not fully described by example_files.yaml, so keep one
+    # cross-platform rolling cache writer instead of competing per-job caches.
+    - name: Save Downloaded Files
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      if: github.ref == 'refs/heads/main' && matrix.python-version == '3.13' && matrix.use-crypto-lib == 'cryptography' && steps.cache-downloaded-files.outputs.cache-hit != 'true'
+      with:
+        path: '**/tests/pdf_cache/*'
+        key: cache-downloaded-files-main-${{ github.run_id }}
+        enableCrossOsArchive: true
     - name: Rename coverage data file
       run: mv .coverage ".coverage.$RANDOM"
       if: ${{ !startsWith(matrix.python-version, 'pypy') }}


### PR DESCRIPTION
## Summary

- restore one cross-platform downloaded-PDF cache in every test job
- keep the rolling, run-scoped cache key so successful `main` runs publish incremental updates
- let only the Python 3.13 `cryptography` job save the cache, after its full test run succeeds

## Why

The current workflow lets every test job publish the same immutable, run-scoped cache key. The cache retained for the next run therefore depends on which job saves first.

Separating restore and save operations removes that race without splitting the cache by operating system. The key also stays independent of `tests/example_files.yaml`, because tests download additional files at runtime that are not listed in that manifest.

Closes #3728.

## Validation

- parsed the revised workflow as YAML
- verified that Windows, macOS, and Linux use the same key and cross-OS archive setting
- verified that the workflow contains exactly one cache writer after the selected job's tests
- ran the repository PR title checker for the `DEV:` title
- ran `git diff --check`

GitHub Actions remains the integration check for hosted-runner cache behavior.

## AI assistance

OpenAI Codex (GPT-5.6 Sol) assisted with repository research, implementation, and local validation. The proposed behavior was checked against the current workflow, issue discussion, and repository contribution policy.
