### PR TITLE
STY: Type read_object as the PdfObject it always returns

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -354,7 +354,7 @@ class PdfReader(PdfDocCommon):
 
     def _get_object_from_stream(
         self, indirect_reference: IndirectObject
-    ) -> Union[int, PdfObject, str]:
+    ) -> PdfObject:
         # indirect reference to object in object stream
         # read the entire object stream into memory
         stmnum, _idx = self.xref_objStm[indirect_reference.idnum]
@@ -399,7 +399,7 @@ class PdfReader(PdfDocCommon):
             obj_index.append((int(objnum), int(offset)))
 
         # Phase 2: Parse each object and cache it.
-        target_obj: Union[int, PdfObject, str] = NullObject()
+        target_obj: PdfObject = NullObject()
         found = False
         for i, (obj_num, obj_offset) in enumerate(obj_index):
             # Skip objects already in the cache.
@@ -439,7 +439,7 @@ class PdfReader(PdfDocCommon):
             # caching those stale versions would shadow the newer xref entry.
             authoritative_stm, _idx = self.xref_objStm.get(obj_num, (None, None))
             if authoritative_stm == stmnum:
-                self.cache_indirect_object(0, obj_num, obj)  # type: ignore[arg-type]
+                self.cache_indirect_object(0, obj_num, obj)
 
             if obj_num == indirect_reference.idnum:
                 target_obj = obj
@@ -465,7 +465,7 @@ class PdfReader(PdfDocCommon):
             indirect_reference.generation == 0
             and indirect_reference.idnum in self.xref_objStm
         ):
-            retval = self._get_object_from_stream(indirect_reference)  # type: ignore
+            retval = self._get_object_from_stream(indirect_reference)
         elif (
             indirect_reference.generation in self.xref
             and indirect_reference.idnum in self.xref[indirect_reference.generation]
@@ -532,7 +532,7 @@ class PdfReader(PdfDocCommon):
             if current_object in self._known_objects:
                 raise LimitReachedError(f"Detected loop with self reference for {indirect_reference!r}.")
             self._known_objects.add(current_object)
-            retval = read_object(self.stream, self)  # type: ignore[assignment]
+            retval = read_object(self.stream, self)
             self._known_objects.remove(current_object)
 
             # override encryption is used for the /Encrypt dictionary
@@ -541,7 +541,6 @@ class PdfReader(PdfDocCommon):
                 if not self._encryption.is_decrypted():
                     raise FileNotDecryptedError("File has not been decrypted")
                 # otherwise, decrypt here...
-                retval = cast(PdfObject, retval)
                 retval = self._encryption.decrypt_object(
                     retval, indirect_reference.idnum, indirect_reference.generation,
                     strict=self.strict,
@@ -573,7 +572,7 @@ class PdfReader(PdfDocCommon):
                 self.stream.seek(m.end(0) + 1)
                 skip_over_whitespace(self.stream)
                 self.stream.seek(-1, 1)
-                retval = read_object(self.stream, self)  # type: ignore[assignment]
+                retval = read_object(self.stream, self)
 
                 # override encryption is used for the /Encrypt dictionary
                 if not self._override_encryption and self._encryption is not None:
@@ -581,7 +580,6 @@ class PdfReader(PdfDocCommon):
                     if not self._encryption.is_decrypted():
                         raise FileNotDecryptedError("File has not been decrypted")
                     # otherwise, decrypt here...
-                    retval = cast(PdfObject, retval)
                     retval = self._encryption.decrypt_object(
                         retval, indirect_reference.idnum, indirect_reference.generation,
                         strict=self.strict,

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -1550,7 +1550,7 @@ def read_object(
     stream: StreamType,
     pdf: Optional[PdfReaderProtocol],
     forced_encoding: Union[str, list[str], dict[int, str], None] = None,
-) -> Union[PdfObject, int, str, ContentStream]:
+) -> PdfObject:
     tok = stream.read(1)
     stream.seek(-1, 1)  # reset to start
     if tok == b"/":


### PR DESCRIPTION
read_object is annotated Union[PdfObject, int, str, ContentStream], but it never
returns an int or a str. Every branch hands back a PdfObject subclass - NameObject,
DictionaryObject, ArrayObject, BooleanObject, NullObject, NumberObject or
IndirectObject - and ContentStream is a DecodedStreamObject, so it is already a
PdfObject too.

Because the annotation was wider than the truth, the callers had to work around it.
_get_object_from_stream repeated the same union, and get_object carried two
type: ignore[assignment] comments plus two cast(PdfObject, retval) calls that existed
only to undo the phantom types again before decrypt_object. Narrowing the return type
lets all six go, including the last bare type: ignore left in the package.

Nothing changes at runtime, so I have not added tests. mypy reports the same 11
pre-existing errors before and after, all in _crypt_providers/_pycryptodome.py.

One thing worth flagging: I could not run the tests that download the corpus locally,
so those are down to CI. The offline suite passes, 1231 tests.
