### PR TITLE
ROB: Do not crash on a malformed embedded files name tree

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1540,7 +1540,7 @@ class PdfDocCommon(ABC):
     @property
     def attachment_list(self) -> Generator[EmbeddedFile, None, None]:
         """Iterable of attachment objects."""
-        yield from EmbeddedFile._load(self.root_object)
+        yield from EmbeddedFile._load(self.root_object, strict=self.strict)
 
     def _list_attachments(self) -> list[str]:
         """

--- a/pypdf/generic/_files.py
+++ b/pypdf/generic/_files.py
@@ -17,7 +17,6 @@ from pypdf.generic import (
     NameObject,
     NullObject,
     NumberObject,
-    PdfObject,
     StreamObject,
     TextStringObject,
     is_null_or_none,
@@ -368,8 +367,15 @@ class EmbeddedFile:
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} name={self.name!r}>"
 
+    @staticmethod
+    def _report_malformed(message: str, strict: bool) -> None:
+        """Raise an exception in strict mode, warn otherwise."""
+        if strict:
+            raise PdfReadError(message)
+        logger_warning(message, source=__name__)
+
     @classmethod
-    def _load_from_names(cls, names: PdfObject) -> Generator[EmbeddedFile]:
+    def _load_from_names(cls, names: ArrayObject) -> Generator[EmbeddedFile]:
         """
         Convert the given name tree into class instances.
 
@@ -380,13 +386,6 @@ class EmbeddedFile:
             Iterable of class instances for the files found.
         """
         # This is a name tree of the format [name_1, reference_1, name_2, reference_2, ...]
-        if not isinstance(names, ArrayObject):
-            logger_warning(
-                "Embedded files name list is not an array: %(names)s",
-                source=__name__,
-                names=names,
-            )
-            return
         for i, name in enumerate(names):
             if not isinstance(name, str):
                 # Skip plain strings and retrieve them as `direct_name` by index.
@@ -395,7 +394,7 @@ class EmbeddedFile:
                 yield EmbeddedFile(name=direct_name, pdf_object=file_dictionary, parent=names)
 
     @classmethod
-    def _load(cls, catalog: DictionaryObject) -> Generator[EmbeddedFile]:
+    def _load(cls, catalog: DictionaryObject, strict: bool = False) -> Generator[EmbeddedFile]:
         """
         Load the embedded files for the given document catalog.
 
@@ -403,47 +402,47 @@ class EmbeddedFile:
 
         Args:
             catalog: The document catalog to load from.
