### PR TITLE
BUG: Repeat the letter for /S /A and /S /a page labels past Z

### DIFF
--- a/pypdf/_page_labels.py
+++ b/pypdf/_page_labels.py
@@ -115,17 +115,9 @@ def number2lowercase_roman_numeral(number: int) -> str:
 def number2uppercase_letter(number: int) -> str:
     if number <= 0:
         raise ValueError("Expecting a positive number")
-    alphabet = string.ascii_uppercase
-    rep = ""
-    while number > 0:
-        remainder = number % 26
-        if remainder == 0:
-            remainder = 26
-        rep = alphabet[remainder - 1] + rep
-        # update
-        number -= remainder
-        number = number // 26
-    return rep
+    # A to Z, then the same letter repeated: AA to ZZ, AAA to ZZZ, and so on.
+    repetitions, position = divmod(number - 1, 26)
+    return string.ascii_uppercase[position] * (repetitions + 1)
 
 
 def number2lowercase_letter(number: int) -> str:

--- a/tests/test_page_labels.py
+++ b/tests/test_page_labels.py
@@ -61,16 +61,45 @@ def test_number2lowercase_roman_numeral():
         (25, "y"),
         (26, "z"),
         (27, "aa"),
-        (28, "ab"),
+        (28, "bb"),
+        (51, "yy"),
+        (52, "zz"),
+        (53, "aaa"),
+        (78, "zzz"),
+        (79, "aaaa"),
     ],
 )
 def test_number2lowercase_letter(number, expected):
     assert number2lowercase_letter(number) == expected
 
 
+@pytest.mark.parametrize(
+    ("number", "expected"),
+    [
+        (26, "Z"),
+        (27, "AA"),
+        (28, "BB"),
+        (52, "ZZ"),
+        (53, "AAA"),
+    ],
+)
+def test_number2uppercase_letter__repeats_the_same_letter(number, expected):
+    """A to Z for the first 26 pages, AA to ZZ for the next 26, and so on."""
+    assert number2uppercase_letter(number) == expected
+
+
 def test_number2uppercase_letter():
     with pytest.raises(ValueError):
         number2uppercase_letter(-1)
+
+
+def test_get_label_from_nums__letter_style_past_z():
+    # Page 28 of an /S /A section is "BB", not "AB". See the module docstring.
+    value = DictionaryObject()
+    value[NameObject("/S")] = NameObject("/A")
+    dictionary_object = DictionaryObject()
+    dictionary_object[NameObject("/Nums")] = ArrayObject([NumberObject(0), value])
+    assert get_label_from_nums(dictionary_object, 27) == "BB"
 
 
 @pytest.mark.parametrize("number", [0, -1, -5])


### PR DESCRIPTION
### Problem

For a page label section with `/S /A`, `PdfReader.page_labels` numbers the 28th page `"AB"`. Per the PDF specification it is `"BB"`. Same for `/S /a`, lowercase.

```python
from pypdf._page_labels import number2uppercase_letter
[number2uppercase_letter(n) for n in (25, 26, 27, 28, 29, 52, 53)]
# on main: ['Y', 'Z', 'AA', 'AB', 'AC', 'AZ', 'BA']
# expected: ['Y', 'Z', 'AA', 'BB', 'CC', 'ZZ', 'AAA']
```

`number2uppercase_letter` (`pypdf/_page_labels.py:115-128`) implements bijective base-26 - the sequence Excel uses for column headers. That is not the sequence the `/A` and `/a` styles denote.

### Why this is a bug and not a design choice

The module's own docstring already states the rule, quoted from the specification (`pypdf/_page_labels.py:55-58`):

```
A       Uppercase letters (A to Z for the first 26 pages,
                           AA to ZZ for the next 26, and so on)
a       Lowercase letters (a to z for the first 26 pages,
                           aa to zz for the next 26, and so on)
```

"AA to ZZ for the next 26" is a range of exactly 26 labels. That only holds if the letter is repeated - AA, BB, CC, ..., ZZ. Under bijective base-26 those 26 pages get AA through AZ, and ZZ is not reached until 702. So the docstring and the implementation describe two different numbering systems, and the docstring is the one that matches 12.4.2, the section it cites.

