### PR TITLE
ROB: Fix compatibility for fonttools < 4.57.0

### DIFF
--- a/pypdf/_font.py
+++ b/pypdf/_font.py
@@ -574,7 +574,11 @@ class Font:
             # creates a dictionary mapping glyphs to the minimum Unicode codepoint.
             tt_font_cmap_table = tt_font_object.get("cmap")
             if tt_font_cmap_table:
-                reverse_cmap = tt_font_cmap_table.buildReversedMin()
+                try:
+                    reverse_cmap = tt_font_cmap_table.buildReversedMin()
+                except AttributeError:
+                    # use buildReversed on fonttools < 4.57 and build a list of minimums from it
+                    reverse_cmap = {k: min(r) for k, r in tt_font_cmap_table.buildReversed().items()}
                 for gid, glyph in enumerate(glyph_order):
                     char_code = reverse_cmap.get(glyph)
                     if char_code is None:

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -189,14 +189,14 @@ def test_font_from_font_file():
 
 
 def test_font_old_fonttools_substitution():
-    from fontTools.ttLib.tables._c_m_a_p import table__c_m_a_p  # noqa: PLC0415
+    import inspect  # noqa: PLC0415
     from unittest import mock  # noqa: PLC0415
+
+    from fontTools.ttLib.tables._c_m_a_p import table__c_m_a_p  # noqa: PLC0415
 
     original_build_reversed_min = table__c_m_a_p.buildReversedMin
 
-    def build_reversed_min(_self) -> dict:
-        import inspect  # noqa: PLC0415
-
+    def build_reversed_min(_self: table__c_m_a_p) -> dict[str, int]:
         caller = inspect.currentframe().f_back
         caller_name = caller.f_code.co_name
         # Check the backwards-compatible substitution works when calling from pypdf

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -188,6 +188,18 @@ def test_font_from_font_file():
                 font._get_typographic_maps()
 
 
+def test_font_old_fonttools_substitution(monkeypatch):
+    pytest.importorskip("fontTools", minversion="4.57.0")
+    from fontTools.ttLib.tables._c_m_a_p import table__c_m_a_p  # noqa: PLC0415
+
+    # Mock the buildReversedMin to fallback for buildReversed as in FontTools < 4.57
+    def mock_build_reversed_min(self) -> dict:
+        return {k: min(r) for k, r in table__c_m_a_p.buildReversed(self).items()}
+    monkeypatch.setattr(table__c_m_a_p, "buildReversedMin", mock_build_reversed_min)
+
+    test_font_from_font_file()
+
+
 def test_font_as_font_resource():
     writer = PdfWriter(RESOURCE_ROOT / "fontsampler.pdf")
     font_resources = writer.pages[0]["/Resources"]["/Font"]

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -188,16 +188,25 @@ def test_font_from_font_file():
                 font._get_typographic_maps()
 
 
-def test_font_old_fonttools_substitution(monkeypatch):
-    pytest.importorskip("fontTools", minversion="4.57.0")
+def test_font_old_fonttools_substitution():
     from fontTools.ttLib.tables._c_m_a_p import table__c_m_a_p  # noqa: PLC0415
+    from unittest import mock  # noqa: PLC0415
 
-    # Mock the buildReversedMin to fallback for buildReversed as in FontTools < 4.57
-    def mock_build_reversed_min(self) -> dict:
-        return {k: min(r) for k, r in table__c_m_a_p.buildReversed(self).items()}
-    monkeypatch.setattr(table__c_m_a_p, "buildReversedMin", mock_build_reversed_min)
+    original_build_reversed_min = table__c_m_a_p.buildReversedMin
 
-    test_font_from_font_file()
+    def build_reversed_min(_self) -> dict:
+        import inspect  # noqa: PLC0415
+
+        caller = inspect.currentframe().f_back
+        caller_name = caller.f_code.co_name
+        # Check the backwards-compatible substitution works when calling from pypdf
+        if caller_name == "from_truetype_font_file":
+            raise AttributeError
+        # Internal code relies on this, thus allow these calls.
+        return original_build_reversed_min(_self)
+
+    with mock.patch("fontTools.ttLib.tables._c_m_a_p.table__c_m_a_p.buildReversedMin", build_reversed_min):
+        test_font_from_font_file()
 
 
 def test_font_as_font_resource():


### PR DESCRIPTION
Hi, thank you very much for maintaining this library!

I got to a situation where I wanted to upgrade pypdf on an old system (security reasons) and I found out it was incompatible with last year's fonttols, since it uses features introduced in https://github.com/fonttools/fonttools/commit/a67b8b1cbe07f5c4c68e1c23cca539c2e130ef66. As it was hard to change the existing packages, I wrote a compatibility crutch.

I am offering it here in case you would like to include it it the package, if not, I understand.

Thank you again for all the work you are doing on pypdf!