+            strict: Whether to raise an exception on malformed name trees
+                instead of issuing a warning and skipping them.
 
         Returns:
             Iterable of class instances for the files found.
         """
-        try:
-            names = catalog["/Names"]
-        except KeyError:
+        if "/Names" not in catalog:
             return
+        names = catalog["/Names"]
         if not isinstance(names, DictionaryObject):
-            logger_warning(
-                "Names tree is not a dictionary: %(names)s",
-                source=__name__,
-                names=names,
-            )
+            cls._report_malformed(f"Names tree is not a dictionary: {names}", strict=strict)
             return
-        try:
-            container = names["/EmbeddedFiles"]
-        except KeyError:
+        if "/EmbeddedFiles" not in names:
             return
+        container = names["/EmbeddedFiles"]
         if not isinstance(container, DictionaryObject):
-            logger_warning(
-                "Embedded files entry is not a dictionary: %(container)s",
-                source=__name__,
-                container=container,
-            )
+            cls._report_malformed(f"Embedded files entry is not a dictionary: {container}", strict=strict)
             return
 
         if "/Kids" in container:
             kids = container["/Kids"].get_object()
             if not isinstance(kids, ArrayObject):
-                logger_warning(
-                    "Embedded files /Kids is not an array: %(kids)s",
-                    source=__name__,
-                    kids=kids,
-                )
-            else:
-                for kid in kids:
-                    # There might be further (nested) kids here.
-                    # Wait for an example before evaluating an implementation.
-                    kid = kid.get_object()
-                    if isinstance(kid, DictionaryObject) and "/Names" in kid:
-                        yield from cls._load_from_names(kid["/Names"])
+                cls._report_malformed(f"Embedded files /Kids is not an array: {kids}", strict=strict)
+                return
+            for kid in kids:
+                # There might be further (nested) kids here.
+                # Wait for an example before evaluating an implementation.
+                kid = kid.get_object()
+                if not isinstance(kid, DictionaryObject):
+                    cls._report_malformed(f"Embedded files kid is not a dictionary: {kid}", strict=strict)
+                    continue
+                if "/Names" not in kid:
+                    continue
+                kid_names = kid["/Names"].get_object()
+                if not isinstance(kid_names, ArrayObject):
+                    cls._report_malformed(f"Embedded files name list is not an array: {kid_names}", strict=strict)
+                    continue
+                yield from cls._load_from_names(kid_names)
         if "/Names" in container:
-            yield from cls._load_from_names(container["/Names"])
+            container_names = container["/Names"].get_object()
+            if not isinstance(container_names, ArrayObject):
+                cls._report_malformed(f"Embedded files name list is not an array: {container_names}", strict=strict)
+                return
+            yield from cls._load_from_names(container_names)

--- a/pypdf/generic/_files.py
+++ b/pypdf/generic/_files.py
@@ -411,19 +411,26 @@ class EmbeddedFile:
         if "/Names" not in catalog:
             return
         names = catalog["/Names"]
+        if isinstance(names, NullObject):
+            # A null value is equivalent to an omitted entry.
+            return
         if not isinstance(names, DictionaryObject):
             cls._report_malformed(f"Names tree is not a dictionary: {names}", strict=strict)
             return
         if "/EmbeddedFiles" not in names:
             return
         container = names["/EmbeddedFiles"]
+        if isinstance(container, NullObject):
+            return
         if not isinstance(container, DictionaryObject):
             cls._report_malformed(f"Embedded files entry is not a dictionary: {container}", strict=strict)
             return
 
         if "/Kids" in container:
             kids = container["/Kids"].get_object()
-            if not isinstance(kids, ArrayObject):
+            if isinstance(kids, NullObject):
+                kids = ArrayObject()
+            elif not isinstance(kids, ArrayObject):
                 cls._report_malformed(f"Embedded files /Kids is not an array: {kids}", strict=strict)
                 return
             for kid in kids:
@@ -436,12 +443,16 @@ class EmbeddedFile:
                 if "/Names" not in kid:
                     continue
                 kid_names = kid["/Names"].get_object()
+                if isinstance(kid_names, NullObject):
+                    continue
                 if not isinstance(kid_names, ArrayObject):
                     cls._report_malformed(f"Embedded files name list is not an array: {kid_names}", strict=strict)
                     continue
                 yield from cls._load_from_names(kid_names)
         if "/Names" in container:
             container_names = container["/Names"].get_object()
+            if isinstance(container_names, NullObject):
+                return
             if not isinstance(container_names, ArrayObject):
                 cls._report_malformed(f"Embedded files name list is not an array: {container_names}", strict=strict)
                 return

--- a/pypdf/generic/_files.py
+++ b/pypdf/generic/_files.py
@@ -4,7 +4,7 @@ import bisect
 from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
-from pypdf._utils import format_iso8824_date, parse_iso8824_date
+from pypdf._utils import format_iso8824_date, logger_warning, parse_iso8824_date
 from pypdf.constants import CatalogAttributes as CA
 from pypdf.constants import FileSpecificationDictionaryEntries
 from pypdf.constants import PageAttributes as PG
@@ -17,6 +17,7 @@ from pypdf.generic import (
     NameObject,
     NullObject,
     NumberObject,
+    PdfObject,
     StreamObject,
     TextStringObject,
     is_null_or_none,
@@ -368,7 +369,7 @@ class EmbeddedFile:
         return f"<{self.__class__.__name__} name={self.name!r}>"
 
     @classmethod
-    def _load_from_names(cls, names: ArrayObject) -> Generator[EmbeddedFile]:
+    def _load_from_names(cls, names: PdfObject) -> Generator[EmbeddedFile]:
         """
         Convert the given name tree into class instances.
 
@@ -379,6 +380,13 @@ class EmbeddedFile:
             Iterable of class instances for the files found.
         """
         # This is a name tree of the format [name_1, reference_1, name_2, reference_2, ...]
+        if not isinstance(names, ArrayObject):
+            logger_warning(
+                "Embedded files name list is not an array: %(names)s",
+                source=__name__,
+                names=names,
+            )
+            return
         for i, name in enumerate(names):
             if not isinstance(name, str):
                 # Skip plain strings and retrieve them as `direct_name` by index.
@@ -400,19 +408,42 @@ class EmbeddedFile:
             Iterable of class instances for the files found.
         """
         try:
