### PR TITLE
STY: Enforce lowercase function variables

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -767,7 +767,7 @@ class PdfReader(PdfDocCommon):
         the file. Hence for standard-compliant PDF documents this function will
         read only the last part (DEFAULT_BUFFER_SIZE).
         """
-        HEADER_SIZE = 8  # to parse whole file, Header is e.g. '%PDF-1.6'
+        header_size = 8  # to parse whole file, Header is e.g. '%PDF-1.6'
         line = b""
         first = True
         while not line.startswith(b"%%EOF"):
@@ -786,7 +786,7 @@ class PdfReader(PdfDocCommon):
                     "The file might be truncated and some data might not be read.",
                     source=__name__,
                 )
-            if stream.tell() < HEADER_SIZE:
+            if stream.tell() < header_size:
                 if self.strict:
                     raise PdfReadError("EOF marker not found")
                 logger_warning("EOF marker not found", source=__name__)

--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -612,12 +612,12 @@ class CCITTParameters:
     def group(self) -> int:
         if self.K < 0:
             # Pure two-dimensional encoding (Group 4)
-            CCITTgroup = 4
+            ccitt_group = 4
         else:
             # K == 0: Pure one-dimensional encoding (Group 3, 1-D)
             # K > 0: Mixed one- and two-dimensional encoding (Group 3, 2-D)
-            CCITTgroup = 3
-        return CCITTgroup
+            ccitt_group = 3
+        return ccitt_group
 
 
 def __create_old_class_instance(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ ignore = [
     "FBT002",  # Boolean default value in function definition
     "FBT003",  # Boolean positional value in function call
     "FIX002",  # TODOs should typically not be in the code, but sometimes are ok
-    "N806",    # non-lowercase-variable-in-function
     "N814",    # Camelcase `PageAttributes` imported as constant `PG`
     "N817",    # CamelCase `PagesAttributes` imported as acronym `PA`
     "PERF203", # `try`-`except` within a loop incurs performance overhead

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -974,29 +974,27 @@ def test_merge_page_resources_smoke_test():
     page1 = PageObject.create_blank_page(width=100, height=100)
     page2 = PageObject.create_blank_page(width=100, height=100)
 
-    NO = NameObject
-
     # set up some dummy resources that overlap (or not) between the two pages
     # (note, all the edge cases are tested in test_merge_resources)
-    props1 = page1[NO("/Resources")][NO("/Properties")] = DictionaryObject(
+    props1 = page1[NameObject("/Resources")][NameObject("/Properties")] = DictionaryObject(
         {
-            NO("/just1"): NO("/just1-value"),
-            NO("/overlap-matching"): NO("/overlap-matching-value"),
-            NO("/overlap-different"): NO("/overlap-different-value1"),
+            NameObject("/just1"): NameObject("/just1-value"),
+            NameObject("/overlap-matching"): NameObject("/overlap-matching-value"),
+            NameObject("/overlap-different"): NameObject("/overlap-different-value1"),
         }
     )
-    props2 = page2[NO("/Resources")][NO("/Properties")] = DictionaryObject(
+    props2 = page2[NameObject("/Resources")][NameObject("/Properties")] = DictionaryObject(
         {
-            NO("/just2"): NO("/just2-value"),
-            NO("/overlap-matching"): NO("/overlap-matching-value"),
-            NO("/overlap-different"): NO("/overlap-different-value2"),
+            NameObject("/just2"): NameObject("/just2-value"),
+            NameObject("/overlap-matching"): NameObject("/overlap-matching-value"),
+            NameObject("/overlap-different"): NameObject("/overlap-different-value2"),
         }
     )
     # use these keys for some "operations", to validate renaming
     # (the operand name doesn't matter)
-    contents1 = page1[NO("/Contents")] = ContentStream(None, None)
+    contents1 = page1[NameObject("/Contents")] = ContentStream(None, None)
     contents1.operations = [(ArrayObject(props1.keys()), b"page1-contents")]
-    contents2 = page2[NO("/Contents")] = ContentStream(None, None)
+    contents2 = page2[NameObject("/Contents")] = ContentStream(None, None)
     contents2.operations = [(ArrayObject(props2.keys()), b"page2-contents")]
 
     expected_properties = {
@@ -1013,9 +1011,9 @@ def test_merge_page_resources_smoke_test():
         (
             ArrayObject(
                 [
-                    NO("/just2"),
-                    NO("/overlap-matching"),
-                    NO("/overlap-different-0"),
+                    NameObject("/just2"),
+                    NameObject("/overlap-matching"),
+                    NameObject("/overlap-different-0"),
                 ]
             ),
             b"page2-contents",
@@ -1026,7 +1024,7 @@ def test_merge_page_resources_smoke_test():
     page1.merge_page(page2)
 
     # Assert
-    assert page1[NO("/Resources")][NO("/Properties")] == expected_properties
+    assert page1[NameObject("/Resources")][NameObject("/Properties")] == expected_properties
 
     relevant_operations = [
         (op, name)


### PR DESCRIPTION
## Summary

- resolve the four remaining Ruff `N806` reports by renaming production locals and removing a redundant test alias
- remove the repository-wide `N806` ignore so future regressions are checked in CI
- keep behavior unchanged in PDF EOF scanning, CCITT group selection, and the page-resource smoke test

## Why

Issue #3327 explicitly tracks Ruff-ignore cleanup one rule per pull request. Enabling the rule globally makes the cleanup durable instead of only changing the current occurrences.

Refs #3327.

## Validation

- `uvx ruff==0.16.0 check .`
- `pytest tests/test_filters.py::test_ccittparameters tests/test_page.py::test_merge_page_resources_smoke_test tests/test_reader.py::test_read_malformed_body` (`3 passed` on Python 3.13)
- repository PR title checker
- `git diff --check`

## CI note

The current Python 3.13 failure is the existing test-PDF cache failure mode: cache restoration failed and `Giacalone.pdf` was absent, while the other 1,646 tests in that job passed. The cache change proposed in #4034 is intended to address this infrastructure issue; it is outside this PR's one-rule scope.

## AI assistance

OpenAI Codex (GPT-5.6 Sol) assisted with repository research, implementation, and local validation. The final diff was checked against issue #3327 and the repository contribution policy.
