### PR TITLE
ROB: Fix CFF handling with supplements for fonttools < 4.58.0

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -453,7 +453,7 @@ def _character_map_from_cff_type1_font_file(
                 int_entry.append(i)
         return map_dict, int_entry
 
-    except (struct.error, AssertionError, AttributeError, IndexError, ValueError):
+    except (struct.error, AssertionError, AttributeError, IndexError, NotImplementedError, ValueError):
         return map_dict, int_entry
 
 


### PR DESCRIPTION
Before https://github.com/fonttools/fonttools/commit/1394c643be69be99d5bd57d6ff59b0b878e8b9d6, CFF font files with supplements threw a `NotImplementedError`, thus breaking text extraction. Allow this error as a valid one to not enforce too recent *fonttools* versions.