-            container = cast(
-                DictionaryObject,
-                cast(DictionaryObject, catalog["/Names"])["/EmbeddedFiles"],
-            )
+            names = catalog["/Names"]
         except KeyError:
+            return
+        if not isinstance(names, DictionaryObject):
+            logger_warning(
+                "Names tree is not a dictionary: %(names)s",
+                source=__name__,
+                names=names,
+            )
+            return
+        try:
+            container = names["/EmbeddedFiles"]
+        except KeyError:
+            return
+        if not isinstance(container, DictionaryObject):
+            logger_warning(
+                "Embedded files entry is not a dictionary: %(container)s",
+                source=__name__,
+                container=container,
+            )
             return
 
         if "/Kids" in container:
-            for kid in cast(ArrayObject, container["/Kids"].get_object()):
-                # There might be further (nested) kids here.
-                # Wait for an example before evaluating an implementation.
-                kid = kid.get_object()
-                if "/Names" in kid:
-                    yield from cls._load_from_names(cast(ArrayObject, kid["/Names"]))
+            kids = container["/Kids"].get_object()
+            if not isinstance(kids, ArrayObject):
+                logger_warning(
+                    "Embedded files /Kids is not an array: %(kids)s",
+                    source=__name__,
+                    kids=kids,
+                )
+            else:
+                for kid in kids:
+                    # There might be further (nested) kids here.
+                    # Wait for an example before evaluating an implementation.
+                    kid = kid.get_object()
+                    if isinstance(kid, DictionaryObject) and "/Names" in kid:
+                        yield from cls._load_from_names(kid["/Names"])
         if "/Names" in container:
-            yield from cls._load_from_names(cast(ArrayObject, container["/Names"]))
+            yield from cls._load_from_names(container["/Names"])

--- a/tests/generic/test_files.py
+++ b/tests/generic/test_files.py
@@ -140,18 +140,20 @@ def test_embedded_file__kids() -> None:
     assert attachments == []
 
 
-@pytest.mark.parametrize(
-    "catalog",
-    [
-        # /Names is not a dictionary.
+MALFORMED_NAME_TREE_CATALOGS = [
+    pytest.param(
         DictionaryObject({NameObject("/Names"): NumberObject(1)}),
-        # /EmbeddedFiles is not a dictionary.
+        id="names-tree-is-no-dictionary",
+    ),
+    pytest.param(
         DictionaryObject(
             {NameObject("/Names"): DictionaryObject(
                 {NameObject("/EmbeddedFiles"): NumberObject(1)}
             )}
         ),
-        # /Kids is not an array.
+        id="embedded-files-entry-is-no-dictionary",
+    ),
+    pytest.param(
         DictionaryObject(
             {NameObject("/Names"): DictionaryObject(
                 {NameObject("/EmbeddedFiles"): DictionaryObject(
@@ -159,7 +161,9 @@ def test_embedded_file__kids() -> None:
                 )}
             )}
         ),
-        # A /Kids entry that is not a dictionary.
+        id="kids-entry-is-no-array",
+    ),
+    pytest.param(
         DictionaryObject(
             {NameObject("/Names"): DictionaryObject(
                 {NameObject("/EmbeddedFiles"): DictionaryObject(
@@ -167,7 +171,21 @@ def test_embedded_file__kids() -> None:
                 )}
             )}
         ),
-        # /Names name list is not an array.
+        id="kid-is-no-dictionary",
+    ),
+    pytest.param(
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Kids"): ArrayObject([DictionaryObject(
+                        {NameObject("/Names"): NumberObject(1)}
+                    )])}
+                )}
+            )}
+        ),
+        id="kid-name-list-is-no-array",
+    ),
+    pytest.param(
         DictionaryObject(
             {NameObject("/Names"): DictionaryObject(
                 {NameObject("/EmbeddedFiles"): DictionaryObject(
@@ -175,11 +193,22 @@ def test_embedded_file__kids() -> None:
                 )}
             )}
         ),
-    ],
-)
+        id="name-list-is-no-array",
+    ),
+]
+
+
+@pytest.mark.parametrize("catalog", MALFORMED_NAME_TREE_CATALOGS)
 def test_embedded_file__load_malformed_tree(catalog: DictionaryObject) -> None:
     # A malformed embedded files name tree must not crash attachment loading.
     assert list(EmbeddedFile._load(catalog)) == []
