### PR TITLE
ROB: Do not look up a page size that does not exist yet

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -741,7 +741,7 @@ class PdfWriter(PdfDocCommon):
         if abs(index) > num_pages:
             raise IndexError(f"Index should be in range [-{num_pages}, {num_pages}]")
 
-        if num_pages and (width is None or width <= 0 or height is None or height <= 0):
+        if num_pages:
             # Use the chosen index, but do not exceed the available pages
             fixed_index = min(index, num_pages - 1)
             mediabox = self.pages[fixed_index].mediabox

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -738,7 +738,10 @@ class PdfWriter(PdfDocCommon):
             IndexError: Index is outside of [-self.get_num_pages(), self.get_num_pages()]
         """
         num_pages = self.get_num_pages()
-        if abs(index) <= num_pages:
+        if abs(index) > num_pages:
+            raise IndexError(f"Index should be in range [-{num_pages}, {num_pages}]")
+
+        if num_pages and (width is None or width <= 0 or height is None or height <= 0):
             # Use the chosen index, but do not exceed the available pages
             fixed_index = min(index, num_pages - 1)
             mediabox = self.pages[fixed_index].mediabox
@@ -746,8 +749,6 @@ class PdfWriter(PdfDocCommon):
                 width = mediabox.width
             if height is None or height <= 0:
                 height = mediabox.height
-        else:
-            raise IndexError(f"Index should be in range [-{num_pages}, {num_pages}]")
 
         page = PageObject.create_blank_page(self, width, height)
         self.insert_page(page, index)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -341,6 +341,35 @@ def test_insert_blank_page():
 
 
 @pytest.mark.parametrize(
+    ("width", "height"),
+    [
+        pytest.param(72, 72, id="both"),
+        pytest.param(72, None, id="width-only"),
+        pytest.param(None, 72, id="height-only"),
+    ],
+)
+def test_insert_blank_page__no_pages_yet(width, height):
+    """A writer with no pages looked up the size of a page that does not exist."""
+    writer = PdfWriter()
+
+    if width is None or height is None:
+        with pytest.raises(PageSizeNotDefinedError):
+            writer.insert_blank_page(width=width, height=height)
+        return
+
+    page = writer.insert_blank_page(width=width, height=height)
+    assert len(writer.pages) == 1
+    assert page.mediabox.width == width
+    assert page.mediabox.height == height
+
+
+def test_insert_blank_page__no_pages_yet_and_no_size():
+    """Matches add_blank_page, which raises rather than an opaque IndexError."""
+    with pytest.raises(PageSizeNotDefinedError):
+        PdfWriter().insert_blank_page()
+
+
+@pytest.mark.parametrize(
     ("convert", "needs_cleanup"),
     [
         (str, True),


### PR DESCRIPTION
insert_blank_page reads the mediabox of an existing page before checking
whether the caller supplied a size, so on a writer with no pages it fails on
the lookup rather than doing the documented thing.

    PdfWriter().insert_blank_page(width=72, height=72)
    -> IndexError: Sequence index out of range

The size was given, so nothing needed to be inherited. Without a size the same
call raises the same IndexError, where the docstring promises
PageSizeNotDefinedError — which is what add_blank_page already does for both
cases.

The mediabox is now consulted only when a dimension is actually missing and
there is a page to take it from; otherwise create_blank_page handles it and
raises PageSizeNotDefinedError as documented. Existing behaviour on a
non-empty writer is unchanged: inherited sizes, negative indices, non-positive
values falling back, and the out-of-range IndexError.

Offline suite passes, 1334 tests. Two flatten_form_field tests fail here with
FileNotFoundError both with and without this change, so I could not verify
against the downloaded corpus.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
