### PR TITLE
SEC: Limit allowed length of indirect object tokens

### DIFF
--- a/pypdf/_reader.py
+++ b/pypdf/_reader.py
@@ -617,10 +617,10 @@ class PdfReader(PdfDocCommon):
         skip_over_comment(stream)
         extra = skip_over_whitespace(stream)
         stream.seek(-1, 1)
-        idnum = read_until_whitespace(stream)
+        idnum = read_until_whitespace(stream, max_bytes=IndirectObject._MAXIMUM_PART_LENGTH, strict=self.strict)
         extra |= skip_over_whitespace(stream)
         stream.seek(-1, 1)
-        generation = read_until_whitespace(stream)
+        generation = read_until_whitespace(stream, max_bytes=IndirectObject._MAXIMUM_PART_LENGTH, strict=self.strict)
         extra |= skip_over_whitespace(stream)
         stream.seek(-1, 1)
 
@@ -636,7 +636,14 @@ class PdfReader(PdfDocCommon):
                 idnum=idnum,
                 generation=generation,
             )
-        return int(idnum), int(generation)
+
+        try:
+            return int(idnum), int(generation)
+        except (ValueError, OverflowError) as e:
+            # Only raise a ValueError here as other types would break future processing.
+            raise ValueError(
+                f"Invalid indirect object reference ({idnum!r} {generation!r} R): {e}"
+            ) from e
 
     def cache_get_indirect_object(
         self, generation: int, idnum: int
@@ -1397,17 +1404,21 @@ class PdfReader(PdfDocCommon):
                     object_stream = BytesIO(obj.get_data())
                     actual_count = 0
                     while True:
-                        current = read_until_whitespace(object_stream)
+                        current = read_until_whitespace(
+                            object_stream, max_bytes=IndirectObject._MAXIMUM_PART_LENGTH, strict=self.strict
+                        )
                         if not current.isdigit():
                             break
                         inner_object_number = int(current)
                         skip_over_whitespace(object_stream)
                         object_stream.seek(-1, 1)
-                        current = read_until_whitespace(object_stream)
+                        current = read_until_whitespace(
+                            object_stream, max_bytes=IndirectObject._MAXIMUM_PART_LENGTH, strict=self.strict
+                        )
                         if not current.isdigit():  # pragma: no cover
                             break  # pragma: no cover
-                        inner_generation_number = int(current)
-                        self.xref_objStm[inner_object_number] = (object_number, inner_generation_number)
+                        inner_offset = int(current)
+                        self.xref_objStm[inner_object_number] = (object_number, inner_offset)
                         actual_count += 1
                     expected_count = cast(int, obj["/N"])
                     if actual_count != expected_count:  # pragma: no cover
@@ -1423,6 +1434,10 @@ class PdfReader(PdfDocCommon):
                             generation_number=generation_number,
                             expected=expected_count,
                         )
+                except LimitReachedError:
+                    # Do not let the broad recovery below bypass the token-length limit
+                    # when strict parsing is enabled.
+                    raise
                 except Exception:  # could be multiple causes
                     pass
 

--- a/pypdf/_utils.py
+++ b/pypdf/_utils.py
@@ -158,7 +158,7 @@ WHITESPACES_AS_BYTES = b"".join(WHITESPACES)
 WHITESPACES_AS_REGEXP = b"[" + WHITESPACES_AS_BYTES + b"]"
 
 
