### PR TITLE
ROB: Do not crash when the XFA entry is not a well-formed array

### DIFF
--- a/pypdf/_doc_common.py
+++ b/pypdf/_doc_common.py
@@ -1537,11 +1537,18 @@ class PdfDocCommon(ABC):
         tree = cast(TreeObject, catalog["/AcroForm"])
 
         if "/XFA" in tree:
-            fields = cast(ArrayObject, tree["/XFA"])
+            fields = tree["/XFA"].get_object()
+            if not isinstance(fields, ArrayObject):
+                logger_warning(
+                    "XFA entry is not an array: %(fields)s",
+                    source=__name__,
+                    fields=fields,
+                )
+                return retval
             i = iter(fields)
             for f in i:
                 tag = f
-                f = next(i)
+                f = next(i, None)
                 if isinstance(f, IndirectObject):
                     field = cast(Optional[EncodedStreamObject], f.get_object())
                     if field:

--- a/tests/test_doc_common.py
+++ b/tests/test_doc_common.py
@@ -21,6 +21,7 @@ from pypdf.generic import (
     NameObject,
     NullObject,
     NumberObject,
+    PdfObject,
     RectangleObject,
     TextStringObject,
     TreeObject,
@@ -1376,3 +1377,40 @@ def test_flatten__kid_is_not_a_dictionary(caplog, value, expected):
 
     assert len(PdfReader(stream).pages) == 1
     assert expected in caplog.text
+
+
+def _generate_reader_with_xfa(xfa: PdfObject) -> PdfReader:
+    """A reader whose /AcroForm carries the given /XFA entry."""
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+
+    acro_form = DictionaryObject()
+    acro_form[NameObject("/XFA")] = xfa
+    writer.root_object[NameObject("/AcroForm")] = writer._add_object(acro_form)
+
+    data = BytesIO()
+    writer.write(data)
+    data.seek(0)
+    return PdfReader(data)
+
+
+@pytest.mark.parametrize(
+    ("xfa", "expected"),
+    [
+        pytest.param(NumberObject(5), "XFA entry is not an array: 5", id="number"),
+        pytest.param(TextStringObject("x"), "XFA entry is not an array: x", id="string"),
+        pytest.param(DictionaryObject(), "XFA entry is not an array: {}", id="dictionary"),
+    ],
+)
+def test_xfa__entry_not_an_array(caplog, xfa, expected):
+    """Iterating a non-array /XFA raised a TypeError or exhausted the iterator."""
+    assert _generate_reader_with_xfa(xfa).xfa == {}
+    assert expected in caplog.text
+
+
+def test_xfa__array_with_a_trailing_tag(caplog):
+    """/XFA holds tag/value pairs; a trailing tag raised StopIteration."""
+    reader = _generate_reader_with_xfa(ArrayObject([TextStringObject("datasets")]))
+
+    assert reader.xfa == {}
+    assert caplog.text == ""


### PR DESCRIPTION
reader.xfa iterates /XFA in tag/value pairs after casting it to an array, so a
malformed entry crashes rather than being reported.

Two cases:

- /XFA that is not an array at all raises "argument of type 'NumberObject' is
  not iterable", or exhausts the iterator for a string. The spec also permits a
  stream here, which the pairwise walk cannot consume.
- An array with an odd number of elements — a trailing tag with no value —
  raises StopIteration out of the property, because next(i) has nothing left.

The entry is now checked before iterating, warning and returning no XFA data
the way an absent /AcroForm does, and the paired read tolerates a missing
value instead of raising.

Offline suite passes, 1318 tests. tests/test_reader.py::test_read_pdf15_xref_stream
fails here with FileNotFoundError both with and without this change, so I could
not verify against the downloaded corpus.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
