### PR TITLE
ROB: Do not report a non-stream metadata entry as invalid XML

### DIFF
--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -513,6 +513,13 @@ class DictionaryObject(dict[Any, Any], PdfObject):
             return None
         assert metadata is not None, "mypy"
         metadata = metadata.get_object()
+        if not isinstance(metadata, StreamObject):
+            logger_warning(
+                "Metadata is not a stream: %(metadata)s",
+                source=__name__,
+                metadata=metadata,
+            )
+            return None
         return XmpInformation(metadata)
 
     def write_to_stream(

--- a/tests/test_xmp.py
+++ b/tests/test_xmp.py
@@ -8,7 +8,15 @@ import pypdf.generic
 import pypdf.xmp
 from pypdf import PdfReader, PdfWriter
 from pypdf.errors import LimitReachedError, PdfReadError, XmpDocumentError
-from pypdf.generic import ContentStream, NameObject, StreamObject
+from pypdf.generic import (
+    ArrayObject,
+    ContentStream,
+    DictionaryObject,
+    NameObject,
+    NumberObject,
+    StreamObject,
+    TextStringObject,
+)
 from pypdf.xmp import XmpInformation
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
@@ -100,6 +108,28 @@ def get_all_tiff(xmp: pypdf.xmp.XmpInformation):
         contents = [content.data for content in tag.childNodes]
         data[tag.tagName] = contents
     return data
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "Metadata is not a stream: 1", id="number"),
+        pytest.param(TextStringObject("x"), "Metadata is not a stream: x", id="string"),
+        pytest.param(DictionaryObject(), "Metadata is not a stream: {}", id="dictionary"),
+        pytest.param(ArrayObject(), "Metadata is not a stream: []", id="array"),
+    ],
+)
+def test_xmp_metadata__is_not_a_stream(caplog, value, expected):
+    """A /Metadata entry that is not a stream was reported as invalid XML."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.root_object[NameObject("/Metadata")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).xmp_metadata is None
+    assert expected in caplog.text
 
 
 def test_converter_date():


### PR DESCRIPTION
xmp_metadata hands the /Metadata entry straight to XmpInformation, which is typed for
a StreamObject. If the entry is a number, a string, a dictionary or an array, the
get_data() call inside raises AttributeError and comes back out as
"XML in XmpInformation was invalid" - which points at the XML rather than at the
entry not being a stream at all.

The docstring already says the property can return None when no metadata is found, so
an entry that cannot be one is now logged and returns None as well.

I could not run the tests that download the corpus locally; the offline suite passes,
1238 tests.