-def read_until_whitespace(stream: StreamType, max_bytes: Optional[int] = None) -> bytes:
+def read_until_whitespace(stream: StreamType, max_bytes: Optional[int] = None, strict: bool = False) -> bytes:
     """
     Read non-whitespace characters and return them.
 
@@ -166,7 +166,10 @@ def read_until_whitespace(stream: StreamType, max_bytes: Optional[int] = None) -
 
     Args:
         stream: The data stream from which was read.
-        max_bytes: The maximum number of bytes returned; by default unlimited.
+        max_bytes: The maximum number of bytes which are considered valid. One more byte
+            will always be read from the stream.
+        strict: Whether to raise an exception if the token exceeds max_bytes.
+            If False, a warning is logged and only the first max_bytes are returned.
 
     Returns:
         The data which was read.
@@ -175,11 +178,16 @@ def read_until_whitespace(stream: StreamType, max_bytes: Optional[int] = None) -
     txt = bytearray()
     while True:
         tok = stream.read(1)
-        if tok.isspace() or not tok:
+        if tok.isspace() or tok in WHITESPACES or not tok:
+            break
+        if max_bytes is not None and len(txt) >= max_bytes:
+            if strict:
+                raise LimitReachedError(f"Token exceeds maximum length of {max_bytes} bytes.")
+            logger_warning(
+                "Token exceeds maximum length of %(max_bytes)d bytes.", source=__name__, max_bytes=max_bytes
+            )
             break
         txt += tok
-        if len(txt) == max_bytes:
-            break
     return bytes(txt)
 
 

--- a/pypdf/generic/_base.py
+++ b/pypdf/generic/_base.py
@@ -47,6 +47,7 @@ else:
 from .._codecs import _pdfdoc_encoding_rev
 from .._protocols import PdfObjectProtocol, PdfWriterProtocol
 from .._utils import (
+    WHITESPACES,
     StreamType,
     classproperty,
     deprecation_no_replacement,
@@ -320,6 +321,8 @@ class BooleanObject(PdfObject):
 
 
 class IndirectObject(PdfObject):
+    _MAXIMUM_PART_LENGTH = 64
+
     def __init__(self, idnum: int, generation: int, pdf: Any) -> None:  # PdfReader
         self.idnum = idnum
         self.generation = generation
@@ -457,30 +460,35 @@ class IndirectObject(PdfObject):
 
     @staticmethod
     def read_from_stream(stream: StreamType, pdf: Any) -> "IndirectObject":  # PdfReader
-        idnum = b""
-        while True:
-            tok = stream.read(1)
-            if not tok:
-                raise PdfStreamError(STREAM_TRUNCATED_PREMATURELY)
-            if tok.isspace():
-                break
-            idnum += tok
-        generation = b""
-        while True:
-            tok = stream.read(1)
-            if not tok:
-                raise PdfStreamError(STREAM_TRUNCATED_PREMATURELY)
-            if tok.isspace():
-                if not generation:
-                    continue
-                break
-            generation += tok
+        def read_part(name: str, skip_leading_whitespace: bool) -> bytes:
+            result = bytearray()
+            while True:
+                tok = stream.read(1)
+                if not tok:
+                    raise PdfStreamError(STREAM_TRUNCATED_PREMATURELY)
+                if tok.isspace() or tok in WHITESPACES:
+                    if skip_leading_whitespace and not result:
+                        continue
+                    break
+                if len(result) >= IndirectObject._MAXIMUM_PART_LENGTH:
+                    raise PdfReadError(f"{name} exceeds maximum length limit of {IndirectObject._MAXIMUM_PART_LENGTH}.")
+                result += tok
+            return bytes(result)
+
+        idnum = read_part("Object ID", skip_leading_whitespace=False)
+        generation = read_part("Generation number", skip_leading_whitespace=True)
+
         r = read_non_whitespace(stream)
         if r != b"R":
             raise PdfReadError(
                 f"Error reading indirect object reference at byte {hex(stream.tell())}"
             )
-        return IndirectObject(int(idnum), int(generation), pdf)
+        try:
+            return IndirectObject(int(idnum), int(generation), pdf)
+        except (ValueError, OverflowError) as e:
+            raise PdfReadError(
+                f"Invalid indirect object reference ({idnum!r} {generation!r} R): {e}"
+            ) from e
 
 
 FLOAT_WRITE_PRECISION = 8  # shall be min 5 digits max, allow user adj

--- a/pypdf/generic/_utils.py
+++ b/pypdf/generic/_utils.py
@@ -16,7 +16,7 @@ def read_hex_string_from_stream(
     forced_encoding: Union[str, list[str], dict[int, str], None] = None,
 ) -> Union["TextStringObject", "ByteStringObject"]:
     stream.read(1)
-    arr = []
+    arr = bytearray()
     x = b""
     while True:
         tok = read_non_whitespace(stream)
@@ -149,13 +149,23 @@ def create_string_object(
         return TextStringObject(string)
     if isinstance(string, bytes):
         if isinstance(forced_encoding, (list, dict)):
-            out = ""
+            out = []
+
+            if isinstance(forced_encoding, list):
+                list_length = len(forced_encoding)
+            else:
+                list_length = None
+
             for x in string:
-                try:
-                    out += forced_encoding[x]
-                except Exception:
-                    out += bytes((x,)).decode("charmap")
-            obj = TextStringObject(out)
+                if (
+                        (list_length is not None and x < list_length) or
+                        (list_length is None and x in forced_encoding)
+                ):
+                    value = forced_encoding[x]
+                else:
+                    value = bytes((x,)).decode("charmap")
+                out.append(value)
+            obj = TextStringObject("".join(out))
             obj._original_bytes = string
             return obj
         if isinstance(forced_encoding, str):

--- a/tests/generic/test_base.py
+++ b/tests/generic/test_base.py
@@ -1,12 +1,16 @@
 """Test the pypdf.generic._base module."""
+from contextlib import nullcontext
+from functools import partial
 from io import BytesIO
+from typing import Callable
 
 import pytest
 
 from pypdf import PdfReader, PdfWriter
-from pypdf.errors import LimitReachedError
-from pypdf.generic import FloatObject, NameObject, NumberObject, read_hex_string_from_stream
-from tests import get_data_from_url
+from pypdf._utils import StreamType
+from pypdf.errors import LimitReachedError, PdfReadError
+from pypdf.generic import FloatObject, IndirectObject, NameObject, NumberObject, read_hex_string_from_stream
+from tests import RESOURCE_ROOT, get_data_from_url
 
 
 @pytest.mark.parametrize(
@@ -68,3 +72,81 @@ def test_name_object__read_from_stream__limits() -> None:
             match=r"^Read stream length of 8176 exceeds maximum allowed length of 4096\.$"
     ):
         NameObject.read_from_stream(stream, pdf=None)
+
+
+def _check_indirect_object_reading_limits(
+        function: Callable[[StreamType], IndirectObject], should_raise: bool = True
+) -> None:
+    stream = BytesIO(b"42 0 R")
+    obj = function(stream)
+    assert obj.idnum == 42
+    assert obj.generation == 0
+
+    stream = BytesIO(b"13      37    R")
+    obj = function(stream)
+    assert obj.idnum == 13
+    assert obj.generation == 37
+
+    stream = BytesIO(b"2" * 64 + b" 0 R")
+    obj = function(stream)
+    assert obj.idnum == int("2" * 64)
+    assert obj.generation == 0
+
+    stream = BytesIO(b"10 " + b"2" * 64 + b" R")
+    obj = function(stream)
+    assert obj.idnum == 10
+    assert obj.generation == int("2" * 64)
+
+    stream = BytesIO(b"2" * 65)
+    context = pytest.raises(
+        expected_exception=PdfReadError, match=r"^Object ID exceeds maximum length limit of 64\.$"
+    ) if should_raise else nullcontext()
+    with context:
+        obj = function(stream)
+        assert obj.idnum == int("2" * 64)
+        assert obj.generation == 2
+
+    stream = BytesIO(b"2" * 100)
+    with context:
+        obj = function(stream)
+        assert obj.idnum == int("2" * 64)
+        assert obj.generation == int("2" * 35)
+
+    stream = BytesIO(b"10  " + b"3" * 65)
+    context = pytest.raises(
+        expected_exception=PdfReadError, match=r"^Generation number exceeds maximum length limit of 64\.$"
+    ) if should_raise else nullcontext()
+    with context:
+        obj = function(stream)
+        assert obj.idnum == 10
+        assert obj.generation == int("3" * 64)
+
+    stream = BytesIO(b"10  " + b"3" * 99)
+    with context:
+        obj = function(stream)
+        assert obj.idnum == 10
+        assert obj.generation == int("3" * 64)
+
+    stream = BytesIO(b"xxx 0 R")
+    context = pytest.raises(
+        expected_exception=PdfReadError if should_raise else ValueError,
+        match=r"^Invalid indirect object reference \(b'xxx' b'0' R\): invalid literal for int\(\) with base 10: b'xxx'$"
+    )
+    with context:
+        obj = function(stream)
+        assert obj.idnum == 10
+        assert obj.generation == int("3" * 64)
+
+
+def test_indirect_object__read_from_stream__limits() -> None:
+    test_function = partial(IndirectObject.read_from_stream, pdf=None)
+    _check_indirect_object_reading_limits(test_function)
+
+
+def test_pdf_reader__read_object_header__limits(caplog: pytest.LogCaptureFixture) -> None:
+    def test_function(stream: StreamType) -> IndirectObject:
+        reader = PdfReader(RESOURCE_ROOT / "crazyones.pdf")
+        idnum, generation = reader.read_object_header(stream)
+        return IndirectObject(idnum, generation, pdf=None)
+
+    _check_indirect_object_reading_limits(test_function, should_raise=False)

--- a/tests/generic/test_base.py
+++ b/tests/generic/test_base.py
@@ -129,7 +129,7 @@ def _check_indirect_object_reading_limits(
 
     stream = BytesIO(b"xxx 0 R")
     context = pytest.raises(
-        expected_exception=PdfReadError if should_raise else ValueError,
+        expected_exception=PdfReadError if should_raise else ValueError,  # type: ignore[arg-type]
         match=r"^Invalid indirect object reference \(b'xxx' b'0' R\): invalid literal for int\(\) with base 10: b'xxx'$"
     )
     with context:

--- a/tests/generic/test_utils.py
+++ b/tests/generic/test_utils.py
@@ -1,0 +1,20 @@
+"""Test the pypdf.generic._utils module."""
+from pypdf.generic import create_string_object
+
+
+def test_create_string_object__forced_encoding__list() -> None:
+    forced_encoding = list(map(chr, range(250)))
+    assert create_string_object(b"Hello World!\xff", forced_encoding=forced_encoding) == "Hello World!\xff"
+
+    forced_encoding = list(map(chr, range(256)))
+    forced_encoding[ord("A")] = "Hello"
+    forced_encoding[ord("B")] = "World"
+    assert create_string_object(b"A B!", forced_encoding=forced_encoding) == "Hello World!"
+
+
+def test_create_string_object__forced_encoding__dict() -> None:
+    forced_encoding = dict(zip(range(250), map(chr, range(250))))
+    assert create_string_object(b"Hello World!", forced_encoding=forced_encoding) == "Hello World!"
+
+    forced_encoding = {ord("A"): "Hello", ord("B"): "World"}
+    assert create_string_object(b"A B!", forced_encoding=forced_encoding) == "Hello World!"

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -2,6 +2,7 @@
 
 import codecs
 import gc
+import re
 import weakref
 from base64 import a85encode
 from copy import deepcopy
@@ -11,7 +12,7 @@ import pytest
 
 from pypdf import PdfReader, PdfWriter
 from pypdf.constants import CheckboxRadioButtonAttributes, OutlineFontFlag
-from pypdf.errors import DeprecationError, PdfReadError, PdfStreamError
+from pypdf.errors import STREAM_TRUNCATED_PREMATURELY, DeprecationError, PdfReadError, PdfStreamError
 from pypdf.generic import (
     ArrayObject,
     BooleanObject,
@@ -139,9 +140,8 @@ def test_null_object_exception():
 @pytest.mark.parametrize("value", [b"", b"False", b"foo ", b"foo  ", b"foo bar"])
 def test_indirect_object_premature(value):
     stream = BytesIO(value)
-    with pytest.raises(PdfStreamError) as exc:
+    with pytest.raises(expected_exception=PdfStreamError, match=re.escape(STREAM_TRUNCATED_PREMATURELY)):
         IndirectObject.read_from_stream(stream, None)
-    assert exc.value.args[0] == "Stream has ended unexpectedly"
 
 
 def test_read_hex_string_from_stream():

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2704,3 +2704,118 @@ def test_flatten_keeps_typeless_real_page_strict():
     reader = PdfReader(output, strict=True)
     assert len(reader.pages) == 1
     assert reader.pages[0].mediabox.width == 612
+
+
+def make_pdf_with_object_stream(
+    object_number: bytes = b"1",
+    offset: bytes = b"0",
+    object_data: bytes = b"<< /Test true >>",
+) -> bytes:
+    """
+    Construct a minimal PDF containing an object stream whose header
+    contains the supplied object number and offset.
+
+    The resulting PDF is intentionally constructed at the byte level so
+    malformed object-stream headers can be tested.
+    """
+    # Object-stream header:
+    #
+    #   <object-number> <offset>
+    #
+    # Note that an ObjStm header contains object-number/offset pairs, not
+    # object-number/generation pairs. This is important when testing
+    # _rebuild_xref_table().
+    objstm_header = object_number + b" " + offset + b" "
+    objstm_data = objstm_header + object_data
+
+    objstm = (
+        b"2 0 obj\n"
+         b"<< /Type /ObjStm /N 1 /First "
+        + str(len(objstm_header)).encode()
+        + b" /Length "
+        + str(len(objstm_data)).encode()
+        + b" >>\n"
+        + b"stream\n"
+        + objstm_data
+        + b"\nendstream\n"
+        + b"endobj\n"
+    )
+
+    # A normal indirect object, so PdfReader has something to resolve
+    # while rebuilding the xref table.
+    catalog = b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+
+    header = b"%PDF-1.5\n%\xe2\xe3\xcf\xd3\n"
+    body = header + catalog + objstm
+
+    # Calculate offsets.
+    catalog_offset = len(header)
+    objstm_offset = catalog_offset + len(catalog)
+
+    xref_offset = len(body)
+
+    xref = (
+        b"xref\n"
+        b"0 3\n"
+        b"0000000000 65535 f \n"
+        + f"{catalog_offset:010d} 00000 n \n".encode()
+        + f"{objstm_offset:010d} 00000 n \n".encode()
+    )
+
+    trailer = (
+        b"trailer\n"
+        b"<< /Size 3 /Root 1 0 R >>\n"
+        b"startxref\n"
+        + str(xref_offset).encode()
+        + b"\n%%EOF\n"
+    )
+
+    return body + xref + trailer
+
+
+def test_rebuild_xref_table__object_stream__long_object_number():
+    object_number = b"1" * IndirectObject._MAXIMUM_PART_LENGTH
+    pdf = make_pdf_with_object_stream(
+        object_number=object_number,
+    )
+    reader = PdfReader(BytesIO(pdf), strict=True)
+    reader._rebuild_xref_table(BytesIO(pdf))
+    assert reader.xref_objStm == {
+        int(object_number.decode()): (2, 0)
+    }
+
+    object_number = b"1" * (IndirectObject._MAXIMUM_PART_LENGTH + 1)
+    pdf = make_pdf_with_object_stream(
+        object_number=object_number,
+    )
+    reader = PdfReader(BytesIO(pdf), strict=True)
+    with pytest.raises(
+        LimitReachedError,
+        match=rf"Token exceeds maximum length of {IndirectObject._MAXIMUM_PART_LENGTH} bytes",
+    ):
+        reader._rebuild_xref_table(BytesIO(pdf))
+
+
+def test_rebuild_xref_table__object_stream__long_offset():
+    offset = b"1" * IndirectObject._MAXIMUM_PART_LENGTH
+    pdf = make_pdf_with_object_stream(
+        object_number=b"1",
+        offset=offset,
+    )
+    reader = PdfReader(BytesIO(pdf), strict=True)
+    reader._rebuild_xref_table(BytesIO(pdf))
+    assert reader.xref_objStm == {
+        1: (2, int(offset.decode()))
+    }
+
+    offset = b"1" * (IndirectObject._MAXIMUM_PART_LENGTH + 1)
+    pdf = make_pdf_with_object_stream(
+        object_number=b"1",
+        offset=offset,
+    )
+    reader = PdfReader(BytesIO(pdf), strict=True)
+    with pytest.raises(
+        LimitReachedError,
+        match=rf"Token exceeds maximum length of {IndirectObject._MAXIMUM_PART_LENGTH} bytes",
+    ):
+        reader._rebuild_xref_table(BytesIO(pdf))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,7 +34,7 @@ from pypdf._utils import (
     skip_over_comment,
     skip_over_whitespace,
 )
-from pypdf.errors import DeprecationError, PdfReadError, PdfStreamError
+from pypdf.errors import DeprecationError, LimitReachedError, PdfReadError, PdfStreamError
 from pypdf.generic import DictionaryObject, NameObject, TextStringObject
 
 from . import is_sublist
@@ -74,8 +74,19 @@ def test_check_if_whitespace_only(value, expected):
     assert check_if_whitespace_only(value) is expected
 
 
-def test_read_until_whitespace():
-    assert read_until_whitespace(io.BytesIO(b"foo"), max_bytes=1) == b"f"
+def test_read_until_whitespace(caplog):
+    assert read_until_whitespace(io.BytesIO(b"foo "), max_bytes=3) == b"foo"
+    assert read_until_whitespace(io.BytesIO(b"foo "), max_bytes=4) == b"foo"
+
+    with pytest.raises(LimitReachedError, match=r"^Token exceeds maximum length of 2 bytes\.$"):
+        read_until_whitespace(io.BytesIO(b"foo "), max_bytes=2, strict=True)
+
+    assert caplog.messages == []
+    assert read_until_whitespace(io.BytesIO(b"foo "), max_bytes=2, strict=False) == b"fo"
+    assert caplog.messages == ["Token exceeds maximum length of 2 bytes."]
+
+    # PDF specification treats NUL as whitespace.
+    assert read_until_whitespace(io.BytesIO(b"foo\x00bar")) == b"foo"
 
 
 @pytest.mark.timeout(5)


### PR DESCRIPTION
These changes are based on the original changes proposed by the reporter, but have been modified/extended quite a bit for the final patch.

Disclosure: The original patches were assisted by Antigravity with Google Gemini 3.8 Flash. Further reviews and refinements where partially done with the help of ChatGPT.