### PR TITLE
BUG: Use current text matrix for visitor_text

### DIFF
--- a/pypdf/_text_extraction/_text_extractor.py
+++ b/pypdf/_text_extraction/_text_extractor.py
@@ -142,6 +142,7 @@ class TextExtraction:
 
     def _post_process_text_operation(self, str_widths: float) -> None:
         """Handle common post-processing for text positioning operations."""
+        text_was_empty = self.text == ""
         try:
             self.text, self.output, self.cm_prev, self.tm_prev = crlf_space_check(
                 self.text,
@@ -157,7 +158,7 @@ class TextExtraction:
                 self.compute_str_widths(self.font_size * self._space_width),
                 self._actual_str_size["str_height"],
             )
-            if self.text == "":
+            if text_was_empty or self.text == "":
                 self.memo_cm = self.cm_matrix.copy()
                 self.memo_tm = self.tm_matrix.copy()
         except OrientationNotFoundError:

--- a/resources/visitor_text_position.pdf
+++ b/resources/visitor_text_position.pdf
@@ -1,0 +1,75 @@
+%PDF-1.3
+%‚„œ”
+1 0 obj
+<<
+/Producer (pypdf)
+>>
+endobj
+2 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Resources <<
+/Font <<
+/F1 5 0 R
+>>
+>>
+/MediaBox [ 0.0 0.0 200 100 ]
+/Parent 2 0 R
+/Contents 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+6 0 obj
+<<
+/Length 77
+>>
+stream
+BT
+/F1 12 Tf
+1 0 0 1 0 50 Tm
+(X) Tj
+0 -30 Td
+100 0 Td
+(visitor Sample) Tj
+ET
+
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000054 00000 n 
+0000000113 00000 n 
+0000000162 00000 n 
+0000000294 00000 n 
+0000000391 00000 n 
+trailer
+<<
+/Size 7
+/Root 3 0 R
+/Info 1 0 R
+>>
+startxref
+518
+%%EOF

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1716,33 +1716,3 @@ def test_extract_text__resources_is_a_dictionary():
 
     assert isinstance(page["/Resources"].get_object(), DictionaryObject)
     assert "crazy ones" in page.extract_text()
-
-
-def test_extract_text__visitor_text_uses_current_text_matrix():
-    reader = PdfReader(RESOURCE_ROOT / "visitor_text_position.pdf")
-    page = reader.pages[0]
-
-    text_visits = []
-
-    def visitor_text(text, cm, tm, font_dict, font_size) -> None:
-        if text.strip() == "visitor Sample":
-            text_visits.append(
-                {
-                    "text": text,
-                    "cm": tuple(float(v) for v in cm),
-                    "tm": tuple(float(v) for v in tm),
-                    "font_size": float(font_size),
-                }
-            )
-
-    extracted_text = page.extract_text(
-        orientations=0,
-        visitor_text=visitor_text,
-    )
-
-    assert "visitor Sample" in extracted_text
-    assert len(text_visits) == 1
-
-    visit = text_visits[0]
-    assert visit["tm"][4] == pytest.approx(100.0)
-    assert visit["tm"][5] == pytest.approx(20.0)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1716,3 +1716,33 @@ def test_extract_text__resources_is_a_dictionary():
 
     assert isinstance(page["/Resources"].get_object(), DictionaryObject)
     assert "crazy ones" in page.extract_text()
+
+
+def test_extract_text__visitor_text_uses_current_text_matrix():
+    reader = PdfReader(RESOURCE_ROOT / "visitor_text_position.pdf")
+    page = reader.pages[0]
+
+    text_visits = []
+
+    def visitor_text(text, cm, tm, font_dict, font_size):
+        if text.strip() == "visitor Sample":
+            text_visits.append(
+                {
+                    "text": text,
+                    "cm": tuple(float(v) for v in cm),
+                    "tm": tuple(float(v) for v in tm),
+                    "font_size": float(font_size),
+                }
+            )
+
+    extracted_text = page.extract_text(
+        orientations=0,
+        visitor_text=visitor_text,
+    )
+
+    assert "visitor Sample" in extracted_text
+    assert len(text_visits) == 1
+
+    visit = text_visits[0]
+    assert visit["tm"][4] == pytest.approx(100.0)
+    assert visit["tm"][5] == pytest.approx(20.0)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -1724,7 +1724,7 @@ def test_extract_text__visitor_text_uses_current_text_matrix():
 
     text_visits = []
 
-    def visitor_text(text, cm, tm, font_dict, font_size):
+    def visitor_text(text, cm, tm, font_dict, font_size) -> None:
         if text.strip() == "visitor Sample":
             text_visits.append(
                 {

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -987,3 +987,33 @@ def test_line_breaks_with_scaled_current_matrix() -> None:
     )
 
     assert PdfReader(buffer).pages[0].extract_text() == "Line one\nLine two"
+
+
+def test_visitor_text_uses_current_text_matrix():
+    reader = PdfReader(RESOURCE_ROOT / "visitor_text_position.pdf")
+    page = reader.pages[0]
+
+    text_visits = []
+
+    def visitor_text(text, cm, tm, font_dict, font_size) -> None:
+        if text.strip() == "visitor Sample":
+            text_visits.append(
+                {
+                    "text": text,
+                    "cm": tuple(float(v) for v in cm),
+                    "tm": tuple(float(v) for v in tm),
+                    "font_size": float(font_size),
+                }
+            )
+
+    extracted_text = page.extract_text(
+        orientations=0,
+        visitor_text=visitor_text,
+    )
+
+    assert "visitor Sample" in extracted_text
+    assert len(text_visits) == 1
+
+    visit = text_visits[0]
+    assert visit["tm"][4] == pytest.approx(100.0)
+    assert visit["tm"][5] == pytest.approx(20.0)

--- a/tests/test_text_extraction.py
+++ b/tests/test_text_extraction.py
@@ -993,18 +993,11 @@ def test_visitor_text_uses_current_text_matrix():
     reader = PdfReader(RESOURCE_ROOT / "visitor_text_position.pdf")
     page = reader.pages[0]
 
-    text_visits = []
+    text_matrices = []
 
     def visitor_text(text, cm, tm, font_dict, font_size) -> None:
         if text.strip() == "visitor Sample":
-            text_visits.append(
-                {
-                    "text": text,
-                    "cm": tuple(float(v) for v in cm),
-                    "tm": tuple(float(v) for v in tm),
-                    "font_size": float(font_size),
-                }
-            )
+            text_matrices.append(tuple(float(v) for v in tm))
 
     extracted_text = page.extract_text(
         orientations=0,
@@ -1012,8 +1005,5 @@ def test_visitor_text_uses_current_text_matrix():
     )
 
     assert "visitor Sample" in extracted_text
-    assert len(text_visits) == 1
-
-    visit = text_visits[0]
-    assert visit["tm"][4] == pytest.approx(100.0)
-    assert visit["tm"][5] == pytest.approx(20.0)
+    assert len(text_matrices) == 1
+    assert text_matrices[0] == pytest.approx((1.0, 0.0, 0.0, 1.0, 100.0, 20.0))


### PR DESCRIPTION
## Summary

Fix #2932.

`visitor_text()` could receive a stale text matrix when a new text
fragment begins with a synthesized leading space.

## Tests

- Added minimal reproducer PDF: `visitor_text_position.pdf`
- Added regression test:
  `test_visitor_text_uses_current_text_matrix`

Fails before the fix, passes after the fix.

## AI Usage

Development assistance: Microsoft Copilot (GPT-5).