### PR TITLE
BUG: Parse a string rect for add_uri into a rectangle

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2323,7 +2323,8 @@ class PdfWriter(PdfDocCommon):
             border_arr = [NumberObject(2), NumberObject(2), NumberObject(2)]
 
         if isinstance(rect, str):
-            rect = NumberObject(rect)
+            coords = [float(n) for n in rect.strip().strip("[]").split()]
+            rect = RectangleObject(coords)
         elif isinstance(rect, RectangleObject):
             pass
         else:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -951,6 +951,13 @@ def test_add_uri(pdf_file_path):
         border=[0, 0, 0],
     )
 
+    # A string rect in the documented "[ xLL yLL xUR yUR ]" form must become a
+    # RectangleObject; it previously collapsed to a single NumberObject of 0.
+    string_rect = writer.pages[3]["/Annots"][0].get_object()["/Rect"]
+    assert list(string_rect) == [200, 300, 250, 350]
+    list_rect = writer.pages[3]["/Annots"][1].get_object()["/Rect"]
+    assert list(list_rect) == [100, 200, 150, 250]
+
     # write "output" to pypdf-output.pdf
     with open(pdf_file_path, "wb") as output_stream:
         writer.write(output_stream)


### PR DESCRIPTION
add_uri documents its rect argument as accepting the string form
"[ xLL yLL xUR yUR ]", but a string was wrapped in a single NumberObject:

    add_uri(0, "https://example.com", "[ 0 0 100 100 ]")

NumberObject cannot parse that, so it warned and fell back to 0 — the
annotation's /Rect became a single 0 instead of a rectangle, leaving the link
with no clickable area. RectangleObject and list forms were unaffected.

The string is now split into its four numbers and built into a RectangleObject,
matching the documented behaviour and the other two input forms.

The existing test_add_uri already passed a string rect but never checked the
result; it now asserts the /Rect for both the string and list forms.

Offline suite passes, 1339 tests.

Used Claude (Opus) to help locate and patch this; I reviewed and tested the change.
