### PR TITLE
DEP: Rework configuration value handling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ You can contribute to `pypdf on GitHub <https://github.com/py-pdf/pypdf>`_.
    modules/actions
    modules/annotations
    modules/constants
+   modules/configuration
    modules/errors
    modules/generic
    modules/PdfDocCommon

--- a/docs/modules/configuration.rst
+++ b/docs/modules/configuration.rst
@@ -1,0 +1,12 @@
+Configuration
+-------------
+
+.. autoclass:: pypdf.Configuration
+    :members:
+    :show-inheritance:
+
+.. autofunction:: pypdf.apply_configuration
+
+.. autofunction:: pypdf.get_configuration
+
+.. autofunction:: pypdf.overwrite_configuration

--- a/docs/user/cropping-and-transforming.md
+++ b/docs/user/cropping-and-transforming.md
@@ -209,7 +209,7 @@ page.bleedbox = RectangleObject((mb.left, mb.bottom, mb.right, mb.top))
 page.artbox = RectangleObject((mb.left, mb.bottom, mb.right, mb.top))
 ```
 
-### pypdf._page.MERGE_CROP_BOX
+### Page merge box
 
 `pypdf<=3.4.0` used to merge the other page with `trimbox`.
 `pypdf>3.4.0` changes this behavior to `cropbox`.
@@ -218,9 +218,9 @@ In case anybody has good reasons to use/expect `trimbox`, you can add the
 following code to get the old behavior:
 
 ```{testcode}
-import pypdf
+from pypdf import overwrite_configuration
 
-pypdf._page.MERGE_CROP_BOX = "trimbox"
+overwrite_configuration(page_merge_box="trimbox")
 ```
 
 ## Transforming several copies of the same page

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -4,36 +4,36 @@ We strive to provide a library with secure defaults.
 
 ## Configuration
 
-### Filters
+### Global
 
-*pypdf* currently employs output size limits for some filters which are known to possibly have large compression ratios
-and other related issues.
+*pypdf* currently employs a set of global configuration values, whose descriptions and defaults are
+available at {py:class}`~pypdf._configuration.Configuration`. They internally rely on
+{py:mod}`contextvars`.
 
-The usual limit is at 75 MB of uncompressed data during decompression. If this is too low for your use case, and you are
-aware of the possible side effects, you can modify the following constants:
+```{testsetup}
+pypdf_test_setup("user/security", {
+    "example.pdf": "../resources/example.pdf",
+})
+```
 
-* `pypdf.filters.JBIG2_MAX_OUTPUT_LENGTH` for the *JBIG2Decode* filter (JBIG2 images)
-* `pypdf.filters.LZW_MAX_OUTPUT_LENGTH` for the maximum output length of the *LZWDecode* filter (LZW compression)
-* `pypdf.filters.RUN_LENGTH_MAX_OUTPUT_LENGTH` for the maximum output length of the *RunLengthDecode* filter (run-length compression)
-* `pypdf.filters.ZLIB_MAX_OUTPUT_LENGTH` for the maximum output length of the *FlateDecode* filter (zlib compression)
-* `pypdf.filters.ZLIB_MAX_RECOVERY_INPUT_LENGTH` for the number of bytes to attempt the recovery with for the *FlateDecode* filter.
-  It defaults to 5 MB due to the much more complex recovery approach.
+```{testcode}
+from pypdf import Configuration, PdfReader, apply_configuration, overwrite_configuration
 
-The following general stream length limits apply, defaulting to 75 MB as well:
+# Limit the values to the current scope.
+# The changed configuration value will be reset when exiting the context manager.
+with apply_configuration(maximum_declared_stream_length=10_000):
+    reader = PdfReader("example.pdf")
+    for page in reader.pages:
+        # Do something with the page.
+        pass
 
