### PR TITLE
ROB: Do not crash when the annotations are not an array

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -2374,7 +2374,15 @@ class PageObject(DictionaryObject):
     def annotations(self) -> Optional[ArrayObject]:
         if "/Annots" not in self:
             return None
-        return cast(ArrayObject, self["/Annots"])
+        annotations = self["/Annots"].get_object()
+        if not isinstance(annotations, ArrayObject):
+            logger_warning(
+                "Annotations are not an array: %(annotations)s",
+                source=__name__,
+                annotations=annotations,
+            )
+            return None
+        return annotations
 
     @annotations.setter
     def annotations(self, value: Optional[ArrayObject]) -> None:

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1594,6 +1594,27 @@ def test_get_rectangle__value_is_not_an_array(value, expected):
         _ = PdfReader(stream).pages[0].mediabox
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(4), "Annotations are not an array: 4", id="number"),
+        pytest.param(TextStringObject("x"), "Annotations are not an array: x", id="string"),
+        pytest.param(DictionaryObject(), "Annotations are not an array: {}", id="dictionary"),
+    ],
+)
+def test_annotations__is_not_an_array(caplog, value, expected):
+    """An /Annots entry that is not an array raised a TypeError when iterated."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Annots")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).pages[0].annotations is None
+    assert expected in caplog.text
+
+
 def test_get_rectangle__size_handling(caplog):
     """
     See issue #2991 and related ones. We would previously generate invalid page boxes when they


### PR DESCRIPTION
page.annotations casts the /Annots entry to an array and hands it straight back, so
a page whose /Annots is a number, a string or a dictionary crashes with
"'NumberObject' object is not iterable" as soon as anything iterates it.

The property is already typed Optional[ArrayObject] and returns None when /Annots is
absent, so an entry that cannot be one is logged and returns None as well. The writer
paths that use it already check for None.

I could not run the tests that download the corpus locally; the offline suite passes,
1262 tests.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
