### PR TITLE
ROB: Reject a page box that is not an array

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -112,7 +112,9 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
                 break
     if isinstance(retval, IndirectObject):
         retval = self.pdf.get_object(retval)
-    if isinstance(retval, ArrayObject) and (length := len(retval)) != 4:
+    if not isinstance(retval, ArrayObject):
+        raise ValueError(f"Expected an array of four values for {name}, got {retval}")
+    if (length := len(retval)) != 4:
         if length > 4:
             # Keep backwards-compatibility with files previously written in a
             # broken way by pypdf, which carried more than four values.
@@ -128,7 +130,7 @@ def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleOb
                 f"Expected four values for {name}, got {length}: {retval}"
             )
     else:
-        retval = RectangleObject(retval)  # type: ignore[arg-type]
+        retval = RectangleObject(retval)
     _set_rectangle(self, name, retval)
     return retval
 

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -29,6 +29,7 @@ from pypdf.generic import (
     IndirectObject,
     NameObject,
     NullObject,
+    NumberObject,
     RectangleObject,
     TextStringObject,
 )
@@ -1568,6 +1569,29 @@ def test_replace_contents__null_object_cloning_error():
 
     reader = PdfReader(data)
     assert len(reader.pages) == 10
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "got 1", id="number"),
+        pytest.param(TextStringObject("x"), "got x", id="string"),
+        pytest.param(DictionaryObject(), "got {}", id="dictionary"),
+    ],
+)
+def test_get_rectangle__value_is_not_an_array(value, expected):
+    """A page box that is not an array raised a TypeError from len()."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/MediaBox")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    with pytest.raises(
+        ValueError, match=f"Expected an array of four values for /MediaBox, {expected}"
+    ):
+        _ = PdfReader(stream).pages[0].mediabox
 
 
 def test_get_rectangle__size_handling(caplog):


### PR DESCRIPTION
_get_rectangle checks the length only when the value is already an ArrayObject.
Anything else falls through to RectangleObject(retval) behind a type: ignore, where
it fails with "object of type 'NumberObject' has no len()" - which says nothing about
which box was wrong.

It now raises a ValueError naming the box, in the same wording as the existing
too-few-values error a few lines below, and the type: ignore is no longer needed.

This is not a behavioural change in the sense of newly rejecting a valid file: the
old code already failed on the same input, just with a less useful error.

I could not run the tests that download the corpus locally; the offline suite passes,
1237 tests.
Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
