### PR TITLE
SEC: Limit allowed length of tokens in parse_bfchar

### DIFF
--- a/pypdf/_cmap.py
+++ b/pypdf/_cmap.py
@@ -287,7 +287,7 @@ def process_cm_line(
     elif process_char:
         try:
             parse_bfchar(line, map_dict, int_entry)
-        except (ValueError, IndexError) as error:
+        except ValueError as error:
             logger_warning("Skipping broken line %(line)r: %(error)s", source=__name__, line=line, error=error)
     return process_rg, process_char, multiline_rg
 
@@ -400,30 +400,44 @@ def parse_bfrange(
 
 def parse_bfchar(line: bytes, map_dict: dict[Any, Any], int_entry: list[int]) -> None:
     lst = [x for x in line.split(b" ") if x]
-    new_count = len(lst) // 2
+    lst_length = len(lst)
+    if lst_length == 0:
+        logger_warning("Skipping broken line %(line)r: Line is empty.", source=__name__, line=line)
+        return
+    if lst_length % 2:
+        logger_warning("Ignoring final token of odd-length line %(line)r.", source=__name__, line=line)
+
+    new_count = lst_length // 2
     _check_mapping_size(len(int_entry) + new_count)  # This can be checked beforehand.
     map_dict[-1] = len(lst[0]) // 2
+
     while len(lst) > 1:
+        source = lst[0]
+        destination = lst[1]
+
+        _check_token_length(source, limit=MAX_CMAP_CODE_BYTES_LIMIT)
+
         map_to = ""
         # placeholder (see above) means empty string
-        if lst[1] != b".":
+        if destination != b".":
+            _check_token_length(destination, limit=MAX_CMAP_STRING_BYTES_LIMIT)
             try:
-                map_to = unhexlify(lst[1]).decode(
-                    "charmap" if len(lst[1]) < 4 else "utf-16-be", "surrogatepass"
+                map_to = unhexlify(destination).decode(
+                    "charmap" if len(destination) < 4 else "utf-16-be", "surrogatepass"
                 )  # join is here as some cases where the code was split
             except BinasciiError as exception:
                 logger_warning(
-                    "Got invalid hex string: %(exception)s (%(lst_value)r)",
+                    "Got invalid hex string: %(exception)s (%(destination)r)",
                     source=__name__,
                     exception=exception,
-                    lst_value=lst[1],
+                    destination=destination,
                 )
         map_dict[
-            unhexlify(lst[0]).decode(
+            unhexlify(source).decode(
                 "charmap" if map_dict[-1] == 1 else "utf-16-be", "surrogatepass"
             )
         ] = map_to
-        int_entry.append(int(lst[0], 16))
+        int_entry.append(int(source, 16))
         lst = lst[2:]
 
 

--- a/tests/test_cmap.py
+++ b/tests/test_cmap.py
@@ -634,6 +634,46 @@ def test_parse_bfchar__iteration_limit():
     assert map_dict == {}
 
 
+def test_parse_bfchar__entry_size_limit():
+    int_entry = []
+    map_dict = {}
+
+    with pytest.raises(
+            expected_exception=LimitReachedError, match=r"^Maximum /ToUnicode code length exceeded: 18 > 16\.$",
+    ):
+        parse_bfchar(
+            line=(b"01" * 9 + b" 0041"),
+            map_dict=map_dict,
+            int_entry=int_entry,
+        )
+    assert map_dict == {-1: 9}
+
+    map_dict = {}
+    with pytest.raises(
+            expected_exception=LimitReachedError, match=r"^Maximum /ToUnicode string length exceeded: 1026 > 1024\.$",
+    ):
+        parse_bfchar(
+            line=(b"01 " + b"ab" * 513),
+            map_dict=map_dict,
+            int_entry=int_entry,
+        )
+    assert map_dict == {-1: 1}
+
+
+def test_parse_bfchar__invalid_tokens(caplog):
+    map_dict = {}
+    int_entry = []
+
+    parse_bfchar(b"", map_dict, int_entry)
+    assert map_dict == {}
+    assert caplog.messages == ["Skipping broken line b'': Line is empty."]
+    caplog.clear()
+
+    parse_bfchar(b"01 0041 02", map_dict, int_entry)
+    assert map_dict == {-1: 1, "\x01": "A"}
+    assert caplog.messages == ["Ignoring final token of odd-length line b'01 0041 02'."]
+
+
 def _make_japanese_cmap_pdf(cmap_name: str, encoding: str) -> bytes:
     """Minimal PDF with a CIDFont using *cmap_name* as /Encoding, no /ToUnicode."""
     writer = PdfWriter()


### PR DESCRIPTION
Additionally, we introduce further length validation checks while we are at it to better deal with malformed inputs.