### PR TITLE
ROB: Do not crash when the font resources are not a dictionary

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -101,6 +101,22 @@ MERGE_CROP_BOX = "cropbox"  # pypdf <= 3.4.0 used "trimbox"
 MAX_XFORM_INVOCATIONS_PER_EXTRACTION = 5_000
 
 
+def _get_font_resources(resources_dict: DictionaryObject) -> DictionaryObject:
+    """Return the /Font resources, or an empty dictionary if they are malformed."""
+    fonts = resources_dict.get("/Font")
+    if fonts is None:
+        return DictionaryObject()
+    fonts = fonts.get_object()
+    if not isinstance(fonts, DictionaryObject):
+        logger_warning(
+            "Font resources are not a dictionary: %(fonts)s",
+            source=__name__,
+            fonts=fonts,
+        )
+        return DictionaryObject()
+    return fonts
+
+
 def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
     retval: Union[RectangleObject, ArrayObject, IndirectObject, None] = self.get(name)
     if isinstance(retval, RectangleObject):
@@ -1861,10 +1877,8 @@ class PageObject(DictionaryObject):
             # file as not damaged, no need to check for TJ or Tj
             return ""
 
-        if (
-            "/Font" in resources_dict
-            and (font_resources_dict := cast(DictionaryObject, resources_dict["/Font"]))
-        ):
+        font_resources_dict = _get_font_resources(resources_dict)
+        if font_resources_dict:
             for font_resource in font_resources_dict:
                 try:
                     font_resource_object = cast(DictionaryObject, font_resources_dict[font_resource].get_object())

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -29,6 +29,7 @@ from pypdf.generic import (
     IndirectObject,
     NameObject,
     NullObject,
+    NumberObject,
     RectangleObject,
     TextStringObject,
 )
@@ -1568,6 +1569,29 @@ def test_replace_contents__null_object_cloning_error():
 
     reader = PdfReader(data)
     assert len(reader.pages) == 10
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "Font resources are not a dictionary: 1", id="number"),
+        pytest.param(TextStringObject("x"), "Font resources are not a dictionary: x", id="string"),
+        pytest.param(ArrayObject(), "Font resources are not a dictionary: []", id="array"),
+    ],
+)
+def test_extract_text__font_resources_not_a_dictionary(caplog, value, expected):
+    """A /Font entry that is not a dictionary raised a TypeError when iterated."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Resources")] = DictionaryObject(
+        {NameObject("/Font"): value}
+    )
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).pages[0].extract_text() == ""
+    assert expected in caplog.text
 
 
 def test_get_rectangle__size_handling(caplog):


### PR DESCRIPTION
_extract_text casts the /Font resources to a dictionary and iterates them straight
away, so a /Font entry that is a number, a string or an array crashes text extraction
with "'NumberObject' object is not iterable".

The lookup moved into a small helper that logs and returns an empty dictionary, which
gives the same result as a page with no fonts at all - extraction returns "" instead
of failing. Keeping it in a helper also avoids pushing _extract_text past the
complexity limit.

I could not run the tests that download the corpus locally; the offline suite passes,
1237 tests.