+
+
+@pytest.mark.parametrize("catalog", MALFORMED_NAME_TREE_CATALOGS)
+def test_embedded_file__load_malformed_tree__strict(catalog: DictionaryObject) -> None:
+    # In strict mode, a malformed embedded files name tree raises instead.
+    with pytest.raises(PdfReadError, match="is not a"):
+        list(EmbeddedFile._load(catalog, strict=True))
 
 
 @pytest.mark.enable_socket

--- a/tests/generic/test_files.py
+++ b/tests/generic/test_files.py
@@ -211,6 +211,72 @@ def test_embedded_file__load_malformed_tree__strict(catalog: DictionaryObject) -
         list(EmbeddedFile._load(catalog, strict=True))
 
 
+SPEC_CONFORMANT_EMPTY_CATALOGS = [
+    pytest.param(
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/Dests"): DictionaryObject()}
+            )}
+        ),
+        id="no-embedded-files-entry",
+    ),
+    pytest.param(
+        DictionaryObject({NameObject("/Names"): NullObject()}),
+        id="null-names-tree",
+    ),
+    pytest.param(
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): NullObject()}
+            )}
+        ),
+        id="null-embedded-files-entry",
+    ),
+    pytest.param(
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Kids"): NullObject()}
+                )}
+            )}
+        ),
+        id="null-kids-entry",
+    ),
+    pytest.param(
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Kids"): ArrayObject([DictionaryObject(
+                        {NameObject("/Names"): NullObject()}
+                    )])}
+                )}
+            )}
+        ),
+        id="null-kid-name-list",
+    ),
+    pytest.param(
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Names"): NullObject()}
+                )}
+            )}
+        ),
+        id="null-name-list",
+    ),
+]
+
+
+@pytest.mark.parametrize("catalog", SPEC_CONFORMANT_EMPTY_CATALOGS)
+def test_embedded_file__load_absent_or_null_entries(
+    catalog: DictionaryObject, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A null value is equivalent to an omitted entry, thus neither warns nor raises.
+    assert list(EmbeddedFile._load(catalog)) == []
+    assert list(EmbeddedFile._load(catalog, strict=True)) == []
+    assert caplog.text == ""
+
+
 @pytest.mark.enable_socket
 def test_embedded_file__ensure_params__existing_params() -> None:
     url = "https://github.com/user-attachments/files/18691309/embedded_files_kids.pdf"

--- a/tests/generic/test_files.py
+++ b/tests/generic/test_files.py
@@ -140,6 +140,48 @@ def test_embedded_file__kids() -> None:
     assert attachments == []
 
 
+@pytest.mark.parametrize(
+    "catalog",
+    [
+        # /Names is not a dictionary.
+        DictionaryObject({NameObject("/Names"): NumberObject(1)}),
+        # /EmbeddedFiles is not a dictionary.
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): NumberObject(1)}
+            )}
+        ),
+        # /Kids is not an array.
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Kids"): NumberObject(1)}
+                )}
+            )}
+        ),
+        # A /Kids entry that is not a dictionary.
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Kids"): ArrayObject([NumberObject(1)])}
+                )}
+            )}
+        ),
+        # /Names name list is not an array.
+        DictionaryObject(
+            {NameObject("/Names"): DictionaryObject(
+                {NameObject("/EmbeddedFiles"): DictionaryObject(
+                    {NameObject("/Names"): NumberObject(1)}
+                )}
+            )}
+        ),
+    ],
+)
+def test_embedded_file__load_malformed_tree(catalog: DictionaryObject) -> None:
+    # A malformed embedded files name tree must not crash attachment loading.
+    assert list(EmbeddedFile._load(catalog)) == []
+
+
 @pytest.mark.enable_socket
 def test_embedded_file__ensure_params__existing_params() -> None:
     url = "https://github.com/user-attachments/files/18691309/embedded_files_kids.pdf"


### PR DESCRIPTION
reader.attachments and reader.attachment_list walk the /Names -> /EmbeddedFiles -> /Kids/-/Names embedded files name tree in EmbeddedFile._load and _load_from_names, but only a missing /EmbeddedFiles was handled; the rest of the walk assumed each level held the right container type. a file whose /Names or /EmbeddedFiles is not a dictionary, whose /Kids is not an array, or whose per-node /Names list is not an array therefore raised an uncaught TypeError instead of reporting no attachments. the cause is that the type of each entry comes straight from untrusted input yet was only cast, never checked. the fix guards each level with isinstance and falls back to the module's existing warn-and-skip behaviour, so a malformed tree yields an empty result the same way a missing one already does. valid single and /Kids-based name trees are unaffected.