### PR TITLE
SEC: Further restrict FlateDecode recovery

### DIFF
--- a/pypdf/filters.py
+++ b/pypdf/filters.py
@@ -144,32 +144,33 @@ def decompress(data: bytes) -> bytes:
 
         # If still failing, then try with increased window size.
         decompressor = zlib.decompressobj(zlib.MAX_WBITS | 32)
-        result_str = b""
+        result = bytearray()
         configuration = get_configuration()
         remaining_limit = configuration.zlib_maximum_output_length
         data_length = len(data)
         known_errors = set()
         for index in range(data_length):
+            if index >= configuration.zlib_maximum_recovery_input_length:
+                raise LimitReachedError(
+                    f"Recovery limit reached while decompressing. {data_length - index} bytes remaining."
+                )
+
             chunk = _SINGLE_BYTES[data[index]]
             try:
                 decompressed = decompressor.decompress(chunk, max_length=remaining_limit)
-                result_str += decompressed
+                result += decompressed
                 remaining_limit -= len(decompressed)
                 if remaining_limit <= 0:
                     raise LimitReachedError(
                         f"Limit reached while decompressing. {data_length - index} bytes remaining."
                     )
             except zlib.error as error:
-                if index > configuration.zlib_maximum_recovery_input_length:
-                    raise LimitReachedError(
-                        f"Recovery limit reached while decompressing. {data_length - index} bytes remaining."
-                    )
                 error_str = str(error)
                 if error_str in known_errors:
                     continue
                 logger_warning(error_str, source=__name__)
                 known_errors.add(error_str)
-        return result_str
+        return bytes(result)
 
 
 class FlateDecode:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1283,7 +1283,7 @@ def test_flate_decode__decode__decode_parms_types__null_object(caplog) -> None:
     assert caplog.messages == []
 
 
-# @pytest.mark.timeout(10)  # Previously took about 28-33 seconds.
+@pytest.mark.timeout(10)  # Previously took about 28-33 seconds.
 def test_decompress__fallback__speed() -> None:
     # `gzip` is an optional module: https://docs.python.org/3/library/gzip.html
     gzip = pytest.importorskip("gzip")

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -275,7 +275,7 @@ def test_ccitt_fax_decode__unsigned_columns():
 def test_decompress_zlib_error(caplog):
     reader = PdfReader(BytesIO(get_data_from_url(name="tika-952445.pdf")))
     for page in reader.pages:
-        page.extract_text()
+        assert page.extract_text() == ""
     assert "incorrect startxref pointer(3)" in caplog.text
 
 
@@ -945,7 +945,7 @@ def test_decompress():
     # Decompress byte-wise with input limit.
     with apply_configuration(zlib_maximum_recovery_input_length=1000), \
             pytest.raises(
-                LimitReachedError, match=r"^Recovery limit reached while decompressing\. 336 bytes remaining\.$"
+                LimitReachedError, match=r"^Recovery limit reached while decompressing\. 337 bytes remaining\.$"
             ):
         decompress(b"A" * 1337)
 
@@ -1281,3 +1281,18 @@ def test_flate_decode__decode__decode_parms_types__null_object(caplog) -> None:
     compressed = zlib.compress(_FLATE_IMAGE_DATA)
     _ = FlateDecode.decode(decode_parms=NullObject(), data=compressed)
     assert caplog.messages == []
+
+
+# @pytest.mark.timeout(10)  # Previously took about 28-33 seconds.
+def test_decompress__fallback__speed() -> None:
+    # `gzip` is an optional module: https://docs.python.org/3/library/gzip.html
+    gzip = pytest.importorskip("gzip")
+
+    buf = BytesIO()
+    size = 1_000_000
+    with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=1, mtime=0) as f:
+        f.write(os.urandom(size))  # incompressible: stream size ~= input size
+    compressed = buf.getvalue()
+
+    result = decompress(compressed)
+    assert len(result) == size


### PR DESCRIPTION
Previously, we would only count invalid bytes which could not be decoded in `/FlateDecode` recovery. This avoids excessive iteration for the completely broken data we tested with, as every input byte fails to decode here.

For actual padded data, this would still be a performance bottleneck, as this is a very inefficient and slow byte-by-byte decoding approach. Given a GZIP file for example, which is a zlib/flate data stream prefixed by some file header bytes, it was possible to trigger the slow path without the recovery limit ever kicking in.

Please note that some persons might see this as a breaking change, for example because some software would use GZIP for compression in zlib/flate streams (for whatever reason). As this violates the PDF specification, a more efficient fallback handling has not been implemented for now. If this really is a concern for some use cases, either increasing the limit (for the slow variant) or providing a corresponding fix (as a fast variant) are still possible.