### PR TITLE
ROB: Do not crash when a page label node entry is not an array

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -134,7 +134,14 @@ def get_label_from_nums(dictionary_object: DictionaryObject, index: int) -> str:
     # The keys shall be sorted in numerical order,
     # analogously to the arrangement of keys in a name tree
     # as described in 7.9.6, "Name Trees."
-    nums = cast(ArrayObject, dictionary_object["/Nums"])
+    nums = dictionary_object["/Nums"].get_object()
+    if not isinstance(nums, ArrayObject):
+        logger_warning(
+            "Page label /Nums is not an array: %(nums)s",
+            source=__name__,
+            nums=nums,
+        )
+        return str(index + 1)  # Fallback
     nums_length = len(nums)
     i = 0
     value = None
@@ -217,7 +224,14 @@ def index2label(reader: PdfCommonDocProtocol, index: int) -> str:
         # Limit maximum depth.
         level = 0
         while level < 100:
-            kids = cast(list[DictionaryObject], number_tree["/Kids"])
+            kids = number_tree["/Kids"].get_object()
+            if not isinstance(kids, ArrayObject):
+                logger_warning(
+                    "Page label /Kids is not an array: %(kids)s",
+                    source=__name__,
+                    kids=kids,
+                )
+                return str(index + 1)  # Fallback
             for kid in kids:
                 # kid = {'/Limits': [0, 63], '/Nums': [0, {'/P': 'C1'}, ...]}
                 limits = kid.get("/Limits", NullObject()).get_object()

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -275,3 +275,36 @@ def test_index2label__page_labels_not_a_dictionary(caplog, value, expected):
 
     assert PdfReader(stream).page_labels == ["1", "2"]
     assert expected in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        pytest.param(
+            "/Nums", NumberObject(3), "Page label /Nums is not an array: 3", id="nums-number"
+        ),
+        pytest.param(
+            "/Nums", TextStringObject("x"), "Page label /Nums is not an array: x", id="nums-string"
+        ),
+        pytest.param(
+            "/Kids", NumberObject(3), "Page label /Kids is not an array: 3", id="kids-number"
+        ),
+        pytest.param(
+            "/Kids", TextStringObject("y"), "Page label /Kids is not an array: y", id="kids-string"
+        ),
+    ],
+)
+def test_index2label__node_entry_is_not_an_array(caplog, key, value, expected):
+    """A /Nums or /Kids entry that is not an array raised a TypeError from len() or iteration."""
+    writer = PdfWriter()
+    for _ in range(2):
+        writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/PageLabels")] = DictionaryObject(
+        {NameObject(key): value}
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).page_labels == ["1", "2"]
+    assert expected in caplog.text


### PR DESCRIPTION
The /PageLabels dictionary itself is guarded since #4022, but the /Nums and /Kids
entries inside it are still read through a cast. A /Nums that is not an array fails
on len(), and a /Kids that is not an array fails when the loop iterates it, so a
malformed number tree crashes reader.page_labels.

Both now log and fall back to str(index + 1), which is what the existing guard just
above already does for a malformed /PageLabels, so the fallback behaviour is
unchanged.

I could not run the tests that download the corpus locally; the offline suite passes,
1238 tests.
