### PR TITLE
ROB: Do not crash when the font encoding differences are not an array

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -9,6 +9,7 @@ from ._codecs import adobe_glyphs, charset_encoding
 from ._utils import logger_error, logger_warning
 from .errors import LimitReachedError
 from .generic import (
+    ArrayObject,
     DecodedStreamObject,
     DictionaryObject,
     NullObject,
@@ -112,7 +113,15 @@ def _parse_encoding(
     if isinstance(enc, DictionaryObject) and "/Differences" in enc:
         x: int = 0
         o: Union[int, str]
-        for o in cast(DictionaryObject, enc["/Differences"]):
+        differences = enc["/Differences"].get_object()
+        if not isinstance(differences, ArrayObject):
+            logger_warning(
+                "Font encoding differences are not an array: %(differences)s",
+                source=__name__,
+                differences=differences,
+            )
+            differences = ArrayObject()
+        for o in differences:
             if isinstance(o, int):
                 x = o
             else:  # isinstance(o, str):

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -26,6 +26,7 @@ from pypdf.generic import (
     NameObject,
     NullObject,
     NumberObject,
+    PdfObject,
     StreamObject,
     TextStringObject,
 )
@@ -751,3 +752,53 @@ def test__character_map_from_cff_type1_font_file_guards(caplog):
 
     with mock.patch("fontTools.cffLib.CFFFontSet", return_value=mock_cff_set):
         _parse_to_unicode(font_dict)
+
+
+def _font_with_differences(differences: PdfObject) -> DictionaryObject:
+    """A Type1 font resource whose /Encoding carries the given /Differences."""
+    font = DictionaryObject()
+    font[NameObject("/Type")] = NameObject("/Font")
+    font[NameObject("/Subtype")] = NameObject("/Type1")
+    font[NameObject("/BaseFont")] = NameObject("/Helvetica")
+    encoding = DictionaryObject()
+    encoding[NameObject("/Differences")] = differences
+    font[NameObject("/Encoding")] = encoding
+    return font
+
+
+@pytest.mark.parametrize(
+    ("differences", "expected"),
+    [
+        pytest.param(
+            NumberObject(5),
+            "Font encoding differences are not an array: 5",
+            id="number",
+        ),
+        pytest.param(
+            TextStringObject("abc"),
+            "Font encoding differences are not an array: abc",
+            id="string",
+        ),
+        pytest.param(
+            DictionaryObject(),
+            "Font encoding differences are not an array: {}",
+            id="dictionary",
+        ),
+    ],
+)
+def test_get_encoding__differences_not_an_array(caplog, differences, expected):
+    """/Differences must be an array; iterating a non-array raised a TypeError."""
+    encoding, _ = get_encoding(_font_with_differences(differences))
+
+    assert encoding == dict(enumerate(charset_encoding["/StandardEncoding"]))
+    assert expected in caplog.text
+
+
+def test_get_encoding__differences_is_an_array(caplog):
+    """The regular path: a proper /Differences array is still applied."""
+    encoding, _ = get_encoding(
+        _font_with_differences(ArrayObject([NumberObject(65), NameObject("/quotesingle")]))
+    )
+
+    assert encoding[65] == "'"
+    assert caplog.text == ""

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -754,7 +754,7 @@ def test__character_map_from_cff_type1_font_file_guards(caplog):
         _parse_to_unicode(font_dict)
 
 
-def _font_with_differences(differences: PdfObject) -> DictionaryObject:
+def _generate_font_with_differences(differences: PdfObject) -> DictionaryObject:
     """A Type1 font resource whose /Encoding carries the given /Differences."""
     font = DictionaryObject()
     font[NameObject("/Type")] = NameObject("/Font")
@@ -788,7 +788,7 @@ def _font_with_differences(differences: PdfObject) -> DictionaryObject:
 )
 def test_get_encoding__differences_not_an_array(caplog, differences, expected):
     """/Differences must be an array; iterating a non-array raised a TypeError."""
-    encoding, _ = get_encoding(_font_with_differences(differences))
+    encoding, _ = get_encoding(_generate_font_with_differences(differences))
 
     assert encoding == dict(enumerate(charset_encoding["/StandardEncoding"]))
     assert expected in caplog.text
@@ -797,7 +797,7 @@ def test_get_encoding__differences_not_an_array(caplog, differences, expected):
 def test_get_encoding__differences_is_an_array(caplog):
     """The regular path: a proper /Differences array is still applied."""
     encoding, _ = get_encoding(
-        _font_with_differences(ArrayObject([NumberObject(65), NameObject("/quotesingle")]))
+        _generate_font_with_differences(ArrayObject([NumberObject(65), NameObject("/quotesingle")]))
     )
 
     assert encoding[65] == "'"


### PR DESCRIPTION
A font /Encoding whose /Differences is not an array crashes text extraction.
The value is cast to a dictionary and iterated directly, so a number, a string
or a dictionary raises "argument of type 'NumberObject' is not iterable".

extract_text(extraction_mode="layout") propagates it, because
_layout_mode_fonts calls Font.from_font_resource without a guard. The default
mode swallows the TypeError and silently drops the font instead, so the page
comes back with the wrong glyphs.

The lookup now warns and falls back to an empty array, which gives the same
result as a font with no /Differences at all.

Offline suite passes, 1314 tests. The corpus tests that download from the
network do not run here; on main they fail identically with FileNotFoundError,
so I could not verify against that set.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