-* `pypdf.filters.MAX_DECLARED_STREAM_LENGTH` for the `/Length` field of streams.
-* `pypdf.filters.MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH` for the maximum allowed output length of array-based streams.
-
-The following general limits apply to images:
-
-* `pypdf.filters.IMAGE_MAX_BUFFER_SIZE` for the maximum buffer size to allocate for images, defaulting to 75 MB
-
-For the *JBIG2Decode* filter, calling the external *jbig2dec* tool can be disabled by setting `pypdf.filters.JBIG2DEC_BINARY = None`.
-
-For the *FlateDecode* filter, the following additional limits apply:
-
-* `pypdf.filters.FLATE_MAX_COLUMNS` for the maximum number of columns, defaulting to 250 000
-* `pypdf.filters.FLATE_MAX_ROW_LENGTH` for the maximum row length, defaulting to 4 MB
+# Overwrite the values globally.
+overwrite_configuration(maximum_declared_stream_length=5_000)
+reader = PdfReader("example.pdf")
+for page in reader.pages:
+    # Do something with the page.
+    pass
+```
 
 ### Reading
 
@@ -52,13 +52,6 @@ For *PdfWriter* instances, the following limits are employed for incremental rea
   500 000. Setting it to `None` will fully disable this limit.
 * `incremental_clone_object_id_limit` limits the maximum object ID to read during cloning. It defaults to
   1 000 000. Setting it to `None` will fully disable this limit.
-
-### XMP
-
-For reading the XML-based XMP metadata, the following limits apply:
-
-* `pypdf.xmp.XMP_MAX_INPUT_LENGTH` for the maximum stream length, defaulting to 5 MB.
-* `pypdf.xmp.XMP_MAX_ELEMENT_COUNT` for the maximum number of elements, defaulting to 100 000.
 
 ## Reporting possible vulnerabilities
 

--- a/pypdf/__init__.py
+++ b/pypdf/__init__.py
@@ -7,6 +7,7 @@ text and metadata from PDFs as well.
 You can read the full docs at https://pypdf.readthedocs.io/.
 """
 
+from ._configuration import Configuration, apply_configuration, get_configuration, overwrite_configuration
 from ._crypt_providers import crypt_provider
 from ._doc_common import DocumentInformation
 from ._encryption import PasswordType
@@ -31,6 +32,7 @@ _debug_versions = (
 )
 
 __all__ = [
+    "Configuration",
     "DocumentInformation",
     "ImageType",
     "ObjectDeletionFlag",
@@ -43,6 +45,9 @@ __all__ = [
     "Transformation",
     "__version__",
     "_debug_versions",
+    "apply_configuration",
+    "get_configuration",
     "mult",
+    "overwrite_configuration",
     "parse_filename_page_ranges",
 ]

--- a/pypdf/_configuration.py
+++ b/pypdf/_configuration.py
@@ -1,0 +1,296 @@
+"""Configuration value handling."""
+import dataclasses
+import functools
+import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Literal, Optional, Union
+
+
+@functools.cache
+def _determine_jbig2dec_binary() -> Optional[str]:
+    """
+    Small utility function to determine the `jbig2dec` binary path only once.
+
+    Returns:
+        The corresponding binary path if available.
+    """
+    return shutil.which("jbig2dec")
+
+
+@dataclasses.dataclass(frozen=True)
+class Configuration:
+    """
+    Configuration used while processing PDF files.
+
+    These limits mostly protect against excessive resource consumption caused by malformed or malicious PDF files.
+
+    .. note::
+
+        Avoid relying on specific implementation details of this class. The main public API consists of the values
+        being considered read-only for each instance with the overwrite method to create a new instance with the
+        specified values changed.
+    """
+
+    maximum_declared_stream_length: int = 75_000_000
+    """The maximum allowed declared ``/Length`` value for streams."""
+    array_based_stream_maximum_output_length: int = 75_000_000
+    """The maximum allowed output length for array-based streams."""
+
+    jbig2_maximum_output_length: int = 75_000_000
+    """
+    The maximum allowed number of uncompressed bytes during decompression when using the ``/JBIG2Decode`` filter
+    (JBIG2 images).
+    """
+    lzw_maximum_output_length: int = 75_000_000
+    """
+    The maximum allowed number of uncompressed bytes during decompression when using the ``/LZWDecode`` filter
+    (LZW compression).
+    """
+    run_length_maximum_output_length: int = 75_000_000
+    """
+    The maximum allowed number of uncompressed bytes during decompression when using the ``/RunLengthDecode`` filter
+    (run-length compression).
+    """
+    zlib_maximum_output_length: int = 75_000_000
+    """
+    The maximum allowed number of uncompressed bytes during decompression when using the ``/FlateDecode`` filter
+    (zlib compression).
+    """
+    zlib_maximum_recovery_input_length: int = 5_000_000
+    """
+    The maximum allowed number of bytes to attempt the recovery with when using the ``/FlateDecode`` filter
+    (zlib compression).
+    """
+
+    flate_maximum_columns: int = 250_000
+    """The maximum allowed number of columns when using the ``/FlateDecode`` filter."""
+    flate_maximum_row_length: int = 4_000_000
+    """The maximum allowed row length when using the ``/FlateDecode`` filter."""
+
+    image_maximum_buffer_size: int = 75_000_000
+    """The maximum allowed number of bytes to allocate for images."""
+
+    xmp_maximum_input_length: int = 5_000_000
+    """The maximum allowed actual decompressed stream length in bytes for XMP data."""
+    xmp_maximum_element_count: int = 100_000
+    """The maximum allowed number of elements for XMP data."""
+
+    outline_maximum_entries: int = 100_000
+    """The maximum allowed number of outline entries."""
+    outline_maximum_depth: int = 100
+    """The maximum allowed depth for outline entries."""
+
+    page_tree_maximum_entries: int = 100_000
+    """The maximum allowed number of entries in the page tree."""
+    page_tree_maximum_depth: int = 100
+    """The maximum allowed depth of the page tree."""
+
+    xform_maximum_invocations_per_extraction: int = 5_000
+    """The maximum allowed number of ``/XObject`` forms per page during text extraction."""
+
+    jbig2dec_binary: Optional[str] = dataclasses.field(default_factory=_determine_jbig2dec_binary)
+    """
+    The location of the ``jbig2dec`` binary.
+
+    This either is a string holding the path to the binary, or ``None`` if the binary could not be found
+    or the binary should not be called.
+    """
+
+    page_merge_box: Literal["cropbox", "trimbox"] = "cropbox"  # pypdf <= 3.4.0 used "trimbox"
+    """The page box to use during merge."""
+
+    disable_legacy_handling: bool = False
+    """
+    Temporary configuration value for applications which do not rely on old overwrites and thus
+    are able to skip legacy handling.
+
+    This disables looking for changes of the old constants during each initialization of the reader
+    class. Please note that while this reduces the required overhead, it will disable all related
+    deprecation warnings/errors. Setting this flag while legacy constants are intentionally being
+    modified is unsupported/incorrect.
+
+    After the deprecation period, this configuration value will be removed with its own deprecation
+    period as well.
+    """
+
+    def with_overwrites(self, **kwargs: Any) -> "Configuration":
+        """
+        Creates a new configuration with the specified values overwritten.
+
+        Args:
+            **kwargs: Configuration field names and their new values.
+
+        Returns:
+            A new configuration with the specified values overwritten.
+        """
+        return dataclasses.replace(self, **kwargs)
+
+
+# A default configuration without any value changes.
+DEFAULT_CONFIGURATION = Configuration()
+
+# The current configuration.
+CURRENT_CONFIGURATION: ContextVar[Configuration] = ContextVar(
+    "pypdf_configuration",
+    default=DEFAULT_CONFIGURATION,
+)
+
+
+def get_configuration() -> Configuration:
+    """
+    Get the current configuration.
+
+    Returns:
+        The current configuration.
+    """
+    return CURRENT_CONFIGURATION.get()
+
+
+def _build_configuration(
+    configuration: Optional[Configuration],
+    overwrites: dict[str, Any],
+) -> Configuration:
+    """
+    Utility function to build a new configuration from the given values.
+
+    Args:
+        configuration: A possible explicit configuration to use instead of the current configuration.
+        overwrites: Entries to overwrite.
+
+    Returns:
+        The generated configuration.
+    """
+    base = configuration if configuration is not None else get_configuration()
+    return base.with_overwrites(**overwrites)
+
+
+def overwrite_configuration(
+    configuration: Optional[Configuration] = None,
+    **overwrites: Any,
+) -> Configuration:
+    """
+    Overwrite the configuration for the current execution context.
+
+    Args:
+        configuration: A direct configuration instance to use.
+        **overwrites: Configuration parameters to overwrite in the current or given configuration.
+
+    Returns:
+        The new configuration.
+    """
+    new_configuration = _build_configuration(configuration, overwrites)
+    CURRENT_CONFIGURATION.set(new_configuration)
+    return new_configuration
+
+
+@contextmanager
+def apply_configuration(
+    configuration: Optional[Configuration] = None,
+    **overwrites: Any,
+) -> Iterator[Configuration]:
+    """
+    Temporarily overwrite the configuration.
+
+    Args:
+        configuration: A direct configuration instance to use.
+        **overwrites: Configuration parameters to overwrite in the current or given configuration.
+
+    Returns:
+        The new configuration.
+    """
+    new_configuration = _build_configuration(configuration, overwrites)
+    token = CURRENT_CONFIGURATION.set(new_configuration)
+    try:
+        yield new_configuration
+    finally:
+        CURRENT_CONFIGURATION.reset(token)
+
+
+# Map the new field names to their legacy names.
+LEGACY_NAME_MAPPING = {
+    "maximum_declared_stream_length": "MAX_DECLARED_STREAM_LENGTH",
+    "array_based_stream_maximum_output_length": "MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH",
+    "jbig2_maximum_output_length": "JBIG2_MAX_OUTPUT_LENGTH",
+    "lzw_maximum_output_length": "LZW_MAX_OUTPUT_LENGTH",
+    "run_length_maximum_output_length": "RUN_LENGTH_MAX_OUTPUT_LENGTH",
+    "zlib_maximum_output_length": "ZLIB_MAX_OUTPUT_LENGTH",
+    "zlib_maximum_recovery_input_length": "ZLIB_MAX_RECOVERY_INPUT_LENGTH",
+    "flate_maximum_columns": "FLATE_MAX_COLUMNS",
+    "flate_maximum_row_length": "FLATE_MAX_ROW_LENGTH",
+    "image_maximum_buffer_size": "FLATE_MAX_BUFFER_SIZE",
+    "xmp_maximum_input_length": "XMP_MAX_INPUT_LENGTH",
+    "xmp_maximum_element_count": "XMP_MAX_ELEMENT_COUNT",
+    "jbig2dec_binary": "JBIG2DEC_BINARY",
+    "page_merge_box": "MERGE_CROP_BOX",
+}
+
+# Record which legacy overwrites have already emitted a warning in the current process/session.
+WARNED_LEGACY_OVERWRITES: set[str] = set()
+
+
+def apply_legacy_configuration() -> Configuration:
+    """
+    Overwrite the current configuration with the legacy configuration if it has been changed.
+
+    Returns:
+        The new configuration which has been applied.
+    """
+    configuration = get_configuration()
+    if configuration.disable_legacy_handling:
+        return configuration
+
+    from pypdf._page import MERGE_CROP_BOX  # noqa: PLC0415
+    from pypdf.filters import (  # noqa: PLC0415
+        FLATE_MAX_BUFFER_SIZE,
+        FLATE_MAX_COLUMNS,
+        FLATE_MAX_ROW_LENGTH,
+        JBIG2_MAX_OUTPUT_LENGTH,
+        JBIG2DEC_BINARY,
+        LZW_MAX_OUTPUT_LENGTH,
+        MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH,
+        MAX_DECLARED_STREAM_LENGTH,
+        RUN_LENGTH_MAX_OUTPUT_LENGTH,
+        ZLIB_MAX_OUTPUT_LENGTH,
+        ZLIB_MAX_RECOVERY_INPUT_LENGTH,
+    )
+    from pypdf.xmp import XMP_MAX_ELEMENT_COUNT, XMP_MAX_INPUT_LENGTH  # noqa: PLC0415
+
+    legacy_values = {
+        "MAX_DECLARED_STREAM_LENGTH": MAX_DECLARED_STREAM_LENGTH,
+        "MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH": MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH,
+        "JBIG2_MAX_OUTPUT_LENGTH": JBIG2_MAX_OUTPUT_LENGTH,
+        "LZW_MAX_OUTPUT_LENGTH": LZW_MAX_OUTPUT_LENGTH,
+        "RUN_LENGTH_MAX_OUTPUT_LENGTH": RUN_LENGTH_MAX_OUTPUT_LENGTH,
+        "ZLIB_MAX_OUTPUT_LENGTH": ZLIB_MAX_OUTPUT_LENGTH,
+        "ZLIB_MAX_RECOVERY_INPUT_LENGTH": ZLIB_MAX_RECOVERY_INPUT_LENGTH,
+        "FLATE_MAX_COLUMNS": FLATE_MAX_COLUMNS,
+        "FLATE_MAX_ROW_LENGTH": FLATE_MAX_ROW_LENGTH,
+        "FLATE_MAX_BUFFER_SIZE": FLATE_MAX_BUFFER_SIZE,
+        "XMP_MAX_INPUT_LENGTH": XMP_MAX_INPUT_LENGTH,
+        "XMP_MAX_ELEMENT_COUNT": XMP_MAX_ELEMENT_COUNT,
+        "JBIG2DEC_BINARY": JBIG2DEC_BINARY,
+        "MERGE_CROP_BOX": MERGE_CROP_BOX,
+    }
+    overwrites: dict[str, Union[int, str, None]] = {}
+
+    for field_name, legacy_name in LEGACY_NAME_MAPPING.items():
+        legacy_value = legacy_values[legacy_name]
+
+        if legacy_value != getattr(DEFAULT_CONFIGURATION, field_name):
+            if legacy_name not in WARNED_LEGACY_OVERWRITES:
+                from pypdf._utils import deprecate_with_replacement  # noqa: PLC0415
+
+                deprecate_with_replacement(
+                    old_name=legacy_name,
+                    new_name=f"Configuration.{field_name}",
+                    removed_in="7.0.0",
+                )
+                WARNED_LEGACY_OVERWRITES.add(legacy_name)
+
+            overwrites[field_name] = legacy_value
+
+    if not overwrites:
+        return configuration
+    return overwrite_configuration(**overwrites)  # type: ignore[arg-type]

--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -40,6 +40,7 @@ from typing import (
     cast,
 )
 
+from ._configuration import get_configuration
 from ._encryption import Encryption
 from ._page import PageObject, _VirtualList
 from ._page_labels import index2label as page_index2page_label
@@ -85,12 +86,6 @@ from .generic import (
 from .generic._files import EmbeddedFile
 from .types import OutlineType, PagemodeType
 from .xmp import XmpInformation
-
-# TODO: Make configurable.
-OUTLINE_MAX_ENTRIES = 100_000
-OUTLINE_MAX_DEPTH = 100
-PAGE_TREE_MAX_ENTRIES = 100_000
-PAGE_TREE_MAX_DEPTH = 100
 
 
 def convert_to_int(d: bytes, size: int) -> Union[int, tuple[Any, ...]]:
@@ -955,8 +950,9 @@ class PdfDocCommon(ABC):
         if node is None:
             return outline
 
-        if depth > OUTLINE_MAX_DEPTH:
-            raise LimitReachedError(f"Maximum outline depth reached: {depth} > {OUTLINE_MAX_DEPTH}.")
+        configuration = get_configuration()
+        if depth > configuration.outline_maximum_depth:
+            raise LimitReachedError(f"Maximum outline depth reached: {depth} > {configuration.outline_maximum_depth}.")
 
         # see if there are any more outline items
         if visited is None:
@@ -968,9 +964,10 @@ class PdfDocCommon(ABC):
                 break
             visited.add(node_id)
             traversal_state.entry_count += 1
-            if traversal_state.entry_count > OUTLINE_MAX_ENTRIES:
+            if traversal_state.entry_count > configuration.outline_maximum_entries:
                 raise LimitReachedError(
-                    f"Maximum outline entry limit reached: {traversal_state.entry_count} > {OUTLINE_MAX_ENTRIES}."
+                    f"Maximum outline entry limit reached: "
+                    f"{traversal_state.entry_count} > {configuration.outline_maximum_entries}."
                 )
 
             if not isinstance(node, DictionaryObject):
@@ -1302,8 +1299,11 @@ class PdfDocCommon(ABC):
             visited = set()
         if traversal_state is None:
             traversal_state = _TraversalState()
-        if depth > PAGE_TREE_MAX_DEPTH:
-            raise LimitReachedError(f"Maximum page tree depth reached: {depth} > {PAGE_TREE_MAX_DEPTH}.")
+        configuration = get_configuration()
+        if depth > configuration.page_tree_maximum_depth:
+            raise LimitReachedError(
+                f"Maximum page tree depth reached: {depth} > {configuration.page_tree_maximum_depth}."
+            )
         if is_null_or_none(pages):
             # Fix issue 327: set flattened_pages attribute only for
             # decrypted file
@@ -1353,10 +1353,10 @@ class PdfDocCommon(ABC):
                     if obj_id in visited:
                         raise PdfReadError("Detected cyclic page references.")
                     traversal_state.entry_count += 1
-                    if traversal_state.entry_count > PAGE_TREE_MAX_ENTRIES:
+                    if traversal_state.entry_count > configuration.page_tree_maximum_entries:
                         raise LimitReachedError(
                             "Maximum page tree entry limit reached: "
-                            f"{traversal_state.entry_count} > {PAGE_TREE_MAX_ENTRIES}."
+                            f"{traversal_state.entry_count} > {configuration.page_tree_maximum_entries}."
                         )
                     visited.add(obj_id)
                     try:

--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -44,6 +44,7 @@ from typing import (
     overload,
 )
 
+from ._configuration import get_configuration
 from ._font import Font
 from ._protocols import PdfCommonDocProtocol
 from ._text_extraction import (
@@ -95,10 +96,7 @@ except ImportError:
     Image = object  # type: ignore[assignment,misc,unused-ignore]  # TODO: Remove unused-ignore on Python 3.10
     pil_not_imported = True  # error will be raised only when using images
 
-MERGE_CROP_BOX = "cropbox"  # pypdf <= 3.4.0 used "trimbox"
-
-# TODO: Make configurable.
-MAX_XFORM_INVOCATIONS_PER_EXTRACTION = 5_000
+MERGE_CROP_BOX = "cropbox"  # DEPRECATED: Use pypdf.Confiugration.
 
 
 def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
@@ -1290,7 +1288,8 @@ class PageObject(DictionaryObject):
 
         page2_content = page2.get_contents()
         if page2_content is not None:
-            rect = getattr(page2, MERGE_CROP_BOX)
+            configuration = get_configuration()
+            rect = getattr(page2, configuration.page_merge_box)
             page2_content.operations.insert(
                 0,
                 (
@@ -1439,7 +1438,8 @@ class PageObject(DictionaryObject):
 
         page2content = page2.get_contents()
         if page2content is not None:
-            rect = getattr(page2, MERGE_CROP_BOX)
+            configuration = get_configuration()
+            rect = getattr(page2, configuration.page_merge_box)
             page2content.operations.insert(
                 0,
                 (
@@ -2018,7 +2018,8 @@ class PageObject(DictionaryObject):
             )
             return ""
 
-        if traversal_state.entry_count >= MAX_XFORM_INVOCATIONS_PER_EXTRACTION:
+        configuration = get_configuration()
+        if traversal_state.entry_count >= configuration.xform_maximum_invocations_per_extraction:
             if not traversal_state.has_logged:
                 traversal_state.has_logged = True
                 logger_warning(
@@ -2027,7 +2028,7 @@ class PageObject(DictionaryObject):
                         "further form content is skipped."
                     ),
                     source=__name__,
-                    limit=MAX_XFORM_INVOCATIONS_PER_EXTRACTION
+                    limit=configuration.xform_maximum_invocations_per_extraction
                 )
             return ""
 

--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -49,6 +49,7 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+from ._configuration import apply_legacy_configuration
 from ._doc_common import PdfDocCommon, convert_to_int
 from ._encryption import Encryption, PasswordType
 from ._utils import (
@@ -140,6 +141,7 @@ class PdfReader(PdfDocCommon):
         self._root_object_recovery_limit = (
             root_object_recovery_limit if isinstance(root_object_recovery_limit, int) else sys.maxsize
         )
+        apply_legacy_configuration()
 
         # Map page indirect_reference number to page number
         self._page_id2num: Optional[dict[Any, Any]] = None

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -49,6 +49,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, NoReturn, Optional, Union, cast
 
 from ._codecs._codecs import LzwCodec as _LzwCodec
+from ._configuration import get_configuration
 from ._utils import (
     WHITESPACES_AS_BYTES,
     deprecate,
@@ -72,17 +73,17 @@ from .generic import (
     is_null_or_none,
 )
 
-MAX_DECLARED_STREAM_LENGTH = 75_000_000
-MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH = 75_000_000
+MAX_DECLARED_STREAM_LENGTH = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
+MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
 
-JBIG2_MAX_OUTPUT_LENGTH = 75_000_000
-LZW_MAX_OUTPUT_LENGTH = 75_000_000
-RUN_LENGTH_MAX_OUTPUT_LENGTH = 75_000_000
-ZLIB_MAX_OUTPUT_LENGTH = 75_000_000
-ZLIB_MAX_RECOVERY_INPUT_LENGTH = 5_000_000
-FLATE_MAX_COLUMNS = 250_000
-FLATE_MAX_ROW_LENGTH = 4_000_000
-FLATE_MAX_BUFFER_SIZE = 75_000_000  # TODO: This should be IMAGE_MAX_BUFFER_SIZE.
+JBIG2_MAX_OUTPUT_LENGTH = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
+LZW_MAX_OUTPUT_LENGTH = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
+RUN_LENGTH_MAX_OUTPUT_LENGTH = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
+ZLIB_MAX_OUTPUT_LENGTH = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
+ZLIB_MAX_RECOVERY_INPUT_LENGTH = 5_000_000  # DEPRECATED: Use pypdf.Confiugration.
+FLATE_MAX_COLUMNS = 250_000  # DEPRECATED: Use pypdf.Confiugration.
+FLATE_MAX_ROW_LENGTH = 4_000_000  # DEPRECATED: Use pypdf.Confiugration.
+FLATE_MAX_BUFFER_SIZE = 75_000_000  # DEPRECATED: Use pypdf.Confiugration.
 
 # Reuse cached 1-byte values in the fallback loop to avoid per-byte allocations.
 _SINGLE_BYTES = tuple(bytes((i,)) for i in range(256))
@@ -90,7 +91,8 @@ _SINGLE_BYTES = tuple(bytes((i,)) for i in range(256))
 
 def _decompress_with_limit(data: bytes) -> bytes:
     decompressor = zlib.decompressobj()
-    result = decompressor.decompress(data, max_length=ZLIB_MAX_OUTPUT_LENGTH)
+    configuration = get_configuration()
+    result = decompressor.decompress(data, max_length=configuration.zlib_maximum_output_length)
     if decompressor.unconsumed_tail:
         raise LimitReachedError(
             f"Limit reached while decompressing. {len(decompressor.unconsumed_tail)} bytes remaining."
@@ -108,7 +110,7 @@ def decompress(data: bytes) -> bytes:
 
     Please note that the output length is limited to avoid memory
     issues. If you need to process larger content streams, consider
-    adapting ``pypdf.filters.ZLIB_MAX_OUTPUT_LENGTH``. In case you
+    adapting ``pypdf.Configuration.zlib_maximum_output_length``. In case you
     are only dealing with trusted inputs and/or want to disable these
     limits, set the value to `0`.
 
@@ -143,7 +145,8 @@ def decompress(data: bytes) -> bytes:
         # If still failing, then try with increased window size.
         decompressor = zlib.decompressobj(zlib.MAX_WBITS | 32)
         result_str = b""
-        remaining_limit = ZLIB_MAX_OUTPUT_LENGTH
+        configuration = get_configuration()
+        remaining_limit = configuration.zlib_maximum_output_length
         data_length = len(data)
         known_errors = set()
         for index in range(data_length):
@@ -157,7 +160,7 @@ def decompress(data: bytes) -> bytes:
                         f"Limit reached while decompressing. {data_length - index} bytes remaining."
                     )
             except zlib.error as error:
-                if index > ZLIB_MAX_RECOVERY_INPUT_LENGTH:
+                if index > configuration.zlib_maximum_recovery_input_length:
                     raise LimitReachedError(
                         f"Recovery limit reached while decompressing. {data_length - index} bytes remaining."
                     )
@@ -210,14 +213,15 @@ class FlateDecode:
         # predictor 1 == no predictor
         if predictor != 1:
             columns, colors, bits_per_component = FlateDecode._get_parameters(parameters)
+            configuration = get_configuration()
 
             # PNG predictor can vary by row and so is the lead byte on each row
             row_length = (
                 math.ceil(columns * colors * bits_per_component / 8) + 1
             )  # number of bytes
-            if row_length > FLATE_MAX_ROW_LENGTH:
+            if row_length > configuration.flate_maximum_row_length:
                 raise LimitReachedError(
-                    f"Row length of {row_length} exceeds defined limit of {FLATE_MAX_ROW_LENGTH}."
+                    f"Row length of {row_length} exceeds defined limit of {configuration.flate_maximum_row_length}."
                 )
 
             # TIFF prediction:
@@ -247,9 +251,12 @@ class FlateDecode:
                 raise PdfReadError(f"Expected positive number for {key}, got {_value}!")
             return _value
 
+        configuration = get_configuration()
         columns = get(key=LZW.COLUMNS, default=1)
-        if columns > FLATE_MAX_COLUMNS:
-            raise LimitReachedError(f"Number of columns {columns} exceeds defined limit of {FLATE_MAX_COLUMNS}.")
+        if columns > configuration.flate_maximum_columns:
+            raise LimitReachedError(
+                f"Number of columns {columns} exceeds defined limit of {configuration.flate_maximum_columns}."
+            )
 
         colors = get(key=LZW.COLORS, default=1)
         if colors > 16:
@@ -440,6 +447,7 @@ class RunLengthDecode:
         index = 0
         data_length = len(data)
         total_length = 0
+        configuration = get_configuration()
         while True:
             if index >= data_length:
                 logger_warning(
@@ -479,7 +487,7 @@ class RunLengthDecode:
                 lst.append(bytes((data[index],)) * length)
                 index += 1
             total_length += length
-            if total_length > RUN_LENGTH_MAX_OUTPUT_LENGTH:
+            if total_length > configuration.run_length_maximum_output_length:
                 raise LimitReachedError("Limit reached while decompressing.")
         return b"".join(lst)
 
@@ -493,7 +501,8 @@ class LZWDecode:
             self.data = data
 
         def decode(self) -> bytes:
-            return _LzwCodec(max_output_length=LZW_MAX_OUTPUT_LENGTH).decode(self.data)
+            configuration = get_configuration()
+            return _LzwCodec(max_output_length=configuration.lzw_maximum_output_length).decode(self.data)
 
     @staticmethod
     def decode(
@@ -728,7 +737,7 @@ class CCITTFaxDecode:
         return tiff_header + data
 
 
-JBIG2DEC_BINARY = shutil.which("jbig2dec")
+JBIG2DEC_BINARY = shutil.which("jbig2dec")  # DEPRECATED: Use pypdf.Confiugration.
 
 
 class JBIG2Decode:
@@ -738,7 +747,8 @@ class JBIG2Decode:
         decode_parms: Optional[DictionaryObject] = None,
         **kwargs: Any,
     ) -> bytes:
-        if JBIG2DEC_BINARY is None:
+        configuration = get_configuration()
+        if configuration.jbig2dec_binary is None:
             raise DependencyError("jbig2dec binary is not available.")
 
         with TemporaryDirectory() as tempdir:
@@ -762,11 +772,11 @@ class JBIG2Decode:
             environment["LC_ALL"] = "C"
             result = subprocess.run(  # noqa: S603
                 [
-                    JBIG2DEC_BINARY,
+                    configuration.jbig2dec_binary,
                     "--embedded",
                     "--format", "png",
                     "--output", "-",
-                    "-M", str(JBIG2_MAX_OUTPUT_LENGTH),
+                    "-M", str(configuration.jbig2_maximum_output_length),
                     *paths
                 ],
                 capture_output=True,
@@ -787,10 +797,11 @@ class JBIG2Decode:
 
     @staticmethod
     def _is_binary_compatible() -> bool:
-        if not JBIG2DEC_BINARY:  # pragma: no cover
+        configuration = get_configuration()
+        if not configuration.jbig2dec_binary:  # pragma: no cover
             return False
         result = subprocess.run(  # noqa: S603
-            [JBIG2DEC_BINARY, "--version"],
+            [configuration.jbig2dec_binary, "--version"],
             capture_output=True,
             text=True,
         )

--- a/pypdf/generic/_data_structures.py
+++ b/pypdf/generic/_data_structures.py
@@ -675,15 +675,16 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 length = -1
             pstart = stream.tell()
 
-            from ..filters import MAX_DECLARED_STREAM_LENGTH  # noqa: PLC0415
+            from .._configuration import get_configuration  # noqa: PLC0415
+            configuration = get_configuration()
             if length >= 0:
-                if length > MAX_DECLARED_STREAM_LENGTH:
+                if length > configuration.maximum_declared_stream_length:
                     raise LimitReachedError(f"Declared stream length of {length} exceeds maximum allowed length.")
 
                 data["__streamdata__"] = stream.read(length)
             else:
                 data["__streamdata__"] = read_until_regex(
-                    stream=stream, regex=re.compile(b"endstream"), length=MAX_DECLARED_STREAM_LENGTH,
+                    stream=stream, regex=re.compile(b"endstream"), length=configuration.maximum_declared_stream_length,
                 )
             e = read_non_whitespace(stream)
             ndstream = stream.read(8)
@@ -703,7 +704,7 @@ class DictionaryObject(dict[Any, Any], PdfObject):
                 elif pdf is not None and not pdf.strict:
                     stream.seek(pstart, 0)
                     data["__streamdata__"] = DictionaryObject._read_unsized_from_stream(
-                        stream=stream, pdf=pdf, length=MAX_DECLARED_STREAM_LENGTH
+                        stream=stream, pdf=pdf, length=configuration.maximum_declared_stream_length
                     )
                     pos = stream.tell()
                 else:
@@ -1231,7 +1232,8 @@ class ContentStream(DecodedStreamObject):
         else:
             stream = stream.get_object()
             if isinstance(stream, ArrayObject):
-                from pypdf.filters import MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH  # noqa: PLC0415
+                from pypdf._configuration import get_configuration  # noqa: PLC0415
+                configuration = get_configuration()
 
                 if (stream_length := len(stream)) > CONTENT_STREAM_ARRAY_MAX_LENGTH:
                     raise LimitReachedError(
@@ -1254,10 +1256,10 @@ class ContentStream(DecodedStreamObject):
                     else:
                         new_data = s_resolved.get_data()
                         length += len(new_data)
-                        if length > MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH:
+                        if length > configuration.array_based_stream_maximum_output_length:
                             raise LimitReachedError(
                                 f"Array-based stream has at least {length} > "
-                                f"{MAX_ARRAY_BASED_STREAM_OUTPUT_LENGTH} output bytes."
+                                f"{configuration.array_based_stream_maximum_output_length} output bytes."
                             )
                         data += new_data
                     if len(data) == 0 or data[-1:] != b"\n":

--- a/pypdf/generic/_image_xobject.py
+++ b/pypdf/generic/_image_xobject.py
@@ -4,6 +4,7 @@ import sys
 from io import BytesIO
 from typing import Any, Literal, Optional, Union, cast
 
+from .._configuration import get_configuration
 from .._utils import check_if_whitespace_only, logger_warning
 from ..constants import ColorSpaces, ImageAttributes, StreamAttributes
 from ..constants import FilterTypes as FT
@@ -133,13 +134,15 @@ def bits2byte(
     colors: int = 1,
     scale: bool = False,
 ) -> bytes:
-    from pypdf.filters import FLATE_MAX_BUFFER_SIZE  # noqa: PLC0415
+    configuration = get_configuration()
 
     # Number of samples per row = pixels per row * components per pixel.
     samples_per_row = size[0] * colors
     buffer_size = samples_per_row * size[1]
-    if buffer_size > FLATE_MAX_BUFFER_SIZE:
-        raise LimitReachedError(f"Requested buffer size {buffer_size} exceeds limit of {FLATE_MAX_BUFFER_SIZE}.")
+    if buffer_size > configuration.image_maximum_buffer_size:
+        raise LimitReachedError(
+            f"Requested buffer size {buffer_size} exceeds limit of {configuration.image_maximum_buffer_size}."
+        )
 
     byte_buffer = bytearray(buffer_size)
     mask = (1 << bits) - 1
@@ -204,10 +207,11 @@ def _image_from_bytes(
     bytes_per_pixel = len(mode)
     required_byte_count = pixel_count * bytes_per_pixel
 
-    from pypdf.filters import FLATE_MAX_BUFFER_SIZE  # noqa: PLC0415
-    if required_byte_count > FLATE_MAX_BUFFER_SIZE:
+    configuration = get_configuration()
+    if required_byte_count > configuration.image_maximum_buffer_size:
         raise LimitReachedError(
-            f"Requested image buffer size {required_byte_count} exceeds limit {FLATE_MAX_BUFFER_SIZE}."
+            f"Requested image buffer size {required_byte_count} exceeds limit "
+            f"{configuration.image_maximum_buffer_size}."
         )
 
     try:

--- a/pypdf/xmp.py
+++ b/pypdf/xmp.py
@@ -23,13 +23,14 @@ from xml.dom.minidom import Element as XmlElement
 from xml.dom.xmlbuilder import Options
 from xml.parsers.expat import ExpatError, XMLParserType
 
+from ._configuration import get_configuration
 from ._protocols import XmpInformationProtocol
 from ._utils import StreamType, deprecate_with_replacement, deprecation_no_replacement
 from .errors import LimitReachedError, PdfReadError, XmpDocumentError
 from .generic import ContentStream, PdfObject, StreamObject
 
-XMP_MAX_INPUT_LENGTH = 5_000_000
-XMP_MAX_ELEMENT_COUNT = 100_000
+XMP_MAX_INPUT_LENGTH = 5_000_000  # DEPRECATED: Use pypdf.Confiugration.
+XMP_MAX_ELEMENT_COUNT = 100_000  # DEPRECATED: Use pypdf.Confiugration.
 
 RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 DC_NAMESPACE = "http://purl.org/dc/elements/1.1/"
@@ -181,6 +182,7 @@ class _XmpBuilder(ExpatBuilderNS):
     def __init__(self, options: Optional[Options] = None) -> None:
         super().__init__(options=options)
         self._element_count = 0
+        self._configuration = get_configuration()
 
     def custom_entity_declaration_handler(
             self,
@@ -198,8 +200,10 @@ class _XmpBuilder(ExpatBuilderNS):
 
     def start_element_handler(self, name: str, attributes: list[str]) -> None:
         self._element_count += 1
-        if self._element_count > XMP_MAX_ELEMENT_COUNT:
-            raise LimitReachedError(f"XMP metadata exceeds limit of {XMP_MAX_ELEMENT_COUNT} elements.")
+        if self._element_count > self._configuration.xmp_maximum_element_count:
+            raise LimitReachedError(
+                f"XMP metadata exceeds limit of {self._configuration.xmp_maximum_element_count} elements."
+            )
         super().start_element_handler(name=name, attributes=attributes)
 
     def install(self, parser: XMLParserType) -> None:
@@ -223,8 +227,11 @@ class XmpInformation(XmpInformationProtocol, PdfObject):
         self.stream = stream
         try:
             data = self.stream.get_data()
-            if (length := len(data)) > XMP_MAX_INPUT_LENGTH:
-                raise LimitReachedError(f"XMP stream size {length} exceeds limit of {XMP_MAX_INPUT_LENGTH}.")
+            configuration = get_configuration()
+            if (length := len(data)) > configuration.xmp_maximum_input_length:
+                raise LimitReachedError(
+                    f"XMP stream size {length} exceeds limit of {configuration.xmp_maximum_input_length}."
+                )
             doc_root: Document = _XmpBuilder().parseString(data)
         except (AttributeError, ExpatError) as e:
             raise PdfReadError(f"XML in XmpInformation was invalid: {e}")

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -10,7 +10,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 import pypdf
-from pypdf import PageObject, PdfReader, PdfWriter, Transformation
+from pypdf import PageObject, PdfReader, PdfWriter, Transformation, apply_configuration
 from pypdf.generic import Destination, read_string_from_stream
 
 from . import RESOURCE_ROOT, SAMPLE_ROOT, get_data_from_url
@@ -50,6 +50,7 @@ def page_ops(pdf_path, password):
     page.extract_text()
 
 
+@apply_configuration(disable_legacy_handling=True)
 def test_page_operations(benchmark):
     """
     Apply various page operations.
@@ -116,6 +117,7 @@ def merge():
         ]
 
 
+@apply_configuration(disable_legacy_handling=True)
 def test_merge(benchmark):
     """
     Apply various page operations.
@@ -134,6 +136,7 @@ def text_extraction(pdf_path):
     return text
 
 
+@apply_configuration(disable_legacy_handling=True)
 def test_text_extraction(benchmark):
     file_path = SAMPLE_ROOT / "009-pdflatex-geotopo/GeoTopo.pdf"
     benchmark(text_extraction, file_path)
@@ -144,6 +147,7 @@ def read_string_from_stream_performance():
     assert read_string_from_stream(stream)
 
 
+@apply_configuration(disable_legacy_handling=True)
 def test_read_string_from_stream_performance(benchmark):
     """
     This test simulates reading an embedded base64 image of 256kb.
@@ -214,6 +218,7 @@ def image_new_property(data):
 
 
 @pytest.mark.enable_socket
+@apply_configuration(disable_legacy_handling=True)
 def test_image_new_property_performance(benchmark):
     url = "https://github.com/py-pdf/pypdf/files/11219022/pdf_font_garbled.pdf"
     name = "pdf_font_garbled.pdf"
@@ -228,6 +233,7 @@ def image_extraction(data):
 
 
 @pytest.mark.enable_socket
+@apply_configuration(disable_legacy_handling=True)
 def test_large_compressed_image_performance(benchmark):
     url = "https://github.com/py-pdf/pypdf/files/15306199/file_with_large_compressed_image.pdf"
     data = BytesIO(get_data_from_url(url=url, name="file_with_large_compressed_image.pdf"))

--- a/tests/generic/test_data_structures.py
+++ b/tests/generic/test_data_structures.py
@@ -292,9 +292,9 @@ def test_dictionary_object__read_from_stream__no_limit(tmp_path: Path) -> None:
     source_file.write_text(
         f"""
 import sys
-from pypdf import filters, PdfReader
+from pypdf import PdfReader, overwrite_configuration
 
-filters.MAX_DECLARED_STREAM_LENGTH = sys.maxsize
+overwrite_configuration(maximum_declared_stream_length=sys.maxsize)
 
 with open({pdf_path_str!r}, mode="rb") as fd:
     reader = PdfReader(fd)
@@ -324,9 +324,9 @@ def test_dictionary_object__read_from_stream__no_limit__path(tmp_path: Path) -> 
     source_file.write_text(
         f"""
 import sys
-from pypdf import filters, PdfReader
+from pypdf import PdfReader, overwrite_configuration
 
-filters.MAX_DECLARED_STREAM_LENGTH = sys.maxsize
+overwrite_configuration(maximum_declared_stream_length=sys.maxsize)
 
 reader = PdfReader({pdf_path_str!r})
 print(reader.pages[0].extract_text())

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,285 @@
+"""Test the pypdf._configuration module."""
+from unittest import mock
+
+import pytest
+
+from pypdf import Configuration, PdfReader, apply_configuration, get_configuration, overwrite_configuration
+from pypdf._configuration import (
+    CURRENT_CONFIGURATION,
+    WARNED_LEGACY_OVERWRITES,
+    _determine_jbig2dec_binary,
+    apply_legacy_configuration,
+)
+from tests import RESOURCE_ROOT
+
+
+def test_configuration__with_overwrites() -> None:
+    reference = Configuration()
+
+    no_parameters = Configuration().with_overwrites()
+    assert reference == no_parameters
+    assert id(reference) != id(no_parameters)
+
+    with_parameters = Configuration().with_overwrites(
+        array_based_stream_maximum_output_length=1337,
+        jbig2dec_binary="/path/to/my/binary"
+    )
+    assert with_parameters != reference
+    assert with_parameters.array_based_stream_maximum_output_length == 1337
+    assert with_parameters.jbig2dec_binary == "/path/to/my/binary"
+
+    with_parameters2 = with_parameters.with_overwrites(page_tree_maximum_entries=42)
+    assert with_parameters2 != with_parameters
+    assert with_parameters2.array_based_stream_maximum_output_length == 1337
+    assert with_parameters2.jbig2dec_binary == "/path/to/my/binary"
+    assert with_parameters2.page_tree_maximum_entries == 42
+
+
+def test_get_configuration() -> None:
+    reference = Configuration()
+
+    result = get_configuration()
+    assert reference == result
+    assert id(reference) != id(result)
+
+
+def test_overwrite_configuration() -> None:
+    old_configuration = CURRENT_CONFIGURATION.get()
+    try:
+        configuration1 = get_configuration()
+
+        # Nothing to overwrite.
+        overwrite_configuration()
+        assert get_configuration() == configuration1
+
+        # Do some basic change to make sure that with a clean class, this is reset correctly.
+        overwrite_configuration(flate_maximum_columns=10)
+        assert get_configuration() == configuration1.with_overwrites(flate_maximum_columns=10)
+
+        # Class passed.
+        overwrite_configuration(Configuration().with_overwrites(array_based_stream_maximum_output_length=1337))
+        configuration2 = get_configuration()
+        assert configuration2 != configuration1
+        assert configuration2 == configuration1.with_overwrites(array_based_stream_maximum_output_length=1337)
+
+        # Kwargs passed.
+        overwrite_configuration(page_tree_maximum_entries=42)
+        configuration3 = get_configuration()
+        assert configuration3 != configuration2
+        assert configuration3 == configuration2.with_overwrites(page_tree_maximum_entries=42)
+
+        # Both passed.
+        overwrite_configuration(
+            Configuration().with_overwrites(zlib_maximum_recovery_input_length=7331),
+            page_tree_maximum_depth=15
+        )
+        configuration4 = get_configuration()
+        assert configuration4 != configuration3
+        assert configuration4 == configuration1.with_overwrites(
+            zlib_maximum_recovery_input_length=7331, page_tree_maximum_depth=15
+        )
+    finally:
+        CURRENT_CONFIGURATION.set(old_configuration)
+
+
+def test_overwrite_configuration__configuration_replaces_current() -> None:
+    old_configuration = CURRENT_CONFIGURATION.get()
+    try:
+        overwrite_configuration(page_tree_maximum_entries=123)
+
+        configuration = Configuration(page_tree_maximum_entries=456)
+        overwrite_configuration(configuration)
+
+        assert get_configuration() == configuration
+    finally:
+        CURRENT_CONFIGURATION.set(old_configuration)
+
+
+def test_apply_configuration() -> None:
+    old_configuration = CURRENT_CONFIGURATION.get()
+    try:
+        configuration1 = get_configuration()
+
+        # Nothing to overwrite.
+        with apply_configuration():
+            assert get_configuration() == configuration1
+        assert get_configuration() == configuration1
+
+        # Class passed.
+        with apply_configuration(Configuration().with_overwrites(array_based_stream_maximum_output_length=1337)):
+            configuration2 = get_configuration()
+            assert configuration2 == configuration1.with_overwrites(array_based_stream_maximum_output_length=1337)
+        assert get_configuration() == configuration1
+
+        # Kwargs passed.
+        with apply_configuration(page_tree_maximum_entries=42):
+            configuration3 = get_configuration()
+            assert configuration3 == configuration1.with_overwrites(page_tree_maximum_entries=42)
+        assert get_configuration() == configuration1
+
+        # Both passed.
+        with apply_configuration(
+                Configuration().with_overwrites(zlib_maximum_recovery_input_length=7331),
+                page_tree_maximum_depth=15
+        ):
+            configuration4 = get_configuration()
+            assert configuration4 == configuration1.with_overwrites(
+                zlib_maximum_recovery_input_length=7331, page_tree_maximum_depth=15
+            )
+        assert get_configuration() == configuration1
+    finally:
+        CURRENT_CONFIGURATION.set(old_configuration)
+
+
+def test_apply_configuration__nested() -> None:
+    old_configuration = CURRENT_CONFIGURATION.get()
+    try:
+        configuration1 = get_configuration()
+
+        # Nothing to overwrite.
+        with apply_configuration():
+            assert get_configuration() == configuration1
+
+            with apply_configuration(Configuration().with_overwrites(array_based_stream_maximum_output_length=1337)):
+                configuration2 = get_configuration()
+                assert configuration2 == configuration1.with_overwrites(array_based_stream_maximum_output_length=1337)
+
+                with apply_configuration(page_tree_maximum_entries=42):
+                    configuration3 = get_configuration()
+                    assert configuration3 == configuration2.with_overwrites(page_tree_maximum_entries=42)
+
+                    with apply_configuration(page_tree_maximum_entries=99):
+                        assert get_configuration() == configuration2.with_overwrites(page_tree_maximum_entries=99)
+                    assert get_configuration() == configuration3
+
+                    with apply_configuration(
+                        Configuration().with_overwrites(zlib_maximum_recovery_input_length=7331),
+                        page_tree_maximum_depth=15
+                    ):
+                        configuration4 = get_configuration()
+                        assert configuration4 == configuration1.with_overwrites(
+                            zlib_maximum_recovery_input_length=7331, page_tree_maximum_depth=15
+                        )
+
+                    assert get_configuration() == configuration3
+                assert get_configuration() == configuration2
+            assert get_configuration() == configuration1
+        assert get_configuration() == configuration1
+    finally:
+        CURRENT_CONFIGURATION.set(old_configuration)
+
+
+def test_apply_configuration__exception() -> None:
+    configuration = get_configuration()
+
+    with pytest.raises(RuntimeError), apply_configuration(page_tree_maximum_entries=42):
+        assert get_configuration().page_tree_maximum_entries == 42
+        raise RuntimeError
+
+    assert get_configuration() == configuration
+
+
+def test_apply_configuration__nested_exception() -> None:
+    configuration = get_configuration()
+
+    with apply_configuration(page_tree_maximum_entries=42):
+        with pytest.raises(RuntimeError), apply_configuration(page_tree_maximum_entries=99):
+            assert get_configuration().page_tree_maximum_entries == 99
+            raise RuntimeError
+
+        assert get_configuration().page_tree_maximum_entries == 42
+
+    assert get_configuration() == configuration
+
+
+def test_apply_legacy_configuration() -> None:
+    WARNED_LEGACY_OVERWRITES.clear()
+    try:
+        # Nothing changed.
+        with mock.patch("pypdf._configuration.overwrite_configuration") as overwrite_mock:
+            apply_legacy_configuration()
+        overwrite_mock.assert_not_called()
+
+        # JBIG2 binary changed.
+        with mock.patch("pypdf.filters.JBIG2DEC_BINARY", "/path/to/my/binary"), \
+                pytest.warns(
+                    expected_warning=DeprecationWarning,
+                    match=(
+                            r"^JBIG2DEC_BINARY is deprecated and will be removed in pypdf 7\.0\.0\. "
+                            r"Use Configuration\.jbig2dec_binary instead\.$"
+                    )
+                ), \
+                mock.patch("pypdf._configuration.overwrite_configuration") as overwrite_mock:
+            apply_legacy_configuration()
+        overwrite_mock.assert_called_once_with(jbig2dec_binary="/path/to/my/binary")
+
+        # Second call should not warn.
+        with mock.patch("pypdf.filters.JBIG2DEC_BINARY", "/path2/to/my/binary"), \
+                mock.patch("pypdf._configuration.overwrite_configuration") as overwrite_mock:
+            apply_legacy_configuration()
+        overwrite_mock.assert_called_once_with(jbig2dec_binary="/path2/to/my/binary")
+
+        # Regular value changed.
+        with mock.patch("pypdf.filters.MAX_DECLARED_STREAM_LENGTH", 42), \
+                pytest.warns(
+                    expected_warning=DeprecationWarning,
+                    match=(
+                            r"^MAX_DECLARED_STREAM_LENGTH is deprecated and will be removed in pypdf 7\.0\.0\. "
+                            r"Use Configuration\.maximum_declared_stream_length instead\.$"
+                    )
+                ), \
+                mock.patch("pypdf._configuration.overwrite_configuration") as overwrite_mock:
+            apply_legacy_configuration()
+        overwrite_mock.assert_called_once_with(maximum_declared_stream_length=42)
+    finally:
+        WARNED_LEGACY_OVERWRITES.clear()
+
+
+def test_apply_legacy_configuration__multiple_overrides(caplog) -> None:
+    WARNED_LEGACY_OVERWRITES.clear()
+    try:
+        with mock.patch("pypdf.filters.MAX_DECLARED_STREAM_LENGTH", 42), \
+                mock.patch("pypdf.filters.LZW_MAX_OUTPUT_LENGTH", 43), \
+                mock.patch("pypdf._page.MERGE_CROP_BOX", "trimbox"), \
+                mock.patch("pypdf._configuration.overwrite_configuration") as overwrite_mock, \
+                pytest.warns(expected_warning=DeprecationWarning, match=r"^\S+ is deprecated and will be removed .+$"):
+            apply_legacy_configuration()
+
+        overwrite_mock.assert_called_once_with(
+            maximum_declared_stream_length=42,
+            lzw_maximum_output_length=43,
+            page_merge_box="trimbox",
+        )
+    finally:
+        WARNED_LEGACY_OVERWRITES.clear()
+
+
+def test_apply_legacy_configuration__from_reader() -> None:
+    with mock.patch(
+            "pypdf.filters.MAX_DECLARED_STREAM_LENGTH", get_configuration().maximum_declared_stream_length // 2
+    ), pytest.warns(
+            expected_warning=DeprecationWarning,
+            match=(
+                r"^MAX_DECLARED_STREAM_LENGTH is deprecated and will be removed in pypdf 7\.0\.0\. "
+                r"Use Configuration\.maximum_declared_stream_length instead\.$"
+            )
+    ):
+        PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+
+    with mock.patch(
+            "pypdf.filters.MAX_DECLARED_STREAM_LENGTH", get_configuration().maximum_declared_stream_length // 2
+    ), apply_configuration(disable_legacy_handling=True):
+        PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+
+
+def test_determine_jbig2dec_binary__cached() -> None:
+    _determine_jbig2dec_binary.cache_clear()
+
+    try:
+        with mock.patch("shutil.which", return_value="/path/to/jbig2dec") as which_mock:
+            assert _determine_jbig2dec_binary() == "/path/to/jbig2dec"
+            assert _determine_jbig2dec_binary() == "/path/to/jbig2dec"
+
+        which_mock.assert_called_once_with("jbig2dec")
+    finally:
+        _determine_jbig2dec_binary.cache_clear()

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -10,7 +10,7 @@ from unittest import mock
 
 import pytest
 
-from pypdf import PdfReader, PdfWriter
+from pypdf import PdfReader, PdfWriter, apply_configuration
 from pypdf.errors import LimitReachedError, PdfReadError
 from pypdf.filters import FlateDecode
 from pypdf.generic import (
@@ -666,7 +666,7 @@ def test_flatten__depth_limit():
         )
     )
 
-    with mock.patch("pypdf._doc_common.PAGE_TREE_MAX_DEPTH", 1), pytest.raises(
+    with apply_configuration(page_tree_maximum_depth=1), pytest.raises(
         LimitReachedError, match=r"^Maximum page tree depth reached: 2 > 1\.$"
     ):
         writer._flatten()
@@ -694,7 +694,7 @@ def test_flatten__entry_limit_for_reused_paths():
         )
     writer.root_object[NameObject("/Pages")] = child
 
-    with mock.patch("pypdf._doc_common.PAGE_TREE_MAX_ENTRIES", 100), pytest.raises(
+    with apply_configuration(page_tree_maximum_entries=100), pytest.raises(
         LimitReachedError, match=r"^Maximum page tree entry limit reached: 101 > 100\.$"
     ):
         writer._flatten()
@@ -844,8 +844,8 @@ def test_xfa__decompression_limit():
     data.flush()
 
     reader = PdfReader(data)
-    with mock.patch("pypdf.filters.ZLIB_MAX_OUTPUT_LENGTH", 75_000), pytest.raises(
-            expected_exception=LimitReachedError, match=r"^Limit reached while decompressing. 902 bytes remaining.$"
+    with apply_configuration(zlib_maximum_output_length=75_000), pytest.raises(
+            expected_exception=LimitReachedError, match=r"^Limit reached while decompressing\. 902 bytes remaining\.$"
     ):
         _ = reader.xfa
 
@@ -1030,7 +1030,7 @@ def test_get_outline__entry_count():
         outline[NameObject("/Next")] = writer._add_object(outlines[index + 1])
         writer._add_object(outline)
 
-    with mock.patch("pypdf._doc_common.OUTLINE_MAX_ENTRIES", 1000), \
+    with apply_configuration(outline_maximum_entries=1000), \
             pytest.raises(
                 expected_exception=LimitReachedError, match=r"^Maximum outline entry limit reached: 1001 > 1000\.$"
             ):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -14,7 +14,7 @@ from unittest import mock
 import pytest
 from PIL import Image, ImageOps
 
-from pypdf import PdfReader, PdfWriter
+from pypdf import PdfReader, PdfWriter, apply_configuration
 from pypdf.errors import DependencyError, DeprecationError, LimitReachedError, PdfReadError, PdfStreamError
 from pypdf.filters import (
     ASCII85Decode,
@@ -723,8 +723,7 @@ def test_flate_decode__image_is_none_due_to_size_limit(caplog):
     url = "https://github.com/user-attachments/files/19464256/file.pdf"
     name = "issue3220.pdf"
 
-    with mock.patch("pypdf.filters.ZLIB_MAX_OUTPUT_LENGTH", 0), \
-            mock.patch("pypdf.filters.FLATE_MAX_BUFFER_SIZE", sys.maxsize):
+    with apply_configuration(zlib_maximum_output_length=0, image_maximum_buffer_size=sys.maxsize):
         reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
         images = reader.pages[0].images
         assert len(images) == 1
@@ -757,7 +756,7 @@ def test_flate_decode__not_rectangular(caplog):
 
 
 def test_jbig2decode__binary_errors():
-    with mock.patch("pypdf.filters.JBIG2DEC_BINARY", None), \
+    with apply_configuration(jbig2dec_binary=None), \
             pytest.raises(DependencyError, match=r"jbig2dec binary is not available\."):
         JBIG2Decode.decode(b"dummy")
 
@@ -770,7 +769,7 @@ def test_jbig2decode__binary_errors():
         )
     )
     with mock.patch("pypdf.filters.subprocess.run", return_value=result), \
-            mock.patch("pypdf.filters.JBIG2DEC_BINARY", "/usr/bin/jbig2dec"), \
+            apply_configuration(jbig2dec_binary="/usr/bin/jbig2dec"), \
             pytest.raises(DependencyError, match=r"jbig2dec>=0.19 is required\."):
         JBIG2Decode.decode(b"dummy")
 
@@ -783,7 +782,7 @@ def test_jbig2decode__binary_errors():
         )
     )
     with mock.patch("pypdf.filters.subprocess.run", return_value=result), \
-            mock.patch("pypdf.filters.JBIG2DEC_BINARY", "/usr/bin/jbig2dec"), \
+            apply_configuration(jbig2dec_binary="/usr/bin/jbig2dec"), \
             pytest.raises(DependencyError, match=r"jbig2dec>=0.19 is required\."):
         JBIG2Decode.decode(b"dummy")
 
@@ -937,14 +936,14 @@ def test_decompress():
 
     # Decompress byte-wise with very low output limit.
     with mock.patch("pypdf.filters._decompress_with_limit", side_effect=zlib.error), \
-            mock.patch("pypdf.filters.ZLIB_MAX_OUTPUT_LENGTH", len(compressed) - 13), \
+            apply_configuration(zlib_maximum_output_length=len(compressed) - 13), \
             pytest.raises(
                 LimitReachedError, match=r"^Limit reached while decompressing\. 12 bytes remaining\.$"
             ):
         decompress(compressed)
 
     # Decompress byte-wise with input limit.
-    with mock.patch("pypdf.filters.ZLIB_MAX_RECOVERY_INPUT_LENGTH", 1000), \
+    with apply_configuration(zlib_maximum_recovery_input_length=1000), \
             pytest.raises(
                 LimitReachedError, match=r"^Recovery limit reached while decompressing\. 336 bytes remaining\.$"
             ):
@@ -1105,7 +1104,7 @@ def test_runlengthdecode__decode_limit():
     encoded = (b"\x81A" * runs) + b"\x80"
 
     # Use a very low limit for this exact comparison, otherwise *pytest* takes ages to render a failure diff.
-    with mock.patch("pypdf.filters.RUN_LENGTH_MAX_OUTPUT_LENGTH", uncompressed_size):
+    with apply_configuration(run_length_maximum_output_length=uncompressed_size):
         assert RunLengthDecode.decode(encoded) == b"A" * uncompressed_size
 
 

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -14,7 +14,7 @@ from zipfile import ZipFile
 import pytest
 from PIL import Image, ImageChops, ImageDraw
 
-from pypdf import PageObject, PdfReader, PdfWriter
+from pypdf import PageObject, PdfReader, PdfWriter, apply_configuration
 from pypdf._page import ImageFile
 from pypdf.errors import LimitReachedError
 from pypdf.filters import JBIG2Decode
@@ -819,7 +819,7 @@ def test_jbig2decode__memory_limit():
         ),
     ]
 
-    with mock.patch("pypdf.filters.JBIG2_MAX_OUTPUT_LENGTH", 5_000_000):
+    with apply_configuration(jbig2_maximum_output_length=5_000_000):
         reader = PdfReader(BytesIO(get_data_from_url(url=url, name=name)))
         page = reader.pages[0]
         with pytest.raises(expected_exception=LimitReachedError, match=rf"({'|'.join(error_messages)})"):

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -7,11 +7,10 @@ The tested code might be in _page.py.
 import re
 from dataclasses import asdict
 from io import BytesIO
-from unittest import mock
 
 import pytest
 
-from pypdf import PdfReader, PdfWriter, mult
+from pypdf import PdfReader, PdfWriter, apply_configuration, mult
 from pypdf._font import Font
 from pypdf._text_extraction import set_custom_rtl
 from pypdf._text_extraction._layout_mode._fixed_width_page import (
@@ -923,7 +922,7 @@ def test_extract_text__form_xobject__limit(caplog) -> None:
     # Takes about 15 seconds without fix.
     reader = PdfReader(BytesIO(_generate_dag_with_forms(12)))
     page = reader.pages[0]
-    with mock.patch("pypdf._page.MAX_XFORM_INVOCATIONS_PER_EXTRACTION", 100):
+    with apply_configuration(xform_maximum_invocations_per_extraction=100):
         text = page.extract_text()
     assert len(text) == 92
     assert text == ".\n" * 46


### PR DESCRIPTION
This change introduces some larger refactoring for how configuration values are handled in *pypdf*.

Previously, they were module-level constants which could be changed by monkey-patching or mocking them. While this works, it is not really intuitive and makes refactorings (like renaming or moving these values) basically impossible without breaking old code.

For this reason, a new configuration class has been introduced, accompanied by a setter and context manager for temporary changes. This allows us provide a clean API for configuration value management and allows us to change configuration values without too much hacking.

During the deprecation period, each `PdfReader.__init__` call tries to resolve changed legacy values and issues a corresponding notice. This is the most reliable method identified during the design phase to allow most of the previous configuration options to be used.

The overhead of legacy resolving can be disabled by using the temporary setting `disable_legacy_handling`.

Closes #3886.

Disclosure: The initial design phase as well as some follow-up refinement and optimization phases have been assisted by ChatGPT. All proposals have been reviewed carefully and implemented by myself where the review was positive.