### PR TITLE
ROB: Do not crash when the page resources are not a dictionary

### DIFF
--- a/pypdf/_page.py
+++ b/pypdf/_page.py
@@ -99,6 +99,21 @@ except ImportError:
 MERGE_CROP_BOX = "cropbox"  # DEPRECATED: Use pypdf.Confiugration.
 
 
+def _get_page_resources(obj: Any) -> DictionaryObject:
+    """Return the inherited /Resources, or an empty dictionary if malformed."""
+    resources = obj.get_inherited(key=PG.RESOURCES, default=DictionaryObject())
+    if is_null_or_none(resources):
+        return DictionaryObject()
+    if not isinstance(resources, DictionaryObject):
+        logger_warning(
+            "Page resources are not a dictionary: %(resources)s",
+            source=__name__,
+            resources=resources,
+        )
+        return DictionaryObject()
+    return resources
+
+
 def _get_rectangle(self: Any, name: str, defaults: Iterable[str]) -> RectangleObject:
     retval: Union[RectangleObject, ArrayObject, IndirectObject, None] = self.get(name)
     if isinstance(retval, RectangleObject):
@@ -1854,11 +1869,8 @@ class PageObject(DictionaryObject):
         font_resources: dict[str, DictionaryObject] = {}
         fonts: dict[str, Font] = {}
 
-        resources_dict = cast(
-            Optional[DictionaryObject],
-            obj.get_inherited(key=PG.RESOURCES, default=DictionaryObject())
-        )
-        if is_null_or_none(resources_dict) or not resources_dict:
+        resources_dict = _get_page_resources(obj)
+        if not resources_dict:
             # No resources means no text is possible (no font); we consider the
             # file as not damaged, no need to check for TJ or Tj
             return ""

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1694,3 +1694,25 @@ def test_extract_text__resources_not_a_dictionary(caplog, value, expected):
 
     assert PdfReader(stream).pages[0].extract_text() == ""
     assert expected in caplog.text
+
+
+def test_extract_text__resources_is_null(caplog):
+    """A null /Resources is missing rather than malformed: no text, no warning."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Resources")] = NullObject()
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).pages[0].extract_text() == ""
+    assert caplog.text == ""
+
+
+def test_extract_text__resources_is_a_dictionary():
+    """The regular path: a proper /Resources still yields its text."""
+    reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+    page = reader.pages[0]
+
+    assert isinstance(page["/Resources"].get_object(), DictionaryObject)
+    assert "crazy ones" in page.extract_text()

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1673,3 +1673,24 @@ def test_box_setter_allows_extra_values(box):
     page = writer.pages[0]
     setattr(page, box, ArrayObject([0, 0, 13, 37, 0, 0]))
     assert getattr(page, box) == RectangleObject((0, 0, 13, 37))
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(NumberObject(1), "Page resources are not a dictionary: 1", id="number"),
+        pytest.param(TextStringObject("x"), "Page resources are not a dictionary: x", id="string"),
+        pytest.param(ArrayObject(), "Page resources are not a dictionary: []", id="array"),
+    ],
+)
+def test_extract_text__resources_not_a_dictionary(caplog, value, expected):
+    """A /Resources entry that is not a dictionary raised a TypeError on the /Font lookup."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    writer.pages[0][NameObject("/Resources")] = value
+    stream = BytesIO()
+    writer.write(stream)
+    stream.seek(0)
+
+    assert PdfReader(stream).pages[0].extract_text() == ""
+    assert expected in caplog.text


### PR DESCRIPTION
extract_text casts the inherited /Resources into a dictionary and then tests
"/Font" in it, so a page whose /Resources is a number, a string or an array
crashes with "argument of type 'NumberObject' is not iterable" rather than
returning no text.

The lookup moved into a small helper that logs and returns an empty
dictionary, which gives the same result as a page with no resources at all.
Keeping it in a helper also avoids pushing _extract_text past the complexity
limit.

I could not run the tests that download the corpus locally; the offline suite
passes, 1283 tests.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
