### PR TITLE
ROB: Do not crash when a page tree entry is not a dictionary

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1362,6 +1362,13 @@ class PdfDocCommon(ABC):
                 if isinstance(page, IndirectObject):
                     additional_arguments["indirect_reference"] = page
                 obj = page.get_object()
+                if not is_null_or_none(obj) and not isinstance(obj, DictionaryObject):
+                    logger_warning(
+                        "Ignoring page tree entry that is not a dictionary: %(entry)s",
+                        source=__name__,
+                        entry=obj,
+                    )
+                    continue
                 if obj:
                     # damaged file may have invalid child in /Pages
                     obj_id = id(obj)
@@ -1377,7 +1384,7 @@ class PdfDocCommon(ABC):
                     try:
                         self._flatten(
                             list_only,
-                            obj,
+                            cast(DictionaryObject, obj),
                             inherit.copy(),
                             visited=visited,
                             depth=depth + 1,

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -1354,3 +1354,25 @@ def test_get_fields__acro_form_is_not_a_dictionary(caplog, value, expected):
 
     assert PdfReader(stream).get_fields() is None
     assert expected in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "Ignoring page tree entry that is not a dictionary: 1", id="number"),
+        pytest.param(TextStringObject("x"), "Ignoring page tree entry that is not a dictionary: x", id="string"),
+        pytest.param(ArrayObject(), "Ignoring page tree entry that is not a dictionary: []", id="array"),
+    ],
+)
+def test_flatten__kid_is_not_a_dictionary(caplog, value, expected):
+    """A /Kids entry that is not a dictionary raised a TypeError from the /Type lookup."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    pages = writer.root_object["/Pages"]
+    pages[NameObject("/Kids")] = ArrayObject([*pages["/Kids"], value])
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert len(PdfReader(stream).pages) == 1
+    assert expected in caplog.text


### PR DESCRIPTION
_flatten guards the /Kids array itself, but not the entries inside it. A /Kids entry
that is a number, a string or an array reaches the /Type membership test and crashes
with "argument of type 'NumberObject' is not iterable", so one bad child makes the
whole document unreadable.

The comment right below already says a damaged file may have an invalid child there,
so the entry is now logged and skipped and the remaining pages still load. A
NullObject child keeps its existing path, since that means absent rather than
malformed.

I could not run the tests that download the corpus locally; the offline suite passes,
1280 tests.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
