### PR TITLE
ROB: Do not crash when a destination tree node entry is not an array

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -516,12 +516,27 @@ class PdfDocCommon(ABC):
         visited.add(tree_id)
 
         if PagesAttributes.KIDS in tree:
+            kids = tree[PagesAttributes.KIDS].get_object()
+            if not isinstance(kids, ArrayObject):
+                logger_warning(
+                    "Destination tree kids are not an array: %(kids)s",
+                    source=__name__,
+                    kids=kids,
+                )
+                return retval
             # recurse down the tree
-            for kid in cast(ArrayObject, tree[PagesAttributes.KIDS]):
+            for kid in kids:
                 self._get_named_destinations(tree=kid.get_object(), retval=retval, visited=visited)
         # §7.9.6, entries in a name tree node dictionary
         elif CA.NAMES in tree:  # /Kids and /Names are exclusives (§7.9.6)
-            names = cast(DictionaryObject, tree[CA.NAMES])
+            names = tree[CA.NAMES].get_object()
+            if not isinstance(names, ArrayObject):
+                logger_warning(
+                    "Destination tree names are not an array: %(names)s",
+                    source=__name__,
+                    names=names,
+                )
+                return retval
             i = 0
             while i < len(names):
                 key = names[i].get_object()

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1185,6 +1185,50 @@ def test_get_named_destinations__tree_is_not_a_dictionary(caplog, key, value, ex
     assert expected in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        pytest.param(
+            "/Names",
+            NumberObject(5),
+            "Destination tree names are not an array: 5",
+            id="names-number",
+        ),
+        pytest.param(
+            "/Names",
+            TextStringObject("x"),
+            "Destination tree names are not an array: x",
+            id="names-string",
+        ),
+        pytest.param(
+            "/Kids",
+            NumberObject(7),
+            "Destination tree kids are not an array: 7",
+            id="kids-number",
+        ),
+        pytest.param(
+            "/Kids",
+            TextStringObject("y"),
+            "Destination tree kids are not an array: y",
+            id="kids-string",
+        ),
+    ],
+)
+def test_get_named_destinations__node_entry_is_not_an_array(caplog, key, value, expected):
+    """A /Names or /Kids entry that is not an array raised a TypeError from len() or iteration."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/Names")] = DictionaryObject(
+        {NameObject("/Dests"): DictionaryObject({NameObject(key): value})}
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).named_destinations == {}
+    assert expected in caplog.text
+
+
 def test_get_named_destinations__names_is_not_a_dictionary():
     """A /Names entry that cannot hold /Dests simply yields no destinations."""
     writer = PdfWriter()


### PR DESCRIPTION
A name tree node holds its entries under /Names or /Kids, and both are read straight
into a cast without checking what came back. If either is not an array, reading the
named destinations crashes: /Names as a number fails on len(), /Names as a string
fails on get_object(), and /Kids as a number fails when the loop tries to iterate it.

This sits right next to the /Dests guard from #4020 and behaves the same way - the
entry is logged and no destinations are returned, instead of the whole document
becoming unreadable.

Tests cover the container itself being wrong. The existing non_array_value test
already covers a bad element inside a valid array, so that case is untouched.

I could not run the tests that download the corpus locally; the offline suite passes,
1238 tests.
Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