Your own `number2uppercase_roman_numeral` at `pypdf/_page_labels.py:82` already does this - it implements the convention its neighbouring comment describes (`:76-78`) closely enough that it *refuses* 4000 at `:85-86`, because that convention cannot express it. Its sibling in the same dispatch dict - `"/R"` at `:164`, `"/A"` at `:166` - silently substitutes a different numbering system than the docstring above it defines.

### Fix

```diff
-    alphabet = string.ascii_uppercase
-    rep = ""
-    while number > 0:
-        remainder = number % 26
-        if remainder == 0:
-            remainder = 26
-        rep = alphabet[remainder - 1] + rep
-        # update
-        number -= remainder
-        number = number // 26
-    return rep
+    # A to Z, then the same letter repeated: AA to ZZ, AAA to ZZZ, and so on.
+    repetitions, position = divmod(number - 1, 26)
+    return string.ascii_uppercase[position] * (repetitions + 1)
```

`number2lowercase_letter` delegates to it, so both styles are covered. Nothing else in `pypdf/` calls either function - they are only reachable through `get_label_from_nums` -> `index2label` -> `PdfReader.page_labels`, so there is no writer-side counterpart to keep in step.

### Blast radius

The two conventions agree on 1..27 and first disagree at 28:

| n | 26 | 27 | 28 | 29 | 52 | 53 | 79 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| before | Z | AA | AB | AC | AZ | BA | CA |
| after | Z | AA | BB | CC | ZZ | AAA | AAAA |

So only a letter-numbered section longer than 27 pages changes at all.

### Tests

**This changes one existing assertion.** `test_number2lowercase_letter` had `(28, "ab")` (`tests/test_page_labels.py:64` on main); it becomes `(28, "bb")`. That case pinned the old answer at exactly the first value where the two conventions diverge, so it has to move for the fix to mean anything - flagging it explicitly rather than burying it in the diff.

Added on top of that:

- `(51, "yy") (52, "zz") (53, "aaa") (78, "zzz") (79, "aaaa")` to the same parametrize, covering both the wrap at ZZ and the roll to three letters.
- `test_number2uppercase_letter__repeats_the_same_letter`, the uppercase equivalent, which had no value-based test at all before.
- `test_get_label_from_nums__letter_style_past_z`, which goes through `get_label_from_nums` with a real `/S /A` dictionary rather than calling the helper directly, so the user-visible path is pinned too.

### Verification

Run against `d80ccfc` (`pypdf/_page_labels.py` md5 `58858ea70f836265cc681e3d2de51ea2` on main), `pytest tests/test_page_labels.py -m "not enable_socket and not samples"`:

| state | `_page_labels.py` md5 | result |
| --- | --- | --- |
| RED - main + new tests | `58858ea70f836265cc681e3d2de51ea2` | 10 failed, 36 passed (`assert 'AB' == 'BB'`) |
| GREEN - this PR | `3b7fdd63e145a6727a0ddd1c242b2409` | 46 passed, exit 0 |
| revert the fix | `58858ea70f836265cc681e3d2de51ea2` | killed, 10 failed |
| off by one down - `divmod(number, 26)` | `456f5f7fbee2d4e3d3efc33ddc3f7848` | killed, 18 failed |
| off by one up - `* (repetitions + 2)` | `1383de54d7ca5e5b8d51c6174873ffad` | killed, 18 failed |

Both over-corrections are on the same axis as the fix, and both die: the first two break n=1..27 as well, which the pre-existing cases catch, and the revert is caught only from n=28 on, by the new ones.

Full gates:

| command | result |
| --- | --- |
| `ruff check pypdf tests make_release.py` | exit 0, all checks passed |
| `mypy pypdf` | exit 1 - 12 errors, all pre-existing in `_crypt_providers/_pycryptodome.py` and `generic/_color.py`; 0 in either file this PR touches |
| `pytest tests --cov=pypdf --cov-append -n auto -vv -p no:benchmark -m "not enable_socket and not samples"` | exit 1 - 1251 passed, 4 skipped, 2 failed. Both failures are `FileNotFoundError` on the `sample-files` submodule, which I do not have checked out; identical pair on a pristine tree (1240 passed, same 2 names) |

---

I used AI assistance for this change: Claude Code, model Claude Opus 5. I reproduced the failure, wrote and ran the tests and the gates myself, and I can explain and defend every line of the diff.
