### PR TITLE
BUG: Use page reference for existing internal link targets

### DIFF
--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2555,12 +2555,15 @@ class PdfWriter(PdfDocCommon):
             and isinstance(destination, DictionaryObject)
             and "target_page_index" in destination
         ):
+            target_page_reference: Union[IndirectObject, NumberObject]
             target_page_index = cast(int, destination["target_page_index"])
             fit_type = cast(str, destination["fit"])
             # Work around the intermediate destination containing native Python
             # objects instead of PdfObject instances.
             fit_args = cast(
-                Sequence[float | Any | None], dict(destination)["fit_args"])
+                Sequence[float | Any | None],
+                dict(destination)["fit_args"]
+            )
 
             if 0 <= target_page_index < len(self.pages):
                 target_page_reference = cast(

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2548,18 +2548,35 @@ class PdfWriter(PdfDocCommon):
             page[NameObject("/Annots")] = ArrayObject()
         assert page.annotations is not None
 
-        # Internal link annotations need the correct object type for the
-        # destination
-        if to_add.get("/Subtype") == "/Link" and "/Dest" in to_add:
-            tmp = cast(dict[Any, Any], to_add[NameObject("/Dest")])
-            dest = Destination(
+        # Resolve pypdf's intermediate internal-link destination.
+        destination = to_add.get("/Dest")
+        if (
+            to_add.get("/Subtype") == "/Link"
+            and isinstance(destination, DictionaryObject)
+            and "target_page_index" in destination
+        ):
+            target_page_index = cast(int, destination["target_page_index"])
+            fit_type = cast(str, destination["fit"])
+            # Work around the intermediate destination containing native Python
+            # objects instead of PdfObject instances.
+            fit_args = cast(
+                Sequence[float | Any | None], dict(destination)["fit_args"])
+
+            if 0 <= target_page_index < len(self.pages):
+                target_page_reference = cast(
+                    IndirectObject,
+                    self.pages[target_page_index].indirect_reference,
+                )
+            else:
+                # Preserve support for referencing a page that may be added
+                # later. See #2450.
+                target_page_reference = NumberObject(target_page_index)
+
+            to_add[NameObject("/Dest")] = Destination(
                 NameObject("/LinkName"),
-                tmp["target_page_index"],
-                Fit(
-                    fit_type=tmp["fit"], fit_args=dict(tmp)["fit_args"]
-                ),  # I have no clue why this dict-hack is necessary
-            )
-            to_add[NameObject("/Dest")] = dest.dest_array
+                target_page_reference,
+                Fit(fit_type=fit_type, fit_args=fit_args),
+            ).dest_array
 
         page.annotations.append(self._add_object(to_add))
 

--- a/pypdf/_writer.py
+++ b/pypdf/_writer.py
@@ -2560,10 +2560,7 @@ class PdfWriter(PdfDocCommon):
             fit_type = cast(str, destination["fit"])
             # Work around the intermediate destination containing native Python
             # objects instead of PdfObject instances.
-            fit_args = cast(
-                Sequence[float | Any | None],
-                dict(destination)["fit_args"]
-            )
+            fit_args = cast(Sequence[Any], dict(destination)["fit_args"])
 
             if 0 <= target_page_index < len(self.pages):
                 target_page_reference = cast(

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -24,8 +24,8 @@ from pypdf.errors import PdfReadError
 from pypdf.generic import (
     ArrayObject,
     DictionaryObject,
-    FloatObject,
     Fit,
+    FloatObject,
     NameObject,
     NumberObject,
     RectangleObject,

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -21,7 +21,15 @@ from pypdf.annotations import (
 )
 from pypdf.constants import AnnotationFlag
 from pypdf.errors import PdfReadError
-from pypdf.generic import ArrayObject, FloatObject, NameObject, NumberObject
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    FloatObject,
+    Fit,
+    NameObject,
+    NumberObject,
+    RectangleObject,
+)
 
 from . import RESOURCE_ROOT, get_data_from_url
 
@@ -382,6 +390,91 @@ def test_link(pdf_file_path):
     # Assert: You need to inspect the file manually
     with open(pdf_file_path, "wb") as fp:
         writer.write(fp)
+
+
+def test_link__existing_target_uses_indirect_reference():
+    # Arrange
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    writer.add_blank_page(width=200, height=200)
+
+    link_annotation = Link(
+        rect=(100, 100, 300, 200),
+        target_page_index=1,
+        border=[50, 10, 4],
+        fit=Fit(fit_type="/XYZ", fit_args=(0, 0, 0)),
+    )
+
+    # Act
+    added_annotation = writer.add_annotation(0, link_annotation)
+
+    # Assert
+    destination = added_annotation["/Dest"]
+
+    assert isinstance(destination, ArrayObject)
+    assert destination[0] == writer.pages[1].indirect_reference
+    assert destination[1] == "/XYZ"
+    assert destination[2:] == [0, 0, 0]
+
+
+def test_link__future_target_preserves_page_index():
+    # Arrange
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+
+    link_annotation = Link(
+        rect=(100, 100, 300, 200),
+        target_page_index=1,
+        border=[50, 10, 4],
+        fit=Fit(fit_type="/Fit"),
+    )
+
+    # Act
+    added_annotation = writer.add_annotation(0, link_annotation)
+
+    # Assert
+    destination = added_annotation["/Dest"]
+
+    assert isinstance(destination, ArrayObject)
+    # Preserve the existing page-index representation when the target page
+    # has not yet been added to the writer. See #2450.
+    assert destination[0] == NumberObject(1)
+    assert destination[1] == "/Fit"
+
+
+def test_link__completed_destination_is_preserved():
+    # Arrange
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    writer.add_blank_page(width=200, height=200)
+
+    target_page_reference = writer.pages[1].indirect_reference
+    assert target_page_reference is not None
+
+    destination = ArrayObject(
+        [
+            target_page_reference,
+            NameObject("/Fit"),
+        ]
+    )
+    link_annotation = DictionaryObject(
+        {
+            NameObject("/Type"): NameObject("/Annot"),
+            NameObject("/Subtype"): NameObject("/Link"),
+            NameObject("/Rect"): RectangleObject((100, 100, 300, 200)),
+            NameObject("/Dest"): destination,
+        }
+    )
+
+    # Act
+    added_annotation = writer.add_annotation(0, link_annotation)
+
+    # Assert
+    added_destination = added_annotation["/Dest"]
+
+    assert isinstance(added_destination, ArrayObject)
+    assert added_destination[0] == target_page_reference
+    assert added_destination[1] == "/Fit"
 
 
 def test_popup(caplog):


### PR DESCRIPTION
## Summary

This change resolves pypdf's intermediate internal-link destination to the target page's indirect reference when the target page is already present in the writer.

When the target page has not yet been added, the existing page-index representation is preserved.

## Scope

Based on the current code paths, this change is limited to pypdf's intermediate representation of an internal direct destination:

```python
to_add.get("/Subtype") == "/Link"
and isinstance(destination, DictionaryObject)
and "target_page_index" in destination
```

Remote and external links should not be affected. URI links and remote or embedded go-to actions are represented through an `/A` action dictionary, such as `/URI`, `/GoToR`, or `/GoToE`, rather than through the annotation-level intermediate `/Dest` dictionary handled here.

An already completed explicit destination is represented as an array rather than this intermediate dictionary, so it is also left unchanged.

## Compatibility

The discussion in #2450 raised the question of whether allowing an internal link to reference a page that has not yet been added to the writer should be treated as supported behavior or as a bug.
This PR intentionally does not make that decision. If the target page is not yet present in the writer, the existing page-index representation is preserved. The change only resolves the destination to an `IndirectObject` when the target page is already available.
The remaining behavior for targets added later can therefore be discussed and addressed separately without blocking this limited improvement.

## Tests

The added tests verify that:

- an existing target page is represented by its `IndirectObject`;
- a target page that has not yet been added preserves the existing page-index representation; and
- an already completed destination array is preserved without being processed as pypdf's intermediate destination.

## AI usage

I used Microsoft 365 Copilot, based on the GPT-5 reasoning model, to assist with reviewing the code paths related to direct `/Dest` entries and remote link actions. I reviewed and verified the resulting implementation and tests